### PR TITLE
Enable local testing without HTTPS

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -49,7 +49,9 @@ final class AppServiceProvider extends ServiceProvider
 
         Vite::useAggressivePrefetching();
 
-        URL::forceHttps();
+        if (!app()->environment(['local', 'testing'])) {
+            URL::forceHttps();
+        }
 
         Date::use(CarbonImmutable::class);
 


### PR DESCRIPTION
When env variable APP_ENV is set to local / testing we disable the force of HTTPS