### PR TITLE
Add uncategorized signatures count to systems

### DIFF
--- a/app/Features/MapTrackingFeature.php
+++ b/app/Features/MapTrackingFeature.php
@@ -57,7 +57,7 @@ final readonly class MapTrackingFeature implements ProvidesInertiaProperties
                     ->orWhereNull('signature_category_id'))
                 ->with(['signatureType', 'signatureCategory', 'wormhole', 'mapConnection']),
         ])
-            ->loadCount('signatures', 'wormholeSignatures', 'mapConnections');
+            ->loadCount('signatures', 'wormholeSignatures', 'mapConnections', 'uncategorizedSignatures');
 
         return $solarsystem->toResource(MapSolarsystemResource::class);
     }

--- a/app/Http/Controllers/Api/MapController.php
+++ b/app/Http/Controllers/Api/MapController.php
@@ -42,7 +42,7 @@ final class MapController extends Controller
                 'mapSolarsystems' => fn (Builder $builder) => $builder->whereNotNull('position_x'),
             ])
             ->with([
-                'mapSolarsystems' => fn (Relation $query) => $query->whereNotNull('position_x')->withCount('signatures', 'wormholeSignatures', 'mapConnections')->with('wormholeSystem:id,threat_level'),
+                'mapSolarsystems' => fn (Relation $query) => $query->whereNotNull('position_x')->withCount('signatures', 'wormholeSignatures', 'mapConnections', 'uncategorizedSignatures')->with('wormholeSystem:id,threat_level'),
                 'mapUserSetting',
             ])
             ->get()

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -56,7 +56,7 @@ final class MapController extends Controller
 
         $map = Map::query()
             ->with([
-                'mapSolarsystems' => fn (Relation $query): Relation => $query->withCount('signatures', 'wormholeSignatures', 'mapConnections'),
+                'mapSolarsystems' => fn (Relation $query): Relation => $query->withCount('signatures', 'wormholeSignatures', 'mapConnections', 'uncategorizedSignatures'),
                 'mapRouteSolarsystems',
             ])
             ->tap(new WithVisibleSolarsystems)

--- a/app/Http/Resources/MapSolarsystemResource.php
+++ b/app/Http/Resources/MapSolarsystemResource.php
@@ -33,6 +33,7 @@ final class MapSolarsystemResource extends JsonResource
             'pinned' => $this->pinned,
             'solarsystem_id' => $this->solarsystem_id,
             'signatures_count' => $this->signatures_count,
+            'uncategorized_signatures_count' => $this->uncategorized_signatures_count,
             'wormhole_signatures_count' => $this->wormhole_signatures_count,
             'map_connections_count' => $this->map_connections_count,
             'threat_level' => $this->whenLoaded('wormholeSystem', fn () => $this->wormholeSystem?->threat_level),

--- a/app/Models/MapSolarsystem.php
+++ b/app/Models/MapSolarsystem.php
@@ -36,6 +36,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
  * @property MapSolarsystemStatus $status
  * @property bool $pinned
  * @property-read int|null $signatures_count
+ * @property-read int|null $uncategorized_signatures_count
  * @property-read int|null $wormhole_signatures_count
  * @property-read int|null $map_connections_count
  * @property-read Solarsystem $solarsystem
@@ -104,6 +105,15 @@ final class MapSolarsystem extends Model implements \OwenIt\Auditing\Contracts\A
     public function signatures(): HasMany
     {
         return $this->hasMany(Signature::class, 'map_solarsystem_id');
+    }
+
+    /**
+     * @return HasMany<Signature,$this>
+     */
+    public function uncategorizedSignatures(): HasMany
+    {
+        return $this->hasMany(Signature::class, 'map_solarsystem_id')
+            ->whereNull('signature_category_id');
     }
 
     /**

--- a/app/Scopes/WithVisibleSolarsystems.php
+++ b/app/Scopes/WithVisibleSolarsystems.php
@@ -17,7 +17,7 @@ final class WithVisibleSolarsystems
     public function __invoke(Builder $query): Builder
     {
         return $query->with([
-            'mapSolarsystems' => fn (Relation $query) => $query->whereNotNull('position_x')->withCount('signatures', 'wormholeSignatures', 'mapConnections')->with('wormholeSystem:id,threat_level'),
+            'mapSolarsystems' => fn (Relation $query) => $query->whereNotNull('position_x')->withCount('signatures', 'wormholeSignatures', 'mapConnections', 'uncategorizedSignatures')->with('wormholeSystem:id,threat_level'),
             'mapConnections' => fn (Relation $query) => $query->whereDoesntHave('fromMapSolarsystem', fn (Builder $query) => $query->whereNull('position_x'))
                 ->whereDoesntHave('toMapSolarsystem', fn (Builder $query) => $query->whereNull('position_x')),
         ]);

--- a/resources/js/components/landing/fixtures.ts
+++ b/resources/js/components/landing/fixtures.ts
@@ -168,6 +168,7 @@ function node(
         signatures_count: 0,
         wormhole_signatures_count: 0,
         map_connections_count: 0,
+        uncategorized_signatures_count: 0,
         threat_level: null,
         signatures: null,
         solarsystem: system,

--- a/resources/js/components/map/MapSolarsystemButton.vue
+++ b/resources/js/components/map/MapSolarsystemButton.vue
@@ -55,6 +55,22 @@ const effectiveThreatLevel = computed(() => {
 
 const open = ref(false);
 
+const hasUncategorizedSignatures = computed(() => {
+    return (map_solarsystem.uncategorized_signatures_count ?? 0) > 0;
+});
+
+const signatureTooltipText = computed(() => {
+    const total = map_solarsystem.signatures_count;
+    const uncategorized = map_solarsystem.uncategorized_signatures_count ?? 0;
+    const signatureLabel = total === 1 ? 'signature' : 'signatures';
+
+    return `${total} ${signatureLabel}${uncategorized ? ` ${uncategorized} uncategorized` : ''}`;
+});
+
+const signatureIconClass = computed(() => {
+    return hasUncategorizedSignatures.value ? 'size-[14px] text-rose-500' : 'size-[14px] text-amber-500';
+});
+
 const extra_connections_count = computed(() => {
     const connections_count = map_solarsystem.wormhole_signatures_count ?? 0;
     const mapped_connections_count = map_solarsystem.map_connections_count ?? 0;
@@ -120,11 +136,9 @@ function handleSubmit() {
                 </Tooltip>
                 <Tooltip v-if="map_solarsystem.signatures_count" :delay-duration="500">
                     <TooltipTrigger>
-                        <SatelliteDish class="size-[14px] text-amber-500" />
+                        <SatelliteDish :class="signatureIconClass" />
                     </TooltipTrigger>
-                    <TooltipContent>
-                        {{ map_solarsystem.signatures_count }} {{ map_solarsystem.signatures_count === 1 ? 'signature' : 'signatures' }}
-                    </TooltipContent>
+                    <TooltipContent>{{ signatureTooltipText }}</TooltipContent>
                 </Tooltip>
                 <HasExtraConnections v-if="extra_connections_count" :extra_connections_count="extra_connections_count" />
                 <SolarsystemSovereignty :sovereignty="resolvedSolarsystem.sovereignty" :solarsystem-id="resolvedSolarsystem.id">

--- a/resources/js/composables/map/actions/createSignature.ts
+++ b/resources/js/composables/map/actions/createSignature.ts
@@ -13,7 +13,7 @@ export function createSignature(map_solarsystem_id: number) {
         {
             preserveScroll: true,
             preserveState: true,
-            only: ['selected_map_solarsystem'],
+            only: ['map', 'selected_map_solarsystem'],
         },
     );
 }

--- a/resources/js/composables/map/composables/useMapEvents.ts
+++ b/resources/js/composables/map/composables/useMapEvents.ts
@@ -81,7 +81,7 @@ export function useMapEvents(map: MaybeRefOrGetter<TMap>) {
     useOnClient(() =>
         useEcho(map_channel_name.value, [SignatureCreatedEvent, SignatureUpdatedEvent, SignatureDeletedEvent], () => {
             router.reload({
-                only: ['selected_map_solarsystem'],
+                only: ['map', 'selected_map_solarsystem'],
             });
         }),
     );

--- a/resources/js/pages/maps/index.ts
+++ b/resources/js/pages/maps/index.ts
@@ -97,6 +97,7 @@ export type TMapSolarsystemBase = {
     signatures_count: number;
     wormhole_signatures_count: number;
     map_connections_count: number;
+    uncategorized_signatures_count: number;
     threat_level?: TThreatLevel | null;
     signatures?: TSignature[] | null;
 };


### PR DESCRIPTION
- Signatures icon for systems now turns red when a system has uncategorized signatures.
- The popup on the signatures icon shows the amount of uncategorized signatures

Also fixed a minor bug where when Signatures where changed (for instance a new wormhole was added) the map was not properly updated. (unmapped wormholes icon and the new uncategorized signatures need that)