### PR TITLE
fix: handle static data generation failure in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,9 +15,14 @@ function generateStaticDataPlugin() {
         if (process.env.SKIP_STATIC_DATA_GENERATION) {
             return;
         }
-        execSync('php artisan generate:static-data --no-interaction', {
-            stdio: 'inherit',
-        });
+        try {
+            execSync('php artisan generate:static-data --no-interaction', {
+                stdio: 'inherit',
+            });
+        } catch {
+            // eslint-disable-next-line no-console
+            console.error('Failed to generate static data! Make sure you downloaded the data using "php artisan sde:download"')
+        }
     };
 
     return {


### PR DESCRIPTION
Wraps the `generate:static-data` call in the Vite plugin in a try/catch so a missing SDE dataset no longer hard-fails the build — it logs a hint to run `php artisan sde:download` instead.