### PR TITLE
Refactor map context menu: icons, clean map, safer clear map

### DIFF
--- a/app/Http/Requests/DeleteMapSelectionRequest.php
+++ b/app/Http/Requests/DeleteMapSelectionRequest.php
@@ -8,6 +8,7 @@ use App\Builders\MapAccessBuilder;
 use App\Enums\Permission;
 use App\Models\Map;
 use App\Models\User;
+use App\Rules\NotHomeSystem;
 use App\Rules\NotPinned;
 use Illuminate\Container\Attributes\CurrentUser;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -39,7 +40,7 @@ final class DeleteMapSelectionRequest extends FormRequest
     {
         return [
             'map_solarsystem_ids' => ['required', 'array'],
-            'map_solarsystem_ids.*' => ['required', 'integer', 'exists:map_solarsystems,id', new NotPinned],
+            'map_solarsystem_ids.*' => ['required', 'integer', 'exists:map_solarsystems,id', new NotPinned, new NotHomeSystem],
         ];
     }
 }

--- a/app/Rules/NotHomeSystem.php
+++ b/app/Rules/NotHomeSystem.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules;
+
+use App\Models\MapSolarsystem;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+final class NotHomeSystem implements ValidationRule
+{
+    /**
+     * Run the validation rule.
+     *
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $map_solarsystem = MapSolarsystem::query()->with('map')->find($value);
+
+        if ($map_solarsystem !== null && $map_solarsystem->map->home_solarsystem_id === $map_solarsystem->solarsystem_id) {
+            $fail('The selected solarsystem is the home system and cannot be deleted.');
+        }
+    }
+}

--- a/resources/js/map/actions/cleanMapSolarsystems.ts
+++ b/resources/js/map/actions/cleanMapSolarsystems.ts
@@ -1,17 +1,17 @@
 import { useMapStore } from '@/map/store/mapStore';
 import MapSelection from '@/routes/map-selection';
 import { router } from '@inertiajs/vue3';
-import { getClearableMapSolarsystems } from './clearableMapSolarsystems';
+import { getOrphanedMapSolarsystems } from './orphanedMapSolarsystems';
 
-export function deleteAllMapSolarsystems(): void {
+export function cleanMapSolarsystems(): void {
     const store = useMapStore();
-    const clearable = getClearableMapSolarsystems(store);
+    const orphaned = getOrphanedMapSolarsystems(store);
 
-    if (clearable.length === 0) return;
+    if (orphaned.length === 0) return;
 
     router.delete(MapSelection.destroy().url, {
         data: {
-            map_solarsystem_ids: clearable.map((system) => system.id),
+            map_solarsystem_ids: orphaned.map((system) => system.id),
         },
         preserveState: true,
         preserveScroll: true,

--- a/resources/js/map/actions/clearableMapSolarsystems.ts
+++ b/resources/js/map/actions/clearableMapSolarsystems.ts
@@ -1,0 +1,11 @@
+import type { MapStore } from '@/map/store/mapStore';
+import type { TMapSolarsystem } from '@/pages/maps';
+
+/**
+ * The systems "Clear map" removes: everything except pinned systems and the
+ * map's home system.
+ */
+export function getClearableMapSolarsystems(store: MapStore): TMapSolarsystem[] {
+    const homeSolarsystemId = store.meta.value?.home_solarsystem_id ?? null;
+    return [...store.systems.values()].filter((system) => !system.pinned && system.solarsystem_id !== homeSolarsystemId);
+}

--- a/resources/js/map/actions/orphanedMapSolarsystems.spec.ts
+++ b/resources/js/map/actions/orphanedMapSolarsystems.spec.ts
@@ -1,0 +1,113 @@
+import { getClearableMapSolarsystems } from '@/map/actions/clearableMapSolarsystems';
+import { getOrphanedMapSolarsystems } from '@/map/actions/orphanedMapSolarsystems';
+import { createMapStore } from '@/map/store/mapStore';
+import { TMap, TMapConnection, TMapSolarsystem, TSolarsystem } from '@/pages/maps';
+import { describe, expect, it } from 'vitest';
+
+const staticSolarsystem = (id: number, name = `J${id}`): TSolarsystem =>
+    ({
+        id,
+        name,
+        class: '3',
+        region: { id: 1, name: 'A-R00001' },
+    }) as TSolarsystem;
+
+function system(id: number, overrides: Partial<TMapSolarsystem> = {}): TMapSolarsystem {
+    return {
+        id,
+        map_id: 1,
+        solarsystem_id: 31000000 + id,
+        alias: null,
+        status: 'unknown',
+        occupier_alias: null,
+        notes: null,
+        position: { x: 100 * id, y: 100 },
+        pinned: false,
+        signatures_count: 0,
+        wormhole_signatures_count: 0,
+        map_connections_count: 0,
+        uncategorized_signatures_count: 0,
+        solarsystem: staticSolarsystem(31000000 + id),
+        ...overrides,
+    } as TMapSolarsystem;
+}
+
+function connection(id: number, from: number, to: number, overrides: Partial<TMapConnection> = {}): TMapConnection {
+    return {
+        id,
+        from_map_solarsystem_id: from,
+        to_map_solarsystem_id: to,
+        type: 'wormhole',
+        preserve_mass: false,
+        mass_status: 'fresh',
+        lifetime_status: 'healthy',
+        lifetime_status_updated_at: null,
+        signatures: [],
+        ship_size: 'large',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        ...overrides,
+    } as TMapConnection;
+}
+
+function storeWith(systems: TMapSolarsystem[], connections: TMapConnection[], home_solarsystem_id: number | null = null) {
+    const store = createMapStore();
+    store.reconcileMap({
+        id: 1,
+        name: 'Test',
+        slug: 'test',
+        home_solarsystem_id,
+        rally_solarsystem_id: null,
+        layout: 'manual',
+        allow_layout_override: false,
+        constant_width_enabled: false,
+        bookmark_format_wormhole: '',
+        bookmark_format_kspace: '',
+        map_solarsystems: systems,
+        map_connections: connections,
+    } as TMap);
+    return store;
+}
+
+describe('getClearableMapSolarsystems', () => {
+    it('excludes pinned systems and the home system', () => {
+        const store = storeWith([system(1, { pinned: true }), system(2), system(3)], [], 31000003);
+
+        const clearable = getClearableMapSolarsystems(store).map((s) => s.id);
+
+        expect(clearable).toEqual([2]);
+    });
+});
+
+describe('getOrphanedMapSolarsystems', () => {
+    it('keeps systems reachable from a pinned or home anchor and drops disconnected branches', () => {
+        // 1 (home) — 2 — 3 chain, 4 (pinned) — 5 branch, 6 — 7 dead branch, 8 isolated.
+        const store = storeWith(
+            [system(1), system(2), system(3), system(4, { pinned: true }), system(5), system(6), system(7), system(8)],
+            [connection(10, 1, 2), connection(11, 2, 3), connection(12, 4, 5), connection(13, 6, 7)],
+            31000001,
+        );
+
+        const orphaned = getOrphanedMapSolarsystems(store)
+            .map((s) => s.id)
+            .sort();
+
+        expect(orphaned).toEqual([6, 7, 8]);
+    });
+
+    it('traverses connections in both directions', () => {
+        const store = storeWith([system(1, { pinned: true }), system(2)], [connection(10, 2, 1)]);
+
+        expect(getOrphanedMapSolarsystems(store)).toEqual([]);
+    });
+
+    it('treats every system as orphaned when the map has no anchors', () => {
+        const store = storeWith([system(1), system(2)], [connection(10, 1, 2)]);
+
+        const orphaned = getOrphanedMapSolarsystems(store)
+            .map((s) => s.id)
+            .sort();
+
+        expect(orphaned).toEqual([1, 2]);
+    });
+});

--- a/resources/js/map/actions/orphanedMapSolarsystems.ts
+++ b/resources/js/map/actions/orphanedMapSolarsystems.ts
@@ -1,0 +1,34 @@
+import type { MapStore } from '@/map/store/mapStore';
+import type { TMapSolarsystem } from '@/pages/maps';
+import { getClearableMapSolarsystems } from './clearableMapSolarsystems';
+
+/**
+ * The systems "Clean map" removes: dead branches that are neither pinned, the
+ * home system, nor reachable from one of those anchors through the connection
+ * graph.
+ */
+export function getOrphanedMapSolarsystems(store: MapStore): TMapSolarsystem[] {
+    const clearable = new Set(getClearableMapSolarsystems(store).map((system) => system.id));
+
+    const adjacency = new Map<number, number[]>();
+    for (const connection of store.connections.values()) {
+        const { from_map_solarsystem_id: from, to_map_solarsystem_id: to } = connection;
+        adjacency.set(from, [...(adjacency.get(from) ?? []), to]);
+        adjacency.set(to, [...(adjacency.get(to) ?? []), from]);
+    }
+
+    const queue = [...store.systems.values()].filter((system) => !clearable.has(system.id)).map((system) => system.id);
+    const reachable = new Set(queue);
+
+    while (queue.length > 0) {
+        const id = queue.pop()!;
+        for (const neighbor of adjacency.get(id) ?? []) {
+            if (!reachable.has(neighbor)) {
+                reachable.add(neighbor);
+                queue.push(neighbor);
+            }
+        }
+    }
+
+    return [...store.systems.values()].filter((system) => !reachable.has(system.id));
+}

--- a/resources/js/map/components/overlays/MapContextMenu.vue
+++ b/resources/js/map/components/overlays/MapContextMenu.vue
@@ -13,15 +13,19 @@ import {
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { NumberField, NumberFieldContent, NumberFieldDecrement, NumberFieldIncrement, NumberFieldInput } from '@/components/ui/number-field';
+import { cleanMapSolarsystems } from '@/map/actions/cleanMapSolarsystems';
+import { getClearableMapSolarsystems } from '@/map/actions/clearableMapSolarsystems';
 import { createMapSolarsystem } from '@/map/actions/createMapSolarsystem';
 import { deleteAllMapSolarsystems } from '@/map/actions/deleteAllMapSolarsystems';
 import { deleteSelectedMapSolarsystems } from '@/map/actions/deleteSelectedMapSolarsystems';
 import { organizeMapSolarsystems } from '@/map/actions/organizeMapSolarsystems';
+import { getOrphanedMapSolarsystems } from '@/map/actions/orphanedMapSolarsystems';
 import { getSelectedMapSolarsystems } from '@/map/actions/selectedMapSolarsystems';
 import type { Vec2 } from '@/map/core/types';
 import { useSolarsystemSearch } from '@/map/interactions/useSolarsystemSearch';
 import { useMapStore } from '@/map/store/mapStore';
 import { TStaticSolarsystem } from '@/types/static-data';
+import { Eraser, LayoutGrid, Plus, Trash2 } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
 
 /**
@@ -38,7 +42,11 @@ const store = useMapStore();
 
 const hasSelection = computed(() => getSelectedMapSolarsystems(store).length > 0);
 
+const clearable_count = computed(() => getClearableMapSolarsystems(store).length);
+const orphaned_count = computed(() => getOrphanedMapSolarsystems(store).length);
+
 const is_clearing_map = ref(false);
+const is_cleaning_map = ref(false);
 
 const search = ref('');
 
@@ -55,28 +63,34 @@ function handleSolarsystemSelect(solarsystem: TStaticSolarsystem) {
     adding.value = false;
 }
 
-function handleDelete() {
-    is_clearing_map.value = true;
-}
-
-function handleConfirmDelete() {
+function handleConfirmClear() {
     deleteAllMapSolarsystems();
     is_clearing_map.value = false;
 }
 
-function handeCancelDelete() {
-    is_clearing_map.value = false;
+function handleConfirmClean() {
+    cleanMapSolarsystems();
+    is_cleaning_map.value = false;
 }
 </script>
 
 <template>
     <ContextMenuContent>
-        <ContextMenuItem @select="adding = true"> Add Solarsystem</ContextMenuItem>
+        <ContextMenuItem @select="adding = true">
+            <Plus class="size-4" />
+            Add Solarsystem
+        </ContextMenuItem>
         <template v-if="hasSelection">
             <ContextMenuSeparator />
-            <ContextMenuItem @select="deleteSelectedMapSolarsystems"> Delete selection</ContextMenuItem>
+            <ContextMenuItem @select="deleteSelectedMapSolarsystems">
+                <Trash2 class="size-4" />
+                Delete selection
+            </ContextMenuItem>
             <ContextMenuSub>
-                <ContextMenuSubTrigger> Organize selection</ContextMenuSubTrigger>
+                <ContextMenuSubTrigger>
+                    <LayoutGrid class="size-4" />
+                    Organize selection
+                </ContextMenuSubTrigger>
                 <ContextMenuSubContent>
                     <div class="grid gap-2 p-1">
                         <NumberField v-model:model-value="spacing" :min="0" :max="4">
@@ -93,21 +107,44 @@ function handeCancelDelete() {
                     </div>
                 </ContextMenuSubContent>
             </ContextMenuSub>
-            <ContextMenuSeparator />
         </template>
-        <ContextMenuItem @select="handleDelete"> Clear map</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem @select="is_cleaning_map = true" :disabled="orphaned_count === 0">
+            <Eraser class="size-4" />
+            Clean map
+        </ContextMenuItem>
+        <ContextMenuItem @select="is_clearing_map = true" :disabled="clearable_count === 0" class="text-destructive focus:text-destructive">
+            <Trash2 class="size-4" />
+            Clear map
+        </ContextMenuItem>
     </ContextMenuContent>
     <Dialog v-model:open="is_clearing_map">
         <DialogContent>
             <DialogHeader>
                 <DialogTitle> Clear map</DialogTitle>
                 <DialogDescription>
-                    Are you sure you want to clear the map? This will remove all solarsystems that are not pinned.
+                    Are you sure you want to clear the map? This will remove {{ clearable_count }}
+                    {{ clearable_count === 1 ? 'solarsystem' : 'solarsystems' }}. Only pinned systems and the home system are kept.
                 </DialogDescription>
             </DialogHeader>
             <DialogFooter>
-                <Button variant="secondary" @click="handeCancelDelete"> Cancel</Button>
-                <Button variant="destructive" @click="handleConfirmDelete"> Clear map</Button>
+                <Button variant="secondary" @click="is_clearing_map = false"> Cancel</Button>
+                <Button variant="destructive" @click="handleConfirmClear"> Clear map</Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+    <Dialog v-model:open="is_cleaning_map">
+        <DialogContent>
+            <DialogHeader>
+                <DialogTitle> Clean map</DialogTitle>
+                <DialogDescription>
+                    Are you sure you want to clean the map? This will remove {{ orphaned_count }}
+                    {{ orphaned_count === 1 ? 'solarsystem' : 'solarsystems' }} not connected to a pinned or home system.
+                </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+                <Button variant="secondary" @click="is_cleaning_map = false"> Cancel</Button>
+                <Button variant="destructive" @click="handleConfirmClean"> Clean map</Button>
             </DialogFooter>
         </DialogContent>
     </Dialog>

--- a/tests/Feature/Actions/MapSelectionActionsTest.php
+++ b/tests/Feature/Actions/MapSelectionActionsTest.php
@@ -8,6 +8,7 @@ use App\Models\Map;
 use App\Models\MapConnection;
 use App\Models\MapSolarsystem;
 use App\Models\MapSolarsystemDetails;
+use App\Rules\NotHomeSystem;
 
 it('repositions the selected systems', function () {
     $map = Map::factory()->create();
@@ -38,4 +39,29 @@ it('removes the selected systems and cascades their connections while keeping de
     expect(MapSolarsystem::whereIn('id', [$a->id, $b->id])->count())->toBe(0)
         ->and(MapConnection::find($connection->id))->toBeNull()
         ->and(MapSolarsystemDetails::where('map_id', $map->id)->count())->toBe(2);
+});
+
+it('rejects deleting the home system through the selection endpoint', function () {
+    $map = Map::factory()->create();
+    $home = placeMapSolarsystem($map, 30008004);
+    $map->update(['home_solarsystem_id' => $home->solarsystem_id]);
+
+    $failed = false;
+    new NotHomeSystem()->validate('map_solarsystem_ids.0', $home->id, function () use (&$failed): void {
+        $failed = true;
+    });
+
+    expect($failed)->toBeTrue();
+});
+
+it('allows deleting a system that is not the home system', function () {
+    $map = Map::factory()->create();
+    $system = placeMapSolarsystem($map, 30008005);
+
+    $failed = false;
+    new NotHomeSystem()->validate('map_solarsystem_ids.0', $system->id, function () use (&$failed): void {
+        $failed = true;
+    });
+
+    expect($failed)->toBeFalse();
 });


### PR DESCRIPTION
- Add icons to the map background context menu, matching the other context menus
- Clear map now keeps pinned systems and the home system, with a confirmation dialog showing the removal count
- New clean map command removes systems not reachable from a pinned or home system via connections
- Server side rule rejects deleting the home system through the bulk selection endpoint