### PR TITLE
Fix the initial-connect map reload and the skyhook transition warning

### DIFF
--- a/resources/js/components/map-skyhooks/Skyhook.vue
+++ b/resources/js/components/map-skyhooks/Skyhook.vue
@@ -100,31 +100,37 @@ const hasRoute = computed(() => route !== null && route.length > 1);
 </script>
 
 <template>
-    <DestinationContextMenu :solarsystem_id="skyhook.solarsystem_id">
-        <div v-element-hover="onHover" class="col-span-full grid grid-cols-subgrid items-center px-3 py-1.5 hover:bg-muted/20">
-            <span class="size-2 rounded-full" :class="statusColor" />
-            <span class="truncate text-xs">{{ planetLabel }}</span>
-            <span class="truncate font-mono text-[10px] text-muted-foreground">{{ staticSolarsystem.region?.name ?? '' }}</span>
-            <SolarsystemSovereignty :solarsystem-id="skyhook.solarsystem_id" class="size-4" />
-            <RoutePopover v-if="hasRoute" :route="route ?? undefined">
-                <span class="cursor-pointer text-right font-mono text-[10px] tracking-wider uppercase hover:text-foreground" :class="jumpsClass">{{
-                    jumpsLabel
-                }}</span>
-            </RoutePopover>
-            <span v-else class="text-right font-mono text-[10px] tracking-wider uppercase" :class="jumpsClass">{{ jumpsLabel }}</span>
-            <Tooltip>
-                <TooltipTrigger as-child>
+    <!-- The context menu root renders no element, but the parent TransitionGroup
+         needs an element root to animate — same wrapper pattern as Killmail.vue. -->
+    <div class="col-span-full grid grid-cols-subgrid">
+        <DestinationContextMenu :solarsystem_id="skyhook.solarsystem_id">
+            <div v-element-hover="onHover" class="col-span-full grid grid-cols-subgrid items-center px-3 py-1.5 hover:bg-muted/20">
+                <span class="size-2 rounded-full" :class="statusColor" />
+                <span class="truncate text-xs">{{ planetLabel }}</span>
+                <span class="truncate font-mono text-[10px] text-muted-foreground">{{ staticSolarsystem.region?.name ?? '' }}</span>
+                <SolarsystemSovereignty :solarsystem-id="skyhook.solarsystem_id" class="size-4" />
+                <RoutePopover v-if="hasRoute" :route="route ?? undefined">
                     <span
-                        class="cursor-help justify-self-end font-mono text-[10px] font-semibold tracking-wider uppercase"
-                        :class="statusTimeClass"
-                        >{{ statusTime }}</span
+                        class="cursor-pointer text-right font-mono text-[10px] tracking-wider uppercase hover:text-foreground"
+                        :class="jumpsClass"
+                        >{{ jumpsLabel }}</span
                     >
-                </TooltipTrigger>
-                <TooltipContent class="flex flex-col gap-0.5">
-                    <span>{{ tooltipHeadline }}</span>
-                    <span class="font-mono text-[10px] text-muted-foreground">{{ tooltipWindow }}</span>
-                </TooltipContent>
-            </Tooltip>
-        </div>
-    </DestinationContextMenu>
+                </RoutePopover>
+                <span v-else class="text-right font-mono text-[10px] tracking-wider uppercase" :class="jumpsClass">{{ jumpsLabel }}</span>
+                <Tooltip>
+                    <TooltipTrigger as-child>
+                        <span
+                            class="cursor-help justify-self-end font-mono text-[10px] font-semibold tracking-wider uppercase"
+                            :class="statusTimeClass"
+                            >{{ statusTime }}</span
+                        >
+                    </TooltipTrigger>
+                    <TooltipContent class="flex flex-col gap-0.5">
+                        <span>{{ tooltipHeadline }}</span>
+                        <span class="font-mono text-[10px] text-muted-foreground">{{ tooltipWindow }}</span>
+                    </TooltipContent>
+                </Tooltip>
+            </div>
+        </DestinationContextMenu>
+    </div>
 </template>

--- a/resources/js/map/sync/reconnect.spec.ts
+++ b/resources/js/map/sync/reconnect.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createReconnectListener } from './reconnect';
+
+describe('createReconnectListener', () => {
+    it('does not fire on the initial connection', () => {
+        const onReconnect = vi.fn();
+        const listener = createReconnectListener(onReconnect);
+
+        listener({ previous: 'initialized', current: 'connecting' });
+        listener({ previous: 'connecting', current: 'connected' });
+
+        expect(onReconnect).not.toHaveBeenCalled();
+    });
+
+    it('fires on a reconnect after a dropped connection', () => {
+        const onReconnect = vi.fn();
+        const listener = createReconnectListener(onReconnect);
+
+        listener({ previous: 'connecting', current: 'connected' });
+        listener({ previous: 'connected', current: 'unavailable' });
+        listener({ previous: 'unavailable', current: 'connecting' });
+        listener({ previous: 'connecting', current: 'connected' });
+
+        expect(onReconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires on every subsequent reconnect', () => {
+        const onReconnect = vi.fn();
+        const listener = createReconnectListener(onReconnect);
+
+        listener({ previous: 'connecting', current: 'connected' });
+        listener({ previous: 'connected', current: 'connecting' });
+        listener({ previous: 'connecting', current: 'connected' });
+        listener({ previous: 'connected', current: 'unavailable' });
+        listener({ previous: 'unavailable', current: 'connected' });
+
+        expect(onReconnect).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores state changes that do not reach connected', () => {
+        const onReconnect = vi.fn();
+        const listener = createReconnectListener(onReconnect);
+
+        listener({ previous: 'connecting', current: 'connected' });
+        listener({ previous: 'connected', current: 'unavailable' });
+        listener({ previous: 'unavailable', current: 'connecting' });
+        listener({ previous: 'connecting', current: 'failed' });
+
+        expect(onReconnect).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/map/sync/reconnect.ts
+++ b/resources/js/map/sync/reconnect.ts
@@ -1,0 +1,24 @@
+export type ConnectionStateChange = {
+    previous: string;
+    current: string;
+};
+
+/**
+ * Wraps a callback so it only fires on genuine reconnects, never on the
+ * initial connection. Pusher reaches 'connected' from 'connecting' on the
+ * first connect too, so the previous state cannot distinguish the two — a
+ * naive previous-state check made every page load trigger a full map reload.
+ */
+export function createReconnectListener(onReconnect: () => void): (states: ConnectionStateChange) => void {
+    let hasConnectedBefore = false;
+
+    return ({ current }) => {
+        if (current !== 'connected') {
+            return;
+        }
+        if (hasConnectedBefore) {
+            onReconnect();
+        }
+        hasConnectedBefore = true;
+    };
+}

--- a/resources/js/map/sync/useMapSync.ts
+++ b/resources/js/map/sync/useMapSync.ts
@@ -8,11 +8,12 @@ import { usePage } from '@inertiajs/vue3';
 import { echo, useEcho } from '@laravel/echo-vue';
 import { computed, MaybeRefOrGetter, onMounted, onUnmounted, toValue } from 'vue';
 import { ALL_MAP_PROPS, mapEventHandlers, type SyncEffect } from './handlers';
+import { type ConnectionStateChange, createReconnectListener } from './reconnect';
 import { createReloadCoalescer } from './reloadCoalescer';
 
 type PusherConnection = {
-    bind(event: 'state_change', callback: (states: { previous: string; current: string }) => void): void;
-    unbind(event: 'state_change', callback: (states: { previous: string; current: string }) => void): void;
+    bind(event: 'state_change', callback: (states: ConnectionStateChange) => void): void;
+    unbind(event: 'state_change', callback: (states: ConnectionStateChange) => void): void;
 };
 
 /**
@@ -50,11 +51,7 @@ export function useMapSync(store: MapStore, mapId: MaybeRefOrGetter<number>): vo
         );
     }
 
-    const handleConnectionStateChange = ({ previous, current }: { previous: string; current: string }): void => {
-        if (current === 'connected' && previous !== 'initialized') {
-            coalescer.schedule(ALL_MAP_PROPS);
-        }
-    };
+    const handleConnectionStateChange = createReconnectListener(() => coalescer.schedule(ALL_MAP_PROPS));
 
     onMounted(() => {
         connection()?.bind('state_change', handleConnectionStateChange);


### PR DESCRIPTION
Two map fixes.

- The websocket reconnect handler reloaded all map props on every initial page connect, not just reconnects, because Pusher reaches connected from connecting on first load. The listener now tracks explicitly whether a connection existed before, so the full resync only runs on genuine reconnects. This removes a redundant full-map request from every page view and the mid-interaction re-render behind the flaky browser tests.
- The skyhook row had the renderless context menu as its component root, so the list TransitionGroup warned "renders non-element root node" once per row. The row now has a subgrid wrapper element as its root, matching the killmail row.