### PR TITLE
fix: clip horizontal overflow while panel list rows animate in

### DIFF
--- a/resources/js/components/map-skyhooks/MapSkyhooks.vue
+++ b/resources/js/components/map-skyhooks/MapSkyhooks.vue
@@ -240,7 +240,7 @@ function handleSort(column: SkyhookSortColumn) {
                         <span v-if="tabCounts.ice" class="ml-1 text-amber-400">{{ tabCounts.ice }}</span>
                     </TabsTrigger>
                 </TabsList>
-                <div class="flex-1 overflow-y-auto">
+                <div class="flex-1 overflow-x-hidden overflow-y-auto">
                     <Deferred data="map_skyhooks">
                         <template v-if="sortedSkyhooks.length">
                             <div class="grid grid-cols-[1rem_auto_auto_1rem_2rem_auto] gap-x-2">

--- a/resources/js/components/ui/map-panel/MapPanelContent.vue
+++ b/resources/js/components/ui/map-panel/MapPanelContent.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts"></script>
 
 <template>
-    <div class="flex-1 overflow-y-auto">
+    <div class="flex-1 overflow-x-hidden overflow-y-auto">
         <slot />
     </div>
 </template>


### PR DESCRIPTION
The list enter transition slides rows in from translateX(20px), which briefly overflows the panel scroll containers and flashes a horizontal scrollbar. MapPanelContent and the skyhook tab's inner scroll container only set overflow-y, which forces overflow-x to auto, so they now clip the x axis. This also covers the killmail and character lists, which use the same animation.