### PR TITLE
feat: redesign landing page in the app's map aesthetic

### DIFF
--- a/app/Http/Controllers/LandingController.php
+++ b/app/Http/Controllers/LandingController.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\KillmailResource;
+use App\Models\Killmail;
+use Illuminate\Http\Resources\Json\ResourceCollection;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -11,6 +14,26 @@ final class LandingController extends Controller
 {
     public function index(): Response
     {
-        return Inertia::render('Landing');
+        return Inertia::render('Landing', [
+            'killmails' => fn (): ResourceCollection => $this->getLatestKillmails(),
+        ]);
+    }
+
+    /**
+     * The most recent J-space kills, polled live by the landing page.
+     */
+    private function getLatestKillmails(): ResourceCollection
+    {
+        return Killmail::query()
+            ->with([
+                'shipType',
+                'victimCorporation:id,name,ticker',
+                'victimAlliance:id,name,ticker',
+            ])
+            ->whereRelation('solarsystem', 'type', 'wormhole')
+            ->orderByDesc('id')
+            ->limit(12)
+            ->get()
+            ->toResourceCollection(KillmailResource::class);
     }
 }

--- a/resources/js/components/landing/fixtures.ts
+++ b/resources/js/components/landing/fixtures.ts
@@ -35,9 +35,12 @@ const SHIPS = {
 /**
  * Real solar systems pulled from resources/static/solarsystems.json (the same
  * dataset the live app uses) so every name, class, region, static and effect is
- * authentic. Class of each system matches the wormhole it connects through.
+ * authentic. The chain is static-accurate too: every connection is either a
+ * static of its source system or an inbound K162 opened by the other side's
+ * static, so the topology could exist in game exactly as drawn.
  */
 const SYSTEMS = {
+    /** C5 home. Its H296 static leads to another C5 (alpha). */
     home: {
         id: 31001880,
         name: 'J152820',
@@ -62,96 +65,91 @@ const SYSTEMS = {
         effect: { name: 'Pulsar', effects: [] },
         connection_type: null,
     },
+    /** C5 behind home's H296 static; its own V753 static leads on to the C6 (delta). */
     alpha: {
-        id: 31000880,
-        name: 'J160650',
-        region_id: 11000009,
-        constellation_id: 21000076,
-        class: '3',
+        id: 31002063,
+        name: 'J154846',
+        region_id: 11000026,
+        constellation_id: 21000256,
+        class: '5',
         security: -1,
         type: 'wh',
-        region: { id: 11000009, name: 'C-R00009' },
+        region: { id: 11000026, name: 'E-R00026' },
         sovereignty: null,
         statics: [
             {
-                id: 30687,
-                leads_to: 'ls',
-                name: 'U210',
+                id: 30703,
+                leads_to: 'c6',
+                name: 'V753',
                 maximum_lifetime: 86400,
-                maximum_jump_mass: 375_000_000,
-                total_mass: 3_000_000_000,
-                signature_strength: 10,
+                maximum_jump_mass: 2_000_000_000,
+                total_mass: 3_300_000_000,
+                signature_strength: 6.67,
             },
         ],
-        effect: null,
+        effect: { name: 'Wolf-Rayet Star', effects: [] },
         connection_type: null,
     },
-    thera: {
-        id: 31001375,
-        name: 'J160225',
-        region_id: 11000016,
-        constellation_id: 21000153,
+    /** C4 whose H900 static opened the K162 into home; its C247 static leads to the C3 (gamma). */
+    beta: {
+        id: 31001663,
+        name: 'J231710',
+        region_id: 11000021,
+        constellation_id: 21000197,
         class: '4',
         security: -1,
         type: 'wh',
-        region: { id: 11000016, name: 'D-R00016' },
+        region: { id: 11000021, name: 'D-R00021' },
         sovereignty: null,
         statics: [
             {
-                id: 30692,
-                leads_to: 'c4',
-                name: 'X877',
-                maximum_lifetime: 57600,
-                maximum_jump_mass: 375_000_000,
-                total_mass: 2_000_000_000,
-                signature_strength: 6.67,
-            },
-            {
-                id: 30690,
-                leads_to: 'c2',
-                name: 'N766',
-                maximum_lifetime: 57600,
-                maximum_jump_mass: 375_000_000,
-                total_mass: 2_000_000_000,
-                signature_strength: 4,
-            },
-        ],
-        effect: null,
-        connection_type: null,
-    },
-    beta: {
-        id: 31000355,
-        name: 'J164417',
-        region_id: 11000004,
-        constellation_id: 21000021,
-        class: '2',
-        security: -1,
-        type: 'wh',
-        region: { id: 11000004, name: 'B-R00004' },
-        sovereignty: null,
-        statics: [
-            {
-                id: 30677,
-                leads_to: 'hs',
-                name: 'B274',
+                id: 30693,
+                leads_to: 'c5',
+                name: 'H900',
                 maximum_lifetime: 86400,
+                maximum_jump_mass: 375_000_000,
+                total_mass: 3_000_000_000,
+                signature_strength: 2.5,
+            },
+            {
+                id: 30691,
+                leads_to: 'c3',
+                name: 'C247',
+                maximum_lifetime: 57600,
                 maximum_jump_mass: 375_000_000,
                 total_mass: 2_000_000_000,
                 signature_strength: 10,
             },
+        ],
+        effect: { name: 'Magnetar', effects: [] },
+        connection_type: null,
+    },
+    /** C3 behind the C4's C247 static; its D845 highsec static is the chain's exit to Jita. */
+    gamma: {
+        id: 31001073,
+        name: 'J121856',
+        region_id: 11000012,
+        constellation_id: 21000106,
+        class: '3',
+        security: -1,
+        type: 'wh',
+        region: { id: 11000012, name: 'C-R00012' },
+        sovereignty: null,
+        statics: [
             {
-                id: 30673,
-                leads_to: 'c3',
-                name: 'O477',
-                maximum_lifetime: 57600,
+                id: 30695,
+                leads_to: 'hs',
+                name: 'D845',
+                maximum_lifetime: 86400,
                 maximum_jump_mass: 375_000_000,
-                total_mass: 2_000_000_000,
+                total_mass: 5_000_000_000,
                 signature_strength: 5,
             },
         ],
         effect: null,
         connection_type: null,
     },
+    /** C6 behind alpha's V753 static — the dangerous end of the chain. */
     delta: {
         id: 31002367,
         name: 'J104859',
@@ -176,20 +174,32 @@ const SYSTEMS = {
         effect: { name: 'Pulsar', effects: [] },
         connection_type: null,
     },
-    amarr: {
-        id: 30002187,
-        name: 'Amarr',
-        region_id: 10000043,
-        constellation_id: 20000322,
-        class: 'h',
-        security: 1,
-        type: 'eve',
-        region: { id: 10000043, name: 'Domain' },
+    /** Neighbouring C5 whose H296 static opened a second K162 into home. */
+    epsilon: {
+        id: 31001881,
+        name: 'J135100',
+        region_id: 11000024,
+        constellation_id: 21000232,
+        class: '5',
+        security: -1,
+        type: 'wh',
+        region: { id: 11000024, name: 'E-R00024' },
         sovereignty: null,
-        statics: null,
+        statics: [
+            {
+                id: 30702,
+                leads_to: 'c5',
+                name: 'H296',
+                maximum_lifetime: 86400,
+                maximum_jump_mass: 2_000_000_000,
+                total_mass: 3_300_000_000,
+                signature_strength: 10,
+            },
+        ],
         effect: null,
         connection_type: null,
     },
+    /** Highsec exit behind the C3's D845 static. */
     jita: {
         id: 30000142,
         name: 'Jita',
@@ -239,19 +249,18 @@ function node(
 }
 
 /**
- * Laid out as a tidy left-to-right tree on the grid (positions are multiples of
- * the grid size). HOME is the hub on the left with three branches; each branch
- * carries one downstream system, including two known-space exits (Jita, Amarr).
- * The right-hand connections run parallel so no curves cross.
+ * A free-flow chain layout (positions are multiples of the grid size). HOME
+ * sits on the left with its H296 static going up the chain toward the C6 and
+ * two inbound K162s; the exit route runs through the C4 and C3 to Jita.
  */
 const NODES = {
-    home: node(1, SYSTEMS.home, { x: 80, y: 320 }, 'friendly', { signatures_count: 8, map_connections_count: 3, wormhole_signatures_count: 4 }),
-    alpha: node(2, SYSTEMS.alpha, { x: 340, y: 180 }, 'unscanned', { signatures_count: 3, map_connections_count: 2 }),
-    thera: node(5, SYSTEMS.thera, { x: 340, y: 320 }, 'empty', { signatures_count: 2, map_connections_count: 2 }),
-    beta: node(3, SYSTEMS.beta, { x: 340, y: 460 }, 'active', { signatures_count: 5, map_connections_count: 2 }),
-    jita: node(7, SYSTEMS.jita, { x: 600, y: 180 }, 'unknown', { map_connections_count: 1 }),
-    amarr: node(6, SYSTEMS.amarr, { x: 600, y: 320 }, 'unknown', { map_connections_count: 1 }),
-    delta: node(4, SYSTEMS.delta, { x: 600, y: 460 }, 'hostile', { threat_level: 'critical', signatures_count: 6, map_connections_count: 1 }),
+    home: node(1, SYSTEMS.home, { x: 80, y: 340 }, 'friendly', { signatures_count: 8, map_connections_count: 3, wormhole_signatures_count: 4 }),
+    alpha: node(2, SYSTEMS.alpha, { x: 340, y: 180 }, 'empty', { signatures_count: 3, map_connections_count: 2 }),
+    beta: node(3, SYSTEMS.beta, { x: 340, y: 340 }, 'active', { signatures_count: 5, map_connections_count: 2 }),
+    gamma: node(4, SYSTEMS.gamma, { x: 600, y: 300 }, 'active', { signatures_count: 2, map_connections_count: 2 }),
+    delta: node(5, SYSTEMS.delta, { x: 600, y: 120 }, 'hostile', { threat_level: 'critical', signatures_count: 6, map_connections_count: 1 }),
+    epsilon: node(6, SYSTEMS.epsilon, { x: 340, y: 500 }, 'unscanned', { map_connections_count: 1 }),
+    jita: node(7, SYSTEMS.jita, { x: 600, y: 460 }, 'unknown', { map_connections_count: 1 }),
 };
 
 export const MAP_SOLARSYSTEMS: TMapSolarsystem[] = Object.values(NODES);
@@ -287,12 +296,12 @@ function connection(
 }
 
 export const MAP_CONNECTIONS: TProcessedConnection[] = [
-    connection(1, NODES.home, NODES.alpha, 'fresh', 'healthy', 'large'),
-    connection(2, NODES.home, NODES.thera, 'fresh', 'eol', 'medium', true),
-    connection(3, NODES.home, NODES.beta, 'reduced', 'healthy', 'large'),
-    connection(4, NODES.alpha, NODES.jita, 'fresh', 'healthy', 'large'),
-    connection(5, NODES.thera, NODES.amarr, 'fresh', 'healthy', 'large', true),
-    connection(6, NODES.beta, NODES.delta, 'critical', 'critical', 'medium'),
+    connection(1, NODES.home, NODES.alpha, 'fresh', 'healthy', 'xlarge'),
+    connection(2, NODES.beta, NODES.home, 'fresh', 'healthy', 'large', true),
+    connection(3, NODES.epsilon, NODES.home, 'reduced', 'eol', 'xlarge'),
+    connection(4, NODES.alpha, NODES.delta, 'critical', 'critical', 'xlarge'),
+    connection(5, NODES.beta, NODES.gamma, 'fresh', 'healthy', 'large', true),
+    connection(6, NODES.gamma, NODES.jita, 'reduced', 'healthy', 'large', true),
 ];
 
 function character(
@@ -343,9 +352,9 @@ export const CHARACTERS: TCharacterViewModel[] = [
         static_solarsystem: toStatic(SYSTEMS.alpha),
     },
     {
-        ...character(2112000003, 'Aura Vex', SHIPS.stratios, SYSTEMS.thera),
-        route: route([SYSTEMS.home, SYSTEMS.thera, SYSTEMS.amarr]),
-        static_solarsystem: toStatic(SYSTEMS.thera),
+        ...character(2112000003, 'Aura Vex', SHIPS.stratios, SYSTEMS.gamma),
+        route: route([SYSTEMS.home, SYSTEMS.beta, SYSTEMS.gamma]),
+        static_solarsystem: toStatic(SYSTEMS.gamma),
     },
     {
         ...character(2112000004, 'Dagan Khar', SHIPS.buzzard, SYSTEMS.beta),
@@ -361,7 +370,7 @@ export const CHARACTERS: TCharacterViewModel[] = [
 
 export const MAP_PILOTS: Record<number, TCharacter[]> = {
     [NODES.home.id]: [CHARACTERS[0], CHARACTERS[4]],
-    [NODES.thera.id]: [CHARACTERS[2]],
+    [NODES.gamma.id]: [CHARACTERS[2]],
 };
 
 function killmail(
@@ -430,7 +439,7 @@ export function buildKillmails(): TKillmailViewModel[] {
         killmail(101, SHIPS.astero, SYSTEMS.delta, 142_000_000, 1),
         killmail(102, SHIPS.drake, SYSTEMS.beta, 88_000_000, 6, { solo: true }),
         killmail(103, SHIPS.sabre, SYSTEMS.home, 61_000_000, 12),
-        killmail(104, SHIPS.legion, SYSTEMS.thera, 412_000_000, 23),
+        killmail(104, SHIPS.legion, SYSTEMS.gamma, 412_000_000, 23),
         killmail(105, SHIPS.venture, SYSTEMS.alpha, 12_000_000, 41),
     ];
 }
@@ -515,13 +524,14 @@ function signature(input: SignatureInput): TSignature {
 /** Built per-render (call inside setup) — see {@link buildKillmails}. */
 export function buildSignatures(): TSignature[] {
     return [
-        // Wormholes, wired to the mapped connections (target class matches the linked system).
+        // Wormholes in HOME, wired to the mapped connections: the H296 static
+        // plus the K162 sides of the holes the C4 and C5 opened into us.
         signature({
             id: 701,
             signature_id: 'AZX-114',
             categoryName: 'Wormhole',
-            code: 'C247',
-            target_class: '3',
+            code: 'H296',
+            target_class: '5',
             map_connection_id: 1,
             minutesAgo: 18,
         }),
@@ -529,11 +539,9 @@ export function buildSignatures(): TSignature[] {
             id: 702,
             signature_id: 'JKL-204',
             categoryName: 'Wormhole',
-            code: 'X877',
+            code: 'K162',
             target_class: '4',
             map_connection_id: 2,
-            lifetime: 'eol',
-            mass: 'reduced',
             minutesAgo: 124,
         }),
         signature({
@@ -541,14 +549,14 @@ export function buildSignatures(): TSignature[] {
             signature_id: 'QRS-557',
             categoryName: 'Wormhole',
             code: 'K162',
-            target_class: '2',
+            target_class: '5',
             map_connection_id: 3,
-            lifetime: 'critical',
-            mass: 'critical',
+            lifetime: 'eol',
+            mass: 'reduced',
             minutesAgo: 6,
         }),
-        // Unconnected static wormhole, not yet linked to a system.
-        signature({ id: 704, signature_id: 'HMF-301', categoryName: 'Wormhole', code: 'H296', target_class: '5', minutesAgo: 41 }),
+        // Wandering K162, not yet linked to a system on the map.
+        signature({ id: 704, signature_id: 'HMF-301', categoryName: 'Wormhole', code: 'K162', target_class: '3', minutesAgo: 41 }),
         // Cosmic signatures (no connection).
         signature({ id: 705, signature_id: 'DAT-209', categoryName: 'Data Site', typeName: 'Unsecured Frontier Database', minutesAgo: 63 }),
         signature({

--- a/resources/js/components/landing/fixtures.ts
+++ b/resources/js/components/landing/fixtures.ts
@@ -245,13 +245,13 @@ function node(
  * The right-hand connections run parallel so no curves cross.
  */
 const NODES = {
-    home: node(1, SYSTEMS.home, { x: 120, y: 180 }, 'friendly', { signatures_count: 8, map_connections_count: 3, wormhole_signatures_count: 4 }),
-    alpha: node(2, SYSTEMS.alpha, { x: 340, y: 60 }, 'unscanned', { signatures_count: 3, map_connections_count: 2 }),
-    thera: node(5, SYSTEMS.thera, { x: 340, y: 180 }, 'empty', { signatures_count: 2, map_connections_count: 2 }),
-    beta: node(3, SYSTEMS.beta, { x: 340, y: 300 }, 'active', { signatures_count: 5, map_connections_count: 2 }),
-    jita: node(7, SYSTEMS.jita, { x: 560, y: 60 }, 'unknown', { map_connections_count: 1 }),
-    amarr: node(6, SYSTEMS.amarr, { x: 560, y: 180 }, 'unknown', { map_connections_count: 1 }),
-    delta: node(4, SYSTEMS.delta, { x: 560, y: 300 }, 'hostile', { threat_level: 'critical', signatures_count: 6, map_connections_count: 1 }),
+    home: node(1, SYSTEMS.home, { x: 80, y: 320 }, 'friendly', { signatures_count: 8, map_connections_count: 3, wormhole_signatures_count: 4 }),
+    alpha: node(2, SYSTEMS.alpha, { x: 340, y: 180 }, 'unscanned', { signatures_count: 3, map_connections_count: 2 }),
+    thera: node(5, SYSTEMS.thera, { x: 340, y: 320 }, 'empty', { signatures_count: 2, map_connections_count: 2 }),
+    beta: node(3, SYSTEMS.beta, { x: 340, y: 460 }, 'active', { signatures_count: 5, map_connections_count: 2 }),
+    jita: node(7, SYSTEMS.jita, { x: 600, y: 180 }, 'unknown', { map_connections_count: 1 }),
+    amarr: node(6, SYSTEMS.amarr, { x: 600, y: 320 }, 'unknown', { map_connections_count: 1 }),
+    delta: node(4, SYSTEMS.delta, { x: 600, y: 460 }, 'hostile', { threat_level: 'critical', signatures_count: 6, map_connections_count: 1 }),
 };
 
 export const MAP_SOLARSYSTEMS: TMapSolarsystem[] = Object.values(NODES);

--- a/resources/js/map/components/MapReadonly.vue
+++ b/resources/js/map/components/MapReadonly.vue
@@ -2,16 +2,15 @@
 import Edge from '@/map/components/edges/Edge.vue';
 import NodeCard from '@/map/components/nodes/NodeCard.vue';
 import { ANCHOR_OFFSET, nodeRect } from '@/map/core/coords';
-import { computeTreeEdgeGeometries } from '@/map/core/geometry/treeRouting';
-import type { EdgeGeometry, EdgeInput, Rect, Size, Vec2 } from '@/map/core/types';
+import { freeEdgeGeometry } from '@/map/core/geometry/freeRouting';
+import type { EdgeGeometry, Size } from '@/map/core/types';
 import type { TMapConnection, TMapSolarsystem } from '@/pages/maps';
 import { TCharacter } from '@/types/models';
-import { computed } from 'vue';
 
 /**
  * Store-free, read-only rendering of plain map data (the landing page's demo
  * map). Same contract as the old MapView: base-unit positions scaled by the
- * `scale` prop, non-interactive cards, and the same tree-routed elbow edges
+ * `scale` prop, non-interactive cards, and the same free-layout curved edges
  * the live map draws.
  */
 type TReadonlyConnection = TMapConnection & {
@@ -43,47 +42,18 @@ const {
  * Fixed-width node cards keep the edge routing fully deterministic: the
  * geometry is correct on the very first paint (no post-mount measurement pass,
  * so no connection jump while the map fades in) and costs nothing to compute.
+ * Nodes are assumed to span two grid fields high (the card's base height).
  */
-const NODE_WIDTH = 180;
-
-function nodeSize(system: TMapSolarsystem): Size {
-    return {
-        width: NODE_WIDTH,
-        height: (pilots[system.id]?.length ?? 0) > 0 ? 60 : 40,
-    };
-}
+const NODE_SIZE: Size = { width: 180, height: 40 };
 
 /**
- * The same global tree-routing pass the live map runs: all edges routed
- * together so fan-outs at shared nodes space themselves out.
+ * The same per-edge free-layout routing the live map uses when the layout is
+ * unlocked: rounded curves between rail endpoints on each node.
  */
-const treeGeometries = computed<Map<number, EdgeGeometry>>(() => {
-    const edges: EdgeInput[] = connections.map((connection) => ({
-        id: connection.id,
-        sourceId: connection.source.id,
-        targetId: connection.target.id,
-    }));
-
-    const rects = new Map<number, Rect>();
-    const anchors = new Map<number, Vec2>();
-    for (const system of solarsystems) {
-        const anchor = system.position ?? { x: 0, y: 0 };
-        anchors.set(system.id, anchor);
-        rects.set(system.id, nodeRect(anchor, nodeSize(system)));
-    }
-
-    return computeTreeEdgeGeometries(edges, rects, anchors);
-});
-
 function connectionGeometry(connection: TReadonlyConnection): EdgeGeometry {
-    return (
-        treeGeometries.value.get(connection.id) ?? {
-            id: connection.id,
-            kind: 'curve',
-            from: connection.source.position ?? { x: 0, y: 0 },
-            to: connection.target.position ?? { x: 0, y: 0 },
-        }
-    );
+    const sourceAnchor = connection.source.position ?? { x: 0, y: 0 };
+    const targetAnchor = connection.target.position ?? { x: 0, y: 0 };
+    return freeEdgeGeometry(connection.id, nodeRect(sourceAnchor, NODE_SIZE), nodeRect(targetAnchor, NODE_SIZE));
 }
 
 /** The node's top-left in screen pixels: the scaled anchor minus the scaled anchor offset. */

--- a/resources/js/map/components/MapReadonly.vue
+++ b/resources/js/map/components/MapReadonly.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
 import Edge from '@/map/components/edges/Edge.vue';
 import NodeCard from '@/map/components/nodes/NodeCard.vue';
-import { ANCHOR_OFFSET } from '@/map/core/coords';
-import type { EdgeGeometry } from '@/map/core/types';
+import { ANCHOR_OFFSET, nodeRect } from '@/map/core/coords';
+import { computeTreeEdgeGeometries } from '@/map/core/geometry/treeRouting';
+import type { EdgeGeometry, EdgeInput, Rect, Size, Vec2 } from '@/map/core/types';
 import type { TMapConnection, TMapSolarsystem } from '@/pages/maps';
 import { TCharacter } from '@/types/models';
+import { computed, onMounted, ref, type ComponentPublicInstance } from 'vue';
 
 /**
  * Store-free, read-only rendering of plain map data (the landing page's demo
  * map). Same contract as the old MapView: base-unit positions scaled by the
- * `scale` prop, curve edges only, non-interactive cards.
+ * `scale` prop, non-interactive cards, and the same tree-routed elbow edges
+ * the live map draws.
  */
 type TReadonlyConnection = TMapConnection & {
     source: TMapSolarsystem;
@@ -36,14 +39,73 @@ const {
     pilots?: Record<number, TCharacter[]>;
 }>();
 
-/** The free-layout curve between the two stored anchors, in base units. */
-function connectionGeometry(connection: TReadonlyConnection): EdgeGeometry {
-    return {
+/**
+ * Node sizes for edge routing: measured from the DOM after mount, with the
+ * card's known base dimensions as the SSR/first-paint estimate.
+ */
+const ESTIMATED_NODE_WIDTH = 120;
+
+const nodeEls = new Map<number, HTMLElement>();
+const measuredSizes = ref<Map<number, Size>>(new Map());
+
+function registerNode(id: number, el: Element | ComponentPublicInstance | null) {
+    if (el instanceof HTMLElement) {
+        nodeEls.set(id, el);
+    } else {
+        nodeEls.delete(id);
+    }
+}
+
+onMounted(() => {
+    const sizes = new Map<number, Size>();
+    for (const [id, el] of nodeEls) {
+        const card = el.firstElementChild as HTMLElement | null;
+        if (!card) continue;
+        sizes.set(id, { width: card.offsetWidth, height: card.offsetHeight });
+    }
+    measuredSizes.value = sizes;
+});
+
+function nodeSize(system: TMapSolarsystem): Size {
+    return (
+        measuredSizes.value.get(system.id) ?? {
+            width: ESTIMATED_NODE_WIDTH,
+            height: (pilots[system.id]?.length ?? 0) > 0 ? 60 : 40,
+        }
+    );
+}
+
+/**
+ * The same global tree-routing pass the live map runs: all edges routed
+ * together so fan-outs at shared nodes space themselves out.
+ */
+const treeGeometries = computed<Map<number, EdgeGeometry>>(() => {
+    const edges: EdgeInput[] = connections.map((connection) => ({
         id: connection.id,
-        kind: 'curve',
-        from: connection.source.position ?? { x: 0, y: 0 },
-        to: connection.target.position ?? { x: 0, y: 0 },
-    };
+        sourceId: connection.source.id,
+        targetId: connection.target.id,
+    }));
+
+    const rects = new Map<number, Rect>();
+    const anchors = new Map<number, Vec2>();
+    for (const system of solarsystems) {
+        const anchor = system.position ?? { x: 0, y: 0 };
+        anchors.set(system.id, anchor);
+        rects.set(system.id, nodeRect(anchor, nodeSize(system)));
+    }
+
+    return computeTreeEdgeGeometries(edges, rects, anchors);
+});
+
+function connectionGeometry(connection: TReadonlyConnection): EdgeGeometry {
+    return (
+        treeGeometries.value.get(connection.id) ?? {
+            id: connection.id,
+            kind: 'curve',
+            from: connection.source.position ?? { x: 0, y: 0 },
+            to: connection.target.position ?? { x: 0, y: 0 },
+        }
+    );
 }
 
 /** The node's top-left in screen pixels: the scaled anchor minus the scaled anchor offset. */
@@ -70,6 +132,7 @@ function nodeTransform(system: TMapSolarsystem): string {
         <div
             v-for="solarsystem in solarsystems"
             :key="solarsystem.id"
+            :ref="(el) => registerNode(solarsystem.id, el)"
             class="pointer-events-none absolute select-none"
             :style="{ transform: nodeTransform(solarsystem) }"
         >

--- a/resources/js/map/components/MapReadonly.vue
+++ b/resources/js/map/components/MapReadonly.vue
@@ -6,7 +6,7 @@ import { computeTreeEdgeGeometries } from '@/map/core/geometry/treeRouting';
 import type { EdgeGeometry, EdgeInput, Rect, Size, Vec2 } from '@/map/core/types';
 import type { TMapConnection, TMapSolarsystem } from '@/pages/maps';
 import { TCharacter } from '@/types/models';
-import { computed, onMounted, ref, type ComponentPublicInstance } from 'vue';
+import { computed } from 'vue';
 
 /**
  * Store-free, read-only rendering of plain map data (the landing page's demo
@@ -40,39 +40,17 @@ const {
 }>();
 
 /**
- * Node sizes for edge routing: measured from the DOM after mount, with the
- * card's known base dimensions as the SSR/first-paint estimate.
+ * Fixed-width node cards keep the edge routing fully deterministic: the
+ * geometry is correct on the very first paint (no post-mount measurement pass,
+ * so no connection jump while the map fades in) and costs nothing to compute.
  */
-const ESTIMATED_NODE_WIDTH = 120;
-
-const nodeEls = new Map<number, HTMLElement>();
-const measuredSizes = ref<Map<number, Size>>(new Map());
-
-function registerNode(id: number, el: Element | ComponentPublicInstance | null) {
-    if (el instanceof HTMLElement) {
-        nodeEls.set(id, el);
-    } else {
-        nodeEls.delete(id);
-    }
-}
-
-onMounted(() => {
-    const sizes = new Map<number, Size>();
-    for (const [id, el] of nodeEls) {
-        const card = el.firstElementChild as HTMLElement | null;
-        if (!card) continue;
-        sizes.set(id, { width: card.offsetWidth, height: card.offsetHeight });
-    }
-    measuredSizes.value = sizes;
-});
+const NODE_WIDTH = 180;
 
 function nodeSize(system: TMapSolarsystem): Size {
-    return (
-        measuredSizes.value.get(system.id) ?? {
-            width: ESTIMATED_NODE_WIDTH,
-            height: (pilots[system.id]?.length ?? 0) > 0 ? 60 : 40,
-        }
-    );
+    return {
+        width: NODE_WIDTH,
+        height: (pilots[system.id]?.length ?? 0) > 0 ? 60 : 40,
+    };
 }
 
 /**
@@ -132,7 +110,6 @@ function nodeTransform(system: TMapSolarsystem): string {
         <div
             v-for="solarsystem in solarsystems"
             :key="solarsystem.id"
-            :ref="(el) => registerNode(solarsystem.id, el)"
             class="pointer-events-none absolute select-none"
             :style="{ transform: nodeTransform(solarsystem) }"
         >
@@ -145,7 +122,7 @@ function nodeTransform(system: TMapSolarsystem): string {
                     :is-active="false"
                     :is-home="home_solarsystem_id === solarsystem.id"
                     :is-rally="rally_solarsystem_id === solarsystem.solarsystem_id"
-                    :fixed-width="false"
+                    :fixed-width="true"
                 />
             </div>
         </div>

--- a/resources/js/pages/Landing.vue
+++ b/resources/js/pages/Landing.vue
@@ -277,12 +277,6 @@ const vReveal = {
                                             <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
                                         </Link>
                                     </Button>
-                                    <Button as-child size="lg" variant="ghost">
-                                        <a :href="page.props.discord.invite" class="inline-flex items-center gap-2">
-                                            <DiscordIcon class="h-4 w-4" />
-                                            Join the Discord
-                                        </a>
-                                    </Button>
                                 </div>
                                 <p class="mt-8 font-mono text-[10px] tracking-wider text-muted-foreground/70 uppercase">
                                     ESI-secure · No client install · Free to use
@@ -338,9 +332,15 @@ const vReveal = {
 
                         <!-- Open source & self-hosting (surfaced early — it's a core differentiator). -->
                         <div class="chain" aria-hidden="true" />
-                        <div v-reveal class="section-card">
+                        <div v-reveal class="section-card section-card--featured">
                             <MapPanelHeader>
                                 <span class="flex items-center gap-2"><Github class="h-3.5 w-3.5" /> 100% open source</span>
+                                <template #actions>
+                                    <span class="flex items-center gap-1.5 font-mono text-[10px] tracking-wider text-orange-400 uppercase">
+                                        <span class="size-1.5 bg-orange-400" />
+                                        Self-host ready
+                                    </span>
+                                </template>
                             </MapPanelHeader>
                             <div class="grid divide-y divide-border/50 lg:grid-cols-[1.1fr_1fr] lg:divide-x lg:divide-y-0">
                                 <div class="p-8 sm:p-12">
@@ -764,6 +764,30 @@ const vReveal = {
     --surface: var(--color-neutral-900);
     --surface-border: var(--color-neutral-700);
     box-shadow: 0 20px 45px -20px rgb(0 0 0 / 0.8);
+}
+
+/* Featured card (self-hosting): the accent-coloured node in the chain. An
+   orange-tinted border, a soft glow, and a faint wash behind the command. */
+.section-card--featured {
+    --surface-border: color-mix(in oklab, var(--color-orange-400) 45%, var(--color-neutral-300));
+    box-shadow:
+        0 20px 45px -20px rgb(0 0 0 / 0.35),
+        0 0 55px -18px color-mix(in oklab, var(--color-orange-400) 55%, transparent);
+}
+
+.dark .section-card--featured {
+    --surface-border: color-mix(in oklab, var(--color-orange-400) 40%, var(--color-neutral-700));
+    box-shadow:
+        0 20px 45px -20px rgb(0 0 0 / 0.8),
+        0 0 55px -18px color-mix(in oklab, var(--color-orange-400) 45%, transparent);
+}
+
+.section-card--featured::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(42rem 22rem at 12% 0%, color-mix(in oklab, var(--color-orange-400) 7%, transparent), transparent 70%);
 }
 
 /* Cells that must repeat the card surface inside hairline grids. */

--- a/resources/js/pages/Landing.vue
+++ b/resources/js/pages/Landing.vue
@@ -64,7 +64,7 @@ const currentYear = format(new UTCDate(), 'yyyy');
 const user = useUser();
 const page = usePage();
 
-const isCompact = useMediaQuery('(max-width: 1024px)');
+const isCompact = useMediaQuery('(max-width: 1279px)');
 
 // The killmail and signature panels show relative timestamps. Render them only
 // after mount so the server markup and the client's first paint always match.
@@ -241,7 +241,7 @@ const vReveal = {
                 <section class="relative overflow-hidden border-b border-border bg-muted/20">
                     <div class="hero-backdrop" aria-hidden="true" />
                     <div class="relative mx-auto max-w-7xl px-6 sm:px-10">
-                        <div class="grid items-center gap-14 py-24 lg:grid-cols-[1.05fr_1fr] lg:py-32">
+                        <div class="grid items-center gap-14 py-24 lg:grid-cols-[0.85fr_1.15fr] lg:py-32">
                             <div class="hero-intro">
                                 <div class="section-label">
                                     <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
@@ -303,13 +303,13 @@ const vReveal = {
                                             </span>
                                         </template>
                                     </MapPanelHeader>
-                                    <div class="relative h-[380px] w-full overflow-hidden sm:h-[460px]">
+                                    <div class="relative h-[420px] w-full overflow-hidden sm:h-[460px] xl:h-[540px]">
                                         <MapReadonly
                                             :solarsystems="MAP_SOLARSYSTEMS"
                                             :connections="MAP_CONNECTIONS"
                                             :pilots="MAP_PILOTS"
                                             :home_solarsystem_id="1"
-                                            :scale="isCompact ? 0.58 : 0.8"
+                                            :scale="isCompact ? 0.62 : 0.85"
                                         />
                                     </div>
                                 </div>

--- a/resources/js/pages/Landing.vue
+++ b/resources/js/pages/Landing.vue
@@ -5,15 +5,15 @@ import Logo from '@/components/icons/Logo.vue';
 import { AllianceLogo, CharacterImage, CorporationLogo } from '@/components/images';
 import CountUp from '@/components/landing/CountUp.vue';
 import { buildKillmails, buildSignatures, CHARACTERS, MAP_CONNECTIONS, MAP_PILOTS, MAP_SOLARSYSTEMS } from '@/components/landing/fixtures';
-import KillmailsView from '@/components/map-killmails/KillmailsView.vue';
+import KillmailsView, { type TKillmailViewModel } from '@/components/map-killmails/KillmailsView.vue';
 import SignaturesView from '@/components/signatures/SignaturesView.vue';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import MapPanel from '@/components/ui/map-panel/MapPanel.vue';
 import MapPanelHeader from '@/components/ui/map-panel/MapPanelHeader.vue';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import Notifications from '@/components/user/Notifications.vue';
+import { useStaticSolarsystems } from '@/composables/useStaticSolarsystems';
 import useUser from '@/composables/useUser';
 import Appearance from '@/layouts/Appearance.vue';
 import SeoHead from '@/layouts/SeoHead.vue';
@@ -21,7 +21,8 @@ import MapReadonly from '@/map/components/MapReadonly.vue';
 import { documentation, home } from '@/routes';
 import Eve from '@/routes/eve';
 import { UTCDate } from '@date-fns/utc';
-import { Link, usePage } from '@inertiajs/vue3';
+import type { TKillmail } from '@/types/models';
+import { Link, usePage, usePoll } from '@inertiajs/vue3';
 import { useMediaQuery } from '@vueuse/core';
 import { format } from 'date-fns';
 import {
@@ -29,7 +30,9 @@ import {
     ArrowRight,
     Bell,
     BookOpen,
+    Check,
     Container,
+    Copy,
     Crosshair,
     Crown,
     Eye,
@@ -51,7 +54,11 @@ import {
     Users,
     X,
 } from 'lucide-vue-next';
-import { onMounted, ref, type Component } from 'vue';
+import { computed, onMounted, ref, type Component } from 'vue';
+
+const { killmails } = defineProps<{
+    killmails?: TKillmail[];
+}>();
 
 const currentYear = format(new UTCDate(), 'yyyy');
 const user = useUser();
@@ -68,7 +75,42 @@ onMounted(() => {
 
 // Built per-render so relative timestamps stay in sync between SSR and client.
 const KILLMAILS = buildKillmails();
+
+// The killmail feed is real: the latest J-space kills from the database,
+// refreshed while the page is open. The demo fixtures only step in when the
+// database has none (e.g. a fresh self-hosted instance).
+const thirty_seconds_in_ms = 30_000;
+usePoll(thirty_seconds_in_ms, { only: ['killmails'] });
+
+const { resolveSolarsystem } = useStaticSolarsystems();
+
+const killmailItems = computed<TKillmailViewModel[]>(() => {
+    if (!killmails?.length) {
+        return KILLMAILS;
+    }
+    return killmails.map((killmail) => ({
+        killmail,
+        solarsystem: resolveSolarsystem(killmail.solarsystem_id),
+        alias: null,
+    }));
+});
 const SIGNATURES = buildSignatures();
+
+// Self-hosting: the interactive setup wizard from the containers repo.
+const installCommand = "curl --proto '=https' --tlsv1.2 -sSf https://install.wormhole.systems | sh";
+const commandCopied = ref(false);
+let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+async function copyInstallCommand() {
+    await navigator.clipboard.writeText(installCommand);
+    commandCopied.value = true;
+    if (copyResetTimer !== null) {
+        clearTimeout(copyResetTimer);
+    }
+    copyResetTimer = setTimeout(() => {
+        commandCopied.value = false;
+    }, 2000);
+}
 
 // Layout editor showcase. Mirrors the real floating toolbar + card grid.
 // Four cards are always present (map, system info, signatures, notes); these
@@ -167,10 +209,6 @@ const vReveal = {
         <div class="relative isolate min-h-screen overflow-x-hidden bg-background text-foreground">
             <SeoHead :title="seoData.title" :description="seoData.description" :keywords="seoData.keywords" />
 
-            <!-- The whole page is a map canvas: the same grid the map uses, with
-                 the sections floating on it as cards, chained down the middle. -->
-            <div class="page-grid" aria-hidden="true" />
-
             <!-- Nav: the app's hairline-and-blur chrome. -->
             <nav class="fixed inset-x-0 top-0 z-50 border-b border-border bg-background/85 backdrop-blur-xl">
                 <div class="mx-auto flex h-14 max-w-7xl items-center justify-between px-6 sm:px-10">
@@ -199,420 +237,450 @@ const vReveal = {
             </nav>
 
             <main class="relative pt-14">
-                <!-- Hero -->
-                <section class="mx-auto max-w-7xl px-6 sm:px-10">
-                    <div class="grid items-center gap-14 py-24 lg:grid-cols-[1.05fr_1fr] lg:py-32">
-                        <div class="hero-intro">
-                            <div class="section-label">
-                                <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
-                                Live, interactive wormhole maps
-                            </div>
-                            <h1 class="mt-7 font-display text-5xl leading-[0.98] font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
-                                Navigate the
-                                <span class="text-orange-400">Unknown</span>
-                            </h1>
-                            <p class="mt-7 max-w-xl text-lg leading-8 text-muted-foreground">
-                                Map your wormhole chain, track signatures, and watch for hostiles together. Fly solo, with your corp, or a whole
-                                alliance. Everyone shares the same live map.
-                            </p>
-                            <div class="mt-9 flex flex-wrap items-center gap-3">
-                                <template v-if="!user">
-                                    <Button asChild size="lg">
-                                        <a :href="Eve.show().url" class="group inline-flex items-center gap-2">
-                                            Sign in with EVE
-                                            <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-                                        </a>
-                                    </Button>
-                                    <Button asChild size="lg" variant="outline">
-                                        <a :href="Eve.show({ query: { without_scopes: true } }).url" class="inline-flex items-center gap-2">
-                                            Sign in without scopes
-                                        </a>
-                                    </Button>
-                                </template>
-                                <Button asChild size="lg" v-else>
-                                    <Link :href="home()" class="group inline-flex items-center gap-2" prefetch>
-                                        Explore Maps
-                                        <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-                                    </Link>
-                                </Button>
-                                <Button as-child size="lg" variant="ghost">
-                                    <a :href="page.props.discord.invite" class="inline-flex items-center gap-2">
-                                        <DiscordIcon class="h-4 w-4" />
-                                        Join the Discord
-                                    </a>
-                                </Button>
-                            </div>
-                            <p class="mt-8 font-mono text-[10px] tracking-wider text-muted-foreground/70 uppercase">
-                                ESI-secure · No client install · Free to use
-                            </p>
-                        </div>
-
-                        <!-- The real map, framed exactly like an in-app card. -->
-                        <div class="hero-console">
-                            <MapPanel>
-                                <MapPanelHeader>
-                                    home.map · J152820
-                                    <template #actions>
-                                        <span class="flex items-center gap-1.5">
-                                            <span class="size-2 rounded-full bg-hostile/70" />
-                                            <span class="size-2 rounded-full bg-active/70" />
-                                            <span class="size-2 rounded-full bg-empty/70" />
-                                        </span>
-                                    </template>
-                                </MapPanelHeader>
-                                <div class="relative h-[380px] w-full overflow-hidden sm:h-[460px]">
-                                    <MapReadonly
-                                        :solarsystems="MAP_SOLARSYSTEMS"
-                                        :connections="MAP_CONNECTIONS"
-                                        :pilots="MAP_PILOTS"
-                                        :home_solarsystem_id="1"
-                                        :scale="isCompact ? 0.58 : 0.8"
-                                    />
+                <!-- Hero: its own solid band, closed off with a hairline. -->
+                <section class="relative overflow-hidden border-b border-border bg-muted/20">
+                    <div class="hero-backdrop" aria-hidden="true" />
+                    <div class="relative mx-auto max-w-7xl px-6 sm:px-10">
+                        <div class="grid items-center gap-14 py-24 lg:grid-cols-[1.05fr_1fr] lg:py-32">
+                            <div class="hero-intro">
+                                <div class="section-label">
+                                    <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
+                                    Live, interactive wormhole maps
                                 </div>
-                            </MapPanel>
+                                <h1
+                                    class="mt-7 font-display text-5xl leading-[0.98] font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl"
+                                >
+                                    Navigate the
+                                    <span class="text-orange-400">Unknown</span>
+                                </h1>
+                                <p class="mt-7 max-w-xl text-lg leading-8 text-muted-foreground">
+                                    Map your wormhole chain, track signatures, and watch for hostiles together. Fly solo, with your corp, or a whole
+                                    alliance. Everyone shares the same live map.
+                                </p>
+                                <div class="mt-9 flex flex-wrap items-center gap-3">
+                                    <template v-if="!user">
+                                        <Button asChild size="lg">
+                                            <a :href="Eve.show().url" class="group inline-flex items-center gap-2">
+                                                Sign in with EVE
+                                                <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                                            </a>
+                                        </Button>
+                                        <Button asChild size="lg" variant="outline">
+                                            <a :href="Eve.show({ query: { without_scopes: true } }).url" class="inline-flex items-center gap-2">
+                                                Sign in without scopes
+                                            </a>
+                                        </Button>
+                                    </template>
+                                    <Button asChild size="lg" v-else>
+                                        <Link :href="home()" class="group inline-flex items-center gap-2" prefetch>
+                                            Explore Maps
+                                            <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                                        </Link>
+                                    </Button>
+                                    <Button as-child size="lg" variant="ghost">
+                                        <a :href="page.props.discord.invite" class="inline-flex items-center gap-2">
+                                            <DiscordIcon class="h-4 w-4" />
+                                            Join the Discord
+                                        </a>
+                                    </Button>
+                                </div>
+                                <p class="mt-8 font-mono text-[10px] tracking-wider text-muted-foreground/70 uppercase">
+                                    ESI-secure · No client install · Free to use
+                                </p>
+                            </div>
+
+                            <!-- The real map, framed as an elevated card. The map grid
+                                 lives inside this card, where it belongs. -->
+                            <div class="hero-console">
+                                <div class="section-card">
+                                    <MapPanelHeader>
+                                        home.map · J152820
+                                        <template #actions>
+                                            <span class="flex items-center gap-1.5">
+                                                <span class="size-2 rounded-full bg-hostile/70" />
+                                                <span class="size-2 rounded-full bg-active/70" />
+                                                <span class="size-2 rounded-full bg-empty/70" />
+                                            </span>
+                                        </template>
+                                    </MapPanelHeader>
+                                    <div class="relative h-[380px] w-full overflow-hidden sm:h-[460px]">
+                                        <MapReadonly
+                                            :solarsystems="MAP_SOLARSYSTEMS"
+                                            :connections="MAP_CONNECTIONS"
+                                            :pilots="MAP_PILOTS"
+                                            :home_solarsystem_id="1"
+                                            :scale="isCompact ? 0.58 : 0.8"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </section>
 
-                <!-- The chain: every section is a card on the map canvas, linked
-                     down the middle column like systems in a wormhole chain. -->
-                <div class="mx-auto max-w-6xl px-6 pb-8 sm:px-10">
-                    <!-- Stats -->
-                    <div class="chain" aria-hidden="true" />
-                    <div v-reveal class="grid grid-cols-2 gap-px bg-border text-center ring-1 ring-border md:grid-cols-4">
-                        <div v-for="stat in stats" :key="stat.k" class="bg-card px-6 py-10">
-                            <div class="font-display text-4xl font-bold tracking-tight text-foreground">
-                                <CountUp :to="stat.to" :suffix="stat.suffix" :decimals="stat.decimals" />
-                            </div>
-                            <div class="mt-2 font-mono text-[10px] tracking-wider text-muted-foreground uppercase">{{ stat.k }}</div>
-                        </div>
-                    </div>
-
-                    <!-- Open source & self-hosting (surfaced early — it's a core differentiator). -->
-                    <div class="chain" aria-hidden="true" />
-                    <MapPanel v-reveal>
-                        <MapPanelHeader>
-                            <span class="flex items-center gap-2"><Github class="h-3.5 w-3.5" /> 100% open source</span>
-                        </MapPanelHeader>
-                        <div class="grid divide-y divide-border/50 lg:grid-cols-[1.1fr_1fr] lg:divide-x lg:divide-y-0">
-                            <div class="p-8 sm:p-12">
-                                <h2 class="section-title">Free, open source, and yours to self-host</h2>
-                                <p class="section-lead">
-                                    Use the hosted version, dig into the code, or spin up your own private instance with the ready-made container
-                                    setup. No lock-in — it's all out in the open.
-                                </p>
-                            </div>
-                            <div class="flex flex-col divide-y divide-border/50">
-                                <a
-                                    href="https://github.com/WormholeSystems/WormholeSystems"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    class="oss-link group"
-                                >
-                                    <Github class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
-                                    <span class="min-w-0 flex-1">
-                                        <span class="block font-display text-base font-bold text-foreground">Source code</span>
-                                        <span class="mt-1 block text-sm leading-6 text-muted-foreground">
-                                            Browse the full source, open issues, and contribute on GitHub.
-                                        </span>
-                                    </span>
-                                    <ArrowRight
-                                        class="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-                                    />
-                                </a>
-                                <a
-                                    href="https://github.com/WormholeSystems/wormholesystems-containers"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    class="oss-link group"
-                                >
-                                    <Container class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
-                                    <span class="min-w-0 flex-1">
-                                        <span class="block font-display text-base font-bold text-foreground">Self-host</span>
-                                        <span class="mt-1 block text-sm leading-6 text-muted-foreground">
-                                            A ready-to-run Docker setup for your own private instance.
-                                        </span>
-                                    </span>
-                                    <ArrowRight
-                                        class="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-                                    />
-                                </a>
+                <!-- The chain: every section is a card, linked down the middle
+                     column like systems in a wormhole chain. -->
+                <div class="relative">
+                    <div class="canvas-backdrop" aria-hidden="true" />
+                    <div class="relative mx-auto max-w-6xl px-6 pb-24 sm:px-10">
+                        <!-- Stats -->
+                        <div class="chain" aria-hidden="true" />
+                        <div v-reveal class="section-card">
+                            <div class="hairline-grid grid grid-cols-2 gap-px text-center md:grid-cols-4">
+                                <div v-for="stat in stats" :key="stat.k" class="surface-cell px-6 py-10">
+                                    <div class="font-display text-4xl font-bold tracking-tight text-foreground">
+                                        <CountUp :to="stat.to" :suffix="stat.suffix" :decimals="stat.decimals" />
+                                    </div>
+                                    <div class="mt-2 font-mono text-[10px] tracking-wider text-muted-foreground uppercase">{{ stat.k }}</div>
+                                </div>
                             </div>
                         </div>
-                    </MapPanel>
 
-                    <!-- 01: Shared mapping -->
-                    <div class="chain" aria-hidden="true" />
-                    <MapPanel v-reveal>
-                        <MapPanelHeader>
-                            <span class="flex items-center gap-2"><Users class="h-3.5 w-3.5" /> 01 · Shared mapping</span>
-                        </MapPanelHeader>
-                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
-                            <div class="p-8 sm:p-12">
-                                <h2 class="section-title">Everyone on the same map, live</h2>
-                                <p class="section-lead">
-                                    When anyone moves, scans a connection, or updates a system, every pilot sees it right away. No pasting bookmarks
-                                    into chat, no side spreadsheet to keep in sync.
-                                </p>
-                                <ul class="points">
-                                    <li><span class="dot" /> See who is online, what they fly, and where they are</li>
-                                    <li><span class="dot" /> Each pilot's route home, with the jump count</li>
-                                    <li><span class="dot" /> Every change shows up for everyone instantly</li>
-                                </ul>
+                        <!-- Open source & self-hosting (surfaced early — it's a core differentiator). -->
+                        <div class="chain" aria-hidden="true" />
+                        <div v-reveal class="section-card">
+                            <MapPanelHeader>
+                                <span class="flex items-center gap-2"><Github class="h-3.5 w-3.5" /> 100% open source</span>
+                            </MapPanelHeader>
+                            <div class="grid divide-y divide-border/50 lg:grid-cols-[1.1fr_1fr] lg:divide-x lg:divide-y-0">
+                                <div class="p-8 sm:p-12">
+                                    <h2 class="section-title">Self-hosting is one command away</h2>
+                                    <p class="section-lead">
+                                        Use the hosted version, dig into the code, or run your own private instance. One command launches the
+                                        interactive setup wizard — no lock-in, it's all out in the open.
+                                    </p>
+                                    <div class="cmd group mt-8">
+                                        <code class="cmd-text">{{ installCommand }}</code>
+                                        <button
+                                            type="button"
+                                            class="cmd-copy"
+                                            :aria-label="commandCopied ? 'Copied' : 'Copy command'"
+                                            @click="copyInstallCommand"
+                                        >
+                                            <Check v-if="commandCopied" class="size-4 text-green-500" />
+                                            <Copy v-else class="size-4" />
+                                        </button>
+                                    </div>
+                                    <p class="mt-3 font-mono text-[10px] tracking-wider text-muted-foreground/70 uppercase">
+                                        All you need is a Linux server with Docker — the wizard handles the rest
+                                    </p>
+                                </div>
+                                <div class="flex flex-col divide-y divide-border/50">
+                                    <a
+                                        href="https://github.com/WormholeSystems/WormholeSystems"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="oss-link group"
+                                    >
+                                        <Github class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                                        <span class="min-w-0 flex-1">
+                                            <span class="block font-display text-base font-bold text-foreground">Source code</span>
+                                            <span class="mt-1 block text-sm leading-6 text-muted-foreground">
+                                                Browse the full source, open issues, and contribute on GitHub.
+                                            </span>
+                                        </span>
+                                        <ArrowRight
+                                            class="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                                        />
+                                    </a>
+                                    <a
+                                        href="https://github.com/WormholeSystems/wormholesystems-containers"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="oss-link group"
+                                    >
+                                        <Container class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                                        <span class="min-w-0 flex-1">
+                                            <span class="block font-display text-base font-bold text-foreground">Container stack</span>
+                                            <span class="mt-1 block text-sm leading-6 text-muted-foreground">
+                                                The Docker setup and setup wizard behind the one-liner.
+                                            </span>
+                                        </span>
+                                        <ArrowRight
+                                            class="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                                        />
+                                    </a>
+                                </div>
                             </div>
-                            <div class="flex flex-col">
+                        </div>
+
+                        <!-- 01: Shared mapping -->
+                        <div class="chain" aria-hidden="true" />
+                        <div v-reveal class="section-card">
+                            <MapPanelHeader>
+                                <span class="flex items-center gap-2"><Users class="h-3.5 w-3.5" /> 01 · Shared mapping</span>
+                            </MapPanelHeader>
+                            <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                                <div class="p-8 sm:p-12">
+                                    <h2 class="section-title">Everyone on the same map, live</h2>
+                                    <p class="section-lead">
+                                        When anyone moves, scans a connection, or updates a system, every pilot sees it right away. No pasting
+                                        bookmarks into chat, no side spreadsheet to keep in sync.
+                                    </p>
+                                    <ul class="points">
+                                        <li><span class="dot" /> See who is online, what they fly, and where they are</li>
+                                        <li><span class="dot" /> Each pilot's route home, with the jump count</li>
+                                        <li><span class="dot" /> Every change shows up for everyone instantly</li>
+                                    </ul>
+                                </div>
+                                <div class="flex flex-col">
+                                    <div class="cell-header">
+                                        <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
+                                        Pilots · {{ CHARACTERS.length }}
+                                    </div>
+                                    <div class="flex-1 overflow-x-auto">
+                                        <CharactersView :characters="CHARACTERS" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- 02: Kill activity -->
+                        <div class="chain" aria-hidden="true" />
+                        <div v-reveal class="section-card">
+                            <MapPanelHeader>
+                                <span class="flex items-center gap-2"><Activity class="h-3.5 w-3.5" /> 02 · Kill activity</span>
+                                <template #actions>
+                                    <span class="font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">via zKillboard</span>
+                                </template>
+                            </MapPanelHeader>
+                            <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                                <div class="p-8 sm:p-12">
+                                    <h2 class="section-title">See every kill in your chain</h2>
+                                    <p class="section-lead">
+                                        Killmails from your systems show up on their own, straight from zKillboard, so you always know where the
+                                        fighting is and how much got blown up.
+                                    </p>
+                                </div>
+                                <div class="p-8 sm:p-12">
+                                    <ul class="points mt-0">
+                                        <li><span class="dot" /> Who died, who got the kill, how many were involved, and the ISK lost</li>
+                                        <li><span class="dot" /> Filter to wormhole space, known space, or everything</li>
+                                        <li><span class="dot" /> Click any kill to jump to that system on the map</li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <div class="border-t border-border/50">
                                 <div class="cell-header">
                                     <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
-                                    Pilots · {{ CHARACTERS.length }}
+                                    Live · Latest J-space kills · {{ killmailItems.length }}
                                 </div>
-                                <div class="flex-1 overflow-x-auto">
-                                    <CharactersView :characters="CHARACTERS" />
+                                <div class="min-h-[13rem] overflow-x-auto py-1">
+                                    <KillmailsView v-if="mounted" :items="killmailItems" />
                                 </div>
                             </div>
                         </div>
-                    </MapPanel>
 
-                    <!-- 02: Kill activity -->
-                    <div class="chain" aria-hidden="true" />
-                    <MapPanel v-reveal>
-                        <MapPanelHeader>
-                            <span class="flex items-center gap-2"><Activity class="h-3.5 w-3.5" /> 02 · Kill activity</span>
-                            <template #actions>
-                                <span class="font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">via zKillboard</span>
-                            </template>
-                        </MapPanelHeader>
-                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
-                            <div class="p-8 sm:p-12">
-                                <h2 class="section-title">See every kill in your chain</h2>
-                                <p class="section-lead">
-                                    Killmails from your systems show up on their own, straight from zKillboard, so you always know where the fighting
-                                    is and how much got blown up.
-                                </p>
-                            </div>
-                            <div class="p-8 sm:p-12">
-                                <ul class="points mt-0">
-                                    <li><span class="dot" /> Who died, who got the kill, how many were involved, and the ISK lost</li>
-                                    <li><span class="dot" /> Filter to wormhole space, known space, or everything</li>
-                                    <li><span class="dot" /> Click any kill to jump to that system on the map</li>
-                                </ul>
-                            </div>
-                        </div>
-                        <div class="border-t border-border/50">
-                            <div class="cell-header">Killmails · {{ KILLMAILS.length }}</div>
-                            <div class="min-h-[13rem] overflow-x-auto py-1">
-                                <KillmailsView v-if="mounted" :items="KILLMAILS" />
-                            </div>
-                        </div>
-                    </MapPanel>
-
-                    <!-- 03: Signatures -->
-                    <div class="chain" aria-hidden="true" />
-                    <MapPanel v-reveal>
-                        <MapPanelHeader>
-                            <span class="flex items-center gap-2"><Crosshair class="h-3.5 w-3.5" /> 03 · Signatures</span>
-                        </MapPanelHeader>
-                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
-                            <div class="flex flex-col lg:order-1">
-                                <div class="cell-header">Signatures · {{ SIGNATURES.length }}</div>
-                                <div class="min-h-[18rem] flex-1 overflow-x-auto">
-                                    <SignaturesView v-if="mounted" :signatures="SIGNATURES" :connections="MAP_CONNECTIONS" />
-                                </div>
-                            </div>
-                            <div class="p-8 sm:p-12 lg:order-2">
-                                <h2 class="section-title">Scanning is just copy and paste</h2>
-                                <p class="section-lead">
-                                    Copy your probe scanner results in game, paste them in, and the map sorts it all out. New signatures get added,
-                                    the ones that are gone get removed, and wormhole types line up with their connections automatically.
-                                </p>
-                                <div class="paste-hint">
-                                    <span class="kbd">Ctrl</span>
-                                    <span class="plus">+</span>
-                                    <span class="kbd">V</span>
-                                    <span class="paste-text">Paste straight from the in-game probe scanner</span>
-                                </div>
-                                <ul class="points">
-                                    <li><span class="dot" /> No formatting and no manual entry</li>
-                                    <li><span class="dot" /> Old signatures and dead connections are cleaned up for you</li>
-                                    <li><span class="dot" /> Mass and lifetime tracked for you, with end-of-life and critical warnings</li>
-                                </ul>
-                            </div>
-                        </div>
-                    </MapPanel>
-
-                    <!-- 04: Customisable widget layout -->
-                    <div class="chain" aria-hidden="true" />
-                    <MapPanel v-reveal>
-                        <MapPanelHeader>
-                            <span class="flex items-center gap-2"><LayoutGrid class="h-3.5 w-3.5" /> 04 · Customisable layout</span>
-                        </MapPanelHeader>
-                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
-                            <div class="p-8 sm:p-12">
-                                <h2 class="section-title">Build the map around you</h2>
-                                <p class="section-lead">
-                                    The map is a grid of cards you can drag, resize, and hide. Keep the systems you watch front and centre and switch
-                                    off the panels you do not use. Layouts are saved per device, with a separate arrangement for each screen size.
-                                </p>
-                                <ul class="points">
-                                    <li><span class="dot" /> Drag and resize any card, from the map to autopilot to killmails</li>
-                                    <li><span class="dot" /> Four cards stay put; eight more can be hidden and brought back any time</li>
-                                    <li><span class="dot" /> Responsive breakpoints from mobile to wide desktop, each with its own layout</li>
-                                </ul>
-                            </div>
-                            <div class="flex flex-col">
-                                <div class="cell-header">
-                                    <span class="size-1.5 animate-pulse rounded-full bg-empty" />
-                                    Editing layout
-                                    <span class="ml-auto font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">J152820</span>
-                                </div>
-                                <div class="relative flex-1 p-3 pb-20">
-                                    <div class="wg-grid">
-                                        <div class="wg-tile wg-map">Map</div>
-                                        <div class="wg-tile">Signatures</div>
-                                        <div class="wg-tile">Autopilot</div>
-                                        <div class="wg-tile">Characters</div>
-                                        <div class="wg-tile">Killmails</div>
+                        <!-- 03: Signatures -->
+                        <div class="chain" aria-hidden="true" />
+                        <div v-reveal class="section-card">
+                            <MapPanelHeader>
+                                <span class="flex items-center gap-2"><Crosshair class="h-3.5 w-3.5" /> 03 · Signatures</span>
+                            </MapPanelHeader>
+                            <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                                <div class="flex flex-col lg:order-1">
+                                    <div class="cell-header">Signatures · {{ SIGNATURES.length }}</div>
+                                    <div class="min-h-[18rem] flex-1 overflow-x-auto">
+                                        <SignaturesView v-if="mounted" :signatures="SIGNATURES" :connections="MAP_CONNECTIONS" />
                                     </div>
-                                    <!-- Faithful replica of the real floating layout-editor toolbar -->
-                                    <div class="le-toolbar">
-                                        <span class="le-btn"><X class="size-4" /></span>
-                                        <span class="le-sep" />
-                                        <span class="le-seg">
-                                            <span class="le-seg-item"><Smartphone class="size-4" /></span>
-                                            <span class="le-seg-item"><Tablet class="size-4" /></span>
-                                            <span class="le-seg-item"><Laptop class="size-4" /></span>
-                                            <span class="le-seg-item is-active"><Monitor class="size-4" /> Large</span>
-                                        </span>
-                                        <span class="le-btn"><Plus class="size-4" /></span>
-                                        <span class="le-sep" />
-                                        <span class="le-btn relative">
-                                            <LayoutGrid class="size-4" />
-                                            <span class="le-badge">{{ hiddenCardCount }}</span>
-                                        </span>
-                                        <span class="le-sep" />
-                                        <span class="le-save"><Save class="size-3.5" /> Save</span>
-                                        <span class="le-btn"><MoreHorizontal class="size-4" /></span>
+                                </div>
+                                <div class="p-8 sm:p-12 lg:order-2">
+                                    <h2 class="section-title">Scanning is just copy and paste</h2>
+                                    <p class="section-lead">
+                                        Copy your probe scanner results in game, paste them in, and the map sorts it all out. New signatures get
+                                        added, the ones that are gone get removed, and wormhole types line up with their connections automatically.
+                                    </p>
+                                    <div class="paste-hint">
+                                        <span class="kbd">Ctrl</span>
+                                        <span class="plus">+</span>
+                                        <span class="kbd">V</span>
+                                        <span class="paste-text">Paste straight from the in-game probe scanner</span>
+                                    </div>
+                                    <ul class="points">
+                                        <li><span class="dot" /> No formatting and no manual entry</li>
+                                        <li><span class="dot" /> Old signatures and dead connections are cleaned up for you</li>
+                                        <li><span class="dot" /> Mass and lifetime tracked for you, with end-of-life and critical warnings</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- 04: Customisable widget layout -->
+                        <div class="chain" aria-hidden="true" />
+                        <div v-reveal class="section-card">
+                            <MapPanelHeader>
+                                <span class="flex items-center gap-2"><LayoutGrid class="h-3.5 w-3.5" /> 04 · Customisable layout</span>
+                            </MapPanelHeader>
+                            <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                                <div class="p-8 sm:p-12">
+                                    <h2 class="section-title">Build the map around you</h2>
+                                    <p class="section-lead">
+                                        The map is a grid of cards you can drag, resize, and hide. Keep the systems you watch front and centre and
+                                        switch off the panels you do not use. Layouts are saved per device, with a separate arrangement for each
+                                        screen size.
+                                    </p>
+                                    <ul class="points">
+                                        <li><span class="dot" /> Drag and resize any card, from the map to autopilot to killmails</li>
+                                        <li><span class="dot" /> Four cards stay put; eight more can be hidden and brought back any time</li>
+                                        <li><span class="dot" /> Responsive breakpoints from mobile to wide desktop, each with its own layout</li>
+                                    </ul>
+                                </div>
+                                <div class="flex flex-col">
+                                    <div class="cell-header">
+                                        <span class="size-1.5 animate-pulse rounded-full bg-empty" />
+                                        Editing layout
+                                        <span class="ml-auto font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">J152820</span>
+                                    </div>
+                                    <div class="relative flex-1 p-3 pb-20">
+                                        <div class="wg-grid">
+                                            <div class="wg-tile wg-map">Map</div>
+                                            <div class="wg-tile">Signatures</div>
+                                            <div class="wg-tile">Autopilot</div>
+                                            <div class="wg-tile">Characters</div>
+                                            <div class="wg-tile">Killmails</div>
+                                        </div>
+                                        <!-- Faithful replica of the real floating layout-editor toolbar -->
+                                        <div class="le-toolbar">
+                                            <span class="le-btn"><X class="size-4" /></span>
+                                            <span class="le-sep" />
+                                            <span class="le-seg">
+                                                <span class="le-seg-item"><Smartphone class="size-4" /></span>
+                                                <span class="le-seg-item"><Tablet class="size-4" /></span>
+                                                <span class="le-seg-item"><Laptop class="size-4" /></span>
+                                                <span class="le-seg-item is-active"><Monitor class="size-4" /> Large</span>
+                                            </span>
+                                            <span class="le-btn"><Plus class="size-4" /></span>
+                                            <span class="le-sep" />
+                                            <span class="le-btn relative">
+                                                <LayoutGrid class="size-4" />
+                                                <span class="le-badge">{{ hiddenCardCount }}</span>
+                                            </span>
+                                            <span class="le-sep" />
+                                            <span class="le-save"><Save class="size-3.5" /> Save</span>
+                                            <span class="le-btn"><MoreHorizontal class="size-4" /></span>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    </MapPanel>
 
-                    <!-- 05: Access control -->
-                    <div class="chain" aria-hidden="true" />
-                    <MapPanel v-reveal>
-                        <MapPanelHeader>
-                            <span class="flex items-center gap-2"><ShieldCheck class="h-3.5 w-3.5" /> 05 · Access control</span>
-                        </MapPanelHeader>
-                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
-                            <div class="flex flex-col lg:order-1">
-                                <div class="cell-header">Access · J152820</div>
-                                <div class="flex-1 px-2 py-1">
-                                    <Table>
-                                        <TableHeader>
-                                            <TableRow class="border-border/50 hover:bg-transparent">
-                                                <TableHead class="w-10" />
-                                                <TableHead>Name</TableHead>
-                                                <TableHead>Type</TableHead>
-                                                <TableHead>Access level</TableHead>
-                                                <TableHead>Expires</TableHead>
-                                            </TableRow>
-                                        </TableHeader>
-                                        <TableBody>
-                                            <TableRow
-                                                v-for="entity in accessEntities"
-                                                :key="entity.type + entity.id"
-                                                class="border-border/50 hover:bg-muted/30"
-                                            >
-                                                <TableCell>
-                                                    <CharacterImage
-                                                        v-if="entity.type === 'character'"
-                                                        :character_id="entity.id"
-                                                        :character_name="entity.name"
-                                                        class="size-8 rounded-lg"
-                                                    />
-                                                    <CorporationLogo
-                                                        v-else-if="entity.type === 'corporation'"
-                                                        :corporation_id="entity.id"
-                                                        :corporation_name="entity.name"
-                                                        class="size-8 rounded-lg"
-                                                    />
-                                                    <AllianceLogo
-                                                        v-else
-                                                        :alliance_id="entity.id"
-                                                        :alliance_name="entity.name"
-                                                        class="size-8 rounded-lg"
-                                                    />
-                                                </TableCell>
-                                                <TableCell class="font-medium whitespace-nowrap">{{ entity.name }}</TableCell>
-                                                <TableCell>
-                                                    <Badge variant="outline" class="capitalize">{{ entity.type }}</Badge>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <Badge
-                                                        v-if="entity.permission === 'owner'"
-                                                        class="bg-amber-500/10 text-amber-500 hover:bg-amber-500/10"
-                                                    >
-                                                        <Crown class="mr-1 size-3" />
-                                                        Owner
-                                                    </Badge>
-                                                    <span v-else class="access-pill">
-                                                        <component
-                                                            :is="permissionMeta[entity.permission].icon"
-                                                            class="size-4"
-                                                            :class="permissionMeta[entity.permission].class"
+                        <!-- 05: Access control -->
+                        <div class="chain" aria-hidden="true" />
+                        <div v-reveal class="section-card">
+                            <MapPanelHeader>
+                                <span class="flex items-center gap-2"><ShieldCheck class="h-3.5 w-3.5" /> 05 · Access control</span>
+                            </MapPanelHeader>
+                            <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                                <div class="flex flex-col lg:order-1">
+                                    <div class="cell-header">Access · J152820</div>
+                                    <div class="flex-1 px-2 py-1">
+                                        <Table>
+                                            <TableHeader>
+                                                <TableRow class="border-border/50 hover:bg-transparent">
+                                                    <TableHead class="w-10" />
+                                                    <TableHead>Name</TableHead>
+                                                    <TableHead>Type</TableHead>
+                                                    <TableHead>Access level</TableHead>
+                                                    <TableHead>Expires</TableHead>
+                                                </TableRow>
+                                            </TableHeader>
+                                            <TableBody>
+                                                <TableRow
+                                                    v-for="entity in accessEntities"
+                                                    :key="entity.type + entity.id"
+                                                    class="border-border/50 hover:bg-muted/30"
+                                                >
+                                                    <TableCell>
+                                                        <CharacterImage
+                                                            v-if="entity.type === 'character'"
+                                                            :character_id="entity.id"
+                                                            :character_name="entity.name"
+                                                            class="size-8 rounded-lg"
                                                         />
-                                                        {{ permissionMeta[entity.permission].label }}
-                                                    </span>
-                                                </TableCell>
-                                                <TableCell class="whitespace-nowrap text-muted-foreground">
-                                                    <span v-if="entity.permission === 'owner'" class="text-muted-foreground/40">—</span>
-                                                    <span v-else>{{ entity.expires ?? 'Never' }}</span>
-                                                </TableCell>
-                                            </TableRow>
-                                        </TableBody>
-                                    </Table>
+                                                        <CorporationLogo
+                                                            v-else-if="entity.type === 'corporation'"
+                                                            :corporation_id="entity.id"
+                                                            :corporation_name="entity.name"
+                                                            class="size-8 rounded-lg"
+                                                        />
+                                                        <AllianceLogo
+                                                            v-else
+                                                            :alliance_id="entity.id"
+                                                            :alliance_name="entity.name"
+                                                            class="size-8 rounded-lg"
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell class="font-medium whitespace-nowrap">{{ entity.name }}</TableCell>
+                                                    <TableCell>
+                                                        <Badge variant="outline" class="capitalize">{{ entity.type }}</Badge>
+                                                    </TableCell>
+                                                    <TableCell>
+                                                        <Badge
+                                                            v-if="entity.permission === 'owner'"
+                                                            class="bg-amber-500/10 text-amber-500 hover:bg-amber-500/10"
+                                                        >
+                                                            <Crown class="mr-1 size-3" />
+                                                            Owner
+                                                        </Badge>
+                                                        <span v-else class="access-pill">
+                                                            <component
+                                                                :is="permissionMeta[entity.permission].icon"
+                                                                class="size-4"
+                                                                :class="permissionMeta[entity.permission].class"
+                                                            />
+                                                            {{ permissionMeta[entity.permission].label }}
+                                                        </span>
+                                                    </TableCell>
+                                                    <TableCell class="whitespace-nowrap text-muted-foreground">
+                                                        <span v-if="entity.permission === 'owner'" class="text-muted-foreground/40">—</span>
+                                                        <span v-else>{{ entity.expires ?? 'Never' }}</span>
+                                                    </TableCell>
+                                                </TableRow>
+                                            </TableBody>
+                                        </Table>
+                                    </div>
+                                </div>
+                                <div class="p-8 sm:p-12 lg:order-2">
+                                    <h2 class="section-title">Decide exactly who sees what</h2>
+                                    <p class="section-lead">
+                                        Four levels of access, from view-only to full control. Viewers read the map, Members contribute signatures and
+                                        connections, Managers handle access and settings, and the Owner runs the whole thing.
+                                    </p>
+                                    <ul class="points">
+                                        <li><span class="dot" /> Grant access to a character, a corporation, or a whole alliance</li>
+                                        <li><span class="dot" /> Viewer, Member, Manager, and Owner roles, each with clear limits</li>
+                                        <li><span class="dot" /> Set an optional expiry for temporary or diplomatic access</li>
+                                    </ul>
                                 </div>
                             </div>
-                            <div class="p-8 sm:p-12 lg:order-2">
-                                <h2 class="section-title">Decide exactly who sees what</h2>
-                                <p class="section-lead">
-                                    Four levels of access, from view-only to full control. Viewers read the map, Members contribute signatures and
-                                    connections, Managers handle access and settings, and the Owner runs the whole thing.
-                                </p>
-                                <ul class="points">
-                                    <li><span class="dot" /> Grant access to a character, a corporation, or a whole alliance</li>
-                                    <li><span class="dot" /> Viewer, Member, Manager, and Owner roles, each with clear limits</li>
-                                    <li><span class="dot" /> Set an optional expiry for temporary or diplomatic access</li>
-                                </ul>
-                            </div>
                         </div>
-                    </MapPanel>
 
-                    <!-- 06: Everything else -->
-                    <div class="chain" aria-hidden="true" />
-                    <MapPanel v-reveal>
-                        <MapPanelHeader>
-                            <span class="flex items-center gap-2"><Sparkles class="h-3.5 w-3.5" /> 06 · Everything else</span>
-                        </MapPanelHeader>
-                        <div class="p-8 sm:p-12">
-                            <h2 class="section-title">Everything else you need to live in a wormhole</h2>
-                            <p class="section-lead">The rest of the tools that make day-to-day wormhole life easier.</p>
-                        </div>
-                        <div class="grid gap-px border-t border-border/50 bg-border/50 sm:grid-cols-2 lg:grid-cols-3">
-                            <div v-for="feature in secondaryFeatures" :key="feature.title" class="group bg-card p-7">
-                                <div class="feat-icon">
-                                    <component
-                                        :is="feature.icon"
-                                        class="h-4.5 w-4.5 text-muted-foreground transition-colors group-hover:text-foreground"
-                                    />
-                                </div>
-                                <h3 class="mt-5 font-display text-lg font-bold text-foreground">{{ feature.title }}</h3>
-                                <p class="mt-2.5 text-[15px] leading-7 text-muted-foreground">{{ feature.body }}</p>
+                        <!-- 06: Everything else -->
+                        <div class="chain" aria-hidden="true" />
+                        <div v-reveal class="section-card">
+                            <MapPanelHeader>
+                                <span class="flex items-center gap-2"><Sparkles class="h-3.5 w-3.5" /> 06 · Everything else</span>
+                            </MapPanelHeader>
+                            <div class="p-8 sm:p-12">
+                                <h2 class="section-title">Everything else you need to live in a wormhole</h2>
+                                <p class="section-lead">The rest of the tools that make day-to-day wormhole life easier.</p>
                             </div>
-                            <!-- Filler cell so the hairline grid stays rectangular on wide screens. -->
-                            <div class="hidden bg-card p-7 lg:block" aria-hidden="true" />
+                            <div class="hairline-grid grid gap-px border-t border-border/50 sm:grid-cols-2 lg:grid-cols-3">
+                                <div v-for="feature in secondaryFeatures" :key="feature.title" class="surface-cell group p-7">
+                                    <div class="feat-icon">
+                                        <component
+                                            :is="feature.icon"
+                                            class="h-4.5 w-4.5 text-muted-foreground transition-colors group-hover:text-foreground"
+                                        />
+                                    </div>
+                                    <h3 class="mt-5 font-display text-lg font-bold text-foreground">{{ feature.title }}</h3>
+                                    <p class="mt-2.5 text-[15px] leading-7 text-muted-foreground">{{ feature.body }}</p>
+                                </div>
+                                <!-- Filler cell so the hairline grid stays rectangular on wide screens. -->
+                                <div class="surface-cell hidden p-7 lg:block" aria-hidden="true" />
+                            </div>
                         </div>
-                    </MapPanel>
+                    </div>
                 </div>
 
                 <!-- CTA: the end of the chain. -->
@@ -677,14 +745,73 @@ const vReveal = {
     font-family: var(--font-display);
 }
 
-/* The map canvas: the same grid the map uses, across the whole page. */
-.page-grid {
-    position: fixed;
+/* Section cards wear the map node-card surface: elevated above the page
+   background exactly like a system card sits above the map canvas. */
+.section-card {
+    --surface: var(--color-white);
+    --surface-border: var(--color-neutral-300);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: 0.25rem;
+    border: 1px solid var(--surface-border);
+    background: var(--surface);
+    box-shadow: 0 20px 45px -20px rgb(0 0 0 / 0.35);
+}
+
+.dark .section-card {
+    --surface: var(--color-neutral-900);
+    --surface-border: var(--color-neutral-700);
+    box-shadow: 0 20px 45px -20px rgb(0 0 0 / 0.8);
+}
+
+/* Cells that must repeat the card surface inside hairline grids. */
+.surface-cell {
+    background: var(--surface);
+}
+
+/* Hairline separators between surface cells, at the same strength as the
+   card's internal dividers. */
+.hairline-grid {
+    background: color-mix(in oklab, var(--border) 50%, var(--surface));
+}
+
+/* Hero backdrop: dotted canvas plus a soft glow behind the map card, masked
+   away from the copy column so text contrast stays untouched. */
+.hero-backdrop {
+    position: absolute;
     inset: 0;
-    z-index: -10;
-    background-image: linear-gradient(to right, var(--grid) 1px, transparent 1px), linear-gradient(to bottom, var(--grid) 1px, transparent 1px);
-    background-size: 32px 32px;
-    opacity: 0.55;
+    pointer-events: none;
+    background-image:
+        radial-gradient(50rem 30rem at 78% 34%, color-mix(in oklab, var(--color-orange-400) 8%, transparent), transparent 70%),
+        radial-gradient(circle, var(--grid) 1px, transparent 1px);
+    background-size:
+        auto,
+        28px 28px;
+    -webkit-mask-image: linear-gradient(100deg, transparent 30%, #000 62%);
+    mask-image: linear-gradient(100deg, transparent 30%, #000 62%);
+}
+
+/* Chain canvas backdrop: a dotted map canvas with faint nebula washes. Dots
+   instead of grid lines, so nothing fights the card borders, faded out where
+   the canvas meets the hero and the CTA. */
+.canvas-backdrop {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        radial-gradient(60rem 44rem at 82% 4%, color-mix(in oklab, var(--color-orange-400) 5%, transparent), transparent 70%),
+        radial-gradient(52rem 40rem at 12% 38%, color-mix(in oklab, var(--color-sky-400) 4%, transparent), transparent 70%),
+        radial-gradient(56rem 42rem at 85% 78%, color-mix(in oklab, var(--color-purple-400) 4%, transparent), transparent 70%),
+        radial-gradient(circle, var(--grid) 1px, transparent 1px);
+    background-size:
+        auto,
+        auto,
+        auto,
+        28px 28px;
+    -webkit-mask-image: linear-gradient(to bottom, transparent, #000 5rem, #000 calc(100% - 5rem), transparent);
+    mask-image: linear-gradient(to bottom, transparent, #000 5rem, #000 calc(100% - 5rem), transparent);
 }
 
 /* Chain connector between section cards: the map's neutral connection stroke
@@ -807,6 +934,47 @@ const vReveal = {
     width: 0.375rem;
     flex-shrink: 0;
     background: var(--color-orange-400);
+}
+
+/* One-command install: inset code row with a copy affordance. */
+.cmd {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-radius: 0.25rem;
+    border: 1px solid var(--surface-border);
+    background: var(--background);
+    padding: 0.35rem 0.35rem 0.35rem 0.9rem;
+}
+
+.cmd-text {
+    flex: 1;
+    overflow-x: auto;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.8rem;
+    line-height: 1.9;
+    white-space: nowrap;
+    color: var(--foreground);
+}
+
+.cmd-copy {
+    display: flex;
+    height: 2rem;
+    width: 2rem;
+    flex-shrink: 0;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.25rem;
+    color: var(--muted-foreground);
+    transition:
+        color 0.2s ease,
+        background-color 0.2s ease;
+}
+
+.cmd-copy:hover {
+    background: color-mix(in oklab, var(--muted) 60%, transparent);
+    color: var(--foreground);
 }
 
 /* Open-source link rows inside the card. */
@@ -1017,7 +1185,7 @@ const vReveal = {
     color: var(--foreground);
 }
 
-/* CTA: quiet finale on the open canvas. */
+/* CTA: quiet finale. */
 .cta {
     position: relative;
     padding-block: 9rem;

--- a/resources/js/pages/Landing.vue
+++ b/resources/js/pages/Landing.vue
@@ -5,11 +5,12 @@ import Logo from '@/components/icons/Logo.vue';
 import { AllianceLogo, CharacterImage, CorporationLogo } from '@/components/images';
 import CountUp from '@/components/landing/CountUp.vue';
 import { buildKillmails, buildSignatures, CHARACTERS, MAP_CONNECTIONS, MAP_PILOTS, MAP_SOLARSYSTEMS } from '@/components/landing/fixtures';
-import WormholeBackground from '@/components/landing/WormholeBackground.vue';
 import KillmailsView from '@/components/map-killmails/KillmailsView.vue';
 import SignaturesView from '@/components/signatures/SignaturesView.vue';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import MapPanel from '@/components/ui/map-panel/MapPanel.vue';
+import MapPanelHeader from '@/components/ui/map-panel/MapPanelHeader.vue';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import Notifications from '@/components/user/Notifications.vue';
@@ -39,7 +40,6 @@ import {
     MoreHorizontal,
     Pencil,
     Plus,
-    Radar,
     Route,
     Save,
     Settings,
@@ -115,31 +115,26 @@ const stats = [
 const secondaryFeatures = [
     {
         icon: Route,
-        color: 'text-orange-400',
         title: 'Smart routing',
         body: 'Finds the shortest way home through the chain, taking wormhole mass limits and any systems you have chosen to avoid into account.',
     },
     {
         icon: Sparkles,
-        color: 'text-orange-400',
         title: 'Intelligence',
         body: 'Keeps notes on your systems automatically, so nobody re-scans what your group already figured out.',
     },
     {
         icon: Crosshair,
-        color: 'text-orange-400',
         title: 'Threat analysis',
         body: 'Flags systems with recent kills, so you know what you might be jumping into.',
     },
     {
         icon: Bell,
-        color: 'text-orange-400',
         title: 'Discord alerts',
         body: 'Sends proximity and killmail alerts to your Discord, filtered however you like.',
     },
     {
         icon: Telescope,
-        color: 'text-orange-400',
         title: 'EVE Scout',
         body: 'Pulls in Thera and Turnur connections and keeps them current, so routing can use them too.',
     },
@@ -169,31 +164,19 @@ const vReveal = {
 
 <template>
     <TooltipProvider :delay-duration="300">
-        <div class="relative isolate min-h-screen overflow-x-hidden bg-background text-foreground" style="--sec: var(--color-orange-400)">
+        <div class="relative isolate min-h-screen overflow-x-hidden bg-background text-foreground">
             <SeoHead :title="seoData.title" :description="seoData.description" :keywords="seoData.keywords" />
-            <WormholeBackground class="fixed inset-0 -z-10" />
 
-            <!-- Stronger blur over the central column: content reads against calm,
-                 heavily blurred space while the margins keep more detail. -->
-            <div class="center-veil" aria-hidden="true" />
+            <!-- The page sits on the same faint grid the map canvas uses, fading
+                 out towards the bottom so long sections rest on plain background. -->
+            <div class="page-grid" aria-hidden="true" />
 
-            <!-- Structural frame: the content lives in a central column bounded by two
-                 rails; the margins outside carry a fine hatch pattern and signal pulses
-                 travel down the rails. Purely decorative, wide screens only. -->
-            <div class="page-frame" aria-hidden="true">
-                <div class="frame-margin frame-margin--left" />
-                <div class="frame-margin frame-margin--right" />
-                <div class="rail rail--left"><span class="rail-pulse" /></div>
-                <div class="rail rail--right"><span class="rail-pulse rail-pulse--alt" /></div>
-            </div>
-
-            <!-- Nav: same instrument-panel language as the windows — hairline accent
-                 border, mono HUD links, chamfered action. -->
-            <nav class="fixed inset-x-0 top-0 z-50 border-b border-orange-400/15 bg-background/70 backdrop-blur-xl">
-                <div class="mx-auto flex h-16 max-w-7xl items-center justify-between px-6 sm:px-12 lg:px-24">
+            <!-- Nav: the app's hairline-and-blur chrome. -->
+            <nav class="fixed inset-x-0 top-0 z-50 border-b border-border bg-background/85 backdrop-blur-xl">
+                <div class="mx-auto flex h-14 max-w-7xl items-center justify-between px-6 sm:px-10">
                     <div class="flex items-center gap-3">
-                        <Logo class="h-7 w-7 text-foreground" />
-                        <span class="font-display text-lg font-bold tracking-tight text-foreground">WormholeSystems</span>
+                        <Logo class="h-6 w-6 text-foreground" />
+                        <span class="font-display text-base font-bold tracking-tight text-foreground">WormholeSystems</span>
                     </div>
                     <div class="flex items-center gap-4">
                         <Link :href="documentation().url" class="nav-link hidden items-center gap-2 sm:flex">
@@ -205,136 +188,133 @@ const vReveal = {
                             Discord
                         </a>
                         <Appearance />
-                        <Button v-if="!user" asChild variant="outline" size="sm" class="hud-btn">
+                        <Button v-if="!user" asChild variant="outline" size="sm">
                             <a :href="Eve.show().url" class="text-sm font-medium">Sign in</a>
                         </Button>
-                        <Button v-else asChild size="sm" variant="outline" class="hud-btn">
+                        <Button v-else asChild size="sm" variant="outline">
                             <Link :href="home()" class="text-sm font-medium" prefetch>Go to maps</Link>
                         </Button>
                     </div>
                 </div>
             </nav>
 
-            <main class="relative pt-16">
+            <main class="relative pt-14">
                 <!-- Hero -->
-                <section class="mx-auto max-w-7xl px-6 sm:px-12 lg:px-24">
-                    <div class="grid items-center gap-16 py-28 lg:grid-cols-[1.05fr_1fr] lg:py-44">
-                        <div class="hero-intro">
-                            <div class="chip">
-                                <span class="size-1.5 animate-pulse rounded-full bg-orange-400 shadow-[0_0_8px_var(--color-orange-400)]" />
-                                Live, interactive wormhole maps
-                            </div>
-                            <h1
-                                class="mt-7 font-display text-6xl leading-[0.95] font-extrabold tracking-tight text-foreground sm:text-7xl lg:text-8xl"
-                            >
-                                Navigate the
-                                <span
-                                    class="text-glow gradient-drift bg-gradient-to-br from-amber-300 via-orange-400 to-red-500 bg-clip-text text-transparent"
-                                    >Unknown</span
+                <section class="border-b border-border">
+                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
+                        <div class="grid items-center gap-14 py-24 lg:grid-cols-[1.05fr_1fr] lg:py-36">
+                            <div class="hero-intro">
+                                <div class="section-label">
+                                    <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
+                                    Live, interactive wormhole maps
+                                </div>
+                                <h1
+                                    class="mt-7 font-display text-5xl leading-[0.98] font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl"
                                 >
-                            </h1>
-                            <p class="mt-8 max-w-xl text-xl leading-8 font-medium text-muted-foreground">
-                                Map your wormhole chain, track signatures, and watch for hostiles together. Fly solo, with your corp, or a whole
-                                alliance. Everyone shares the same live map.
-                            </p>
-                            <div class="mt-10 flex flex-wrap items-center gap-4">
-                                <template v-if="!user">
-                                    <Button asChild size="lg" class="hud-btn">
-                                        <a :href="Eve.show().url" class="group inline-flex items-center gap-2">
-                                            Sign in with EVE
+                                    Navigate the
+                                    <span class="text-orange-400">Unknown</span>
+                                </h1>
+                                <p class="mt-7 max-w-xl text-lg leading-8 text-muted-foreground">
+                                    Map your wormhole chain, track signatures, and watch for hostiles together. Fly solo, with your corp, or a whole
+                                    alliance. Everyone shares the same live map.
+                                </p>
+                                <div class="mt-9 flex flex-wrap items-center gap-3">
+                                    <template v-if="!user">
+                                        <Button asChild size="lg">
+                                            <a :href="Eve.show().url" class="group inline-flex items-center gap-2">
+                                                Sign in with EVE
+                                                <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                                            </a>
+                                        </Button>
+                                        <Button asChild size="lg" variant="outline">
+                                            <a :href="Eve.show({ query: { without_scopes: true } }).url" class="inline-flex items-center gap-2">
+                                                Sign in without scopes
+                                            </a>
+                                        </Button>
+                                    </template>
+                                    <Button asChild size="lg" v-else>
+                                        <Link :href="home()" class="group inline-flex items-center gap-2" prefetch>
+                                            Explore Maps
                                             <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                                        </Link>
+                                    </Button>
+                                    <Button as-child size="lg" variant="ghost">
+                                        <a :href="page.props.discord.invite" class="inline-flex items-center gap-2">
+                                            <DiscordIcon class="h-4 w-4" />
+                                            Join the Discord
                                         </a>
                                     </Button>
-                                    <Button asChild size="lg" variant="outline" class="hud-btn">
-                                        <a :href="Eve.show({ query: { without_scopes: true } }).url" class="inline-flex items-center gap-2">
-                                            Sign in without scopes
-                                        </a>
-                                    </Button>
-                                </template>
-                                <Button asChild size="lg" v-else class="hud-btn">
-                                    <Link :href="home()" class="group inline-flex items-center gap-2" prefetch>
-                                        Explore Maps
-                                        <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-                                    </Link>
-                                </Button>
-                                <Button as-child size="lg" variant="ghost">
-                                    <a :href="page.props.discord.invite" class="inline-flex items-center gap-2">
-                                        <DiscordIcon class="h-4 w-4" />
-                                        Join the Discord
-                                    </a>
-                                </Button>
+                                </div>
+                                <p class="mt-8 font-mono text-[10px] tracking-wider text-muted-foreground/70 uppercase">
+                                    ESI-secure · No client install · Free to use
+                                </p>
                             </div>
-                            <p class="mt-7 font-hud text-xs tracking-wide text-muted-foreground/70">ESI-secure · No client install · Free to use</p>
-                        </div>
 
-                        <!-- Command console: the real map -->
-                        <div class="hero-console">
-                            <div class="window">
-                                <div class="window-bar">
-                                    <div class="flex items-center gap-2 font-hud text-[11px] tracking-wide text-muted-foreground">
-                                        <Radar class="h-3.5 w-3.5 text-orange-400" />
+                            <!-- The real map, framed exactly like an in-app card. -->
+                            <div class="hero-console">
+                                <MapPanel>
+                                    <MapPanelHeader>
                                         home.map · J152820
+                                        <template #actions>
+                                            <span class="flex items-center gap-1.5">
+                                                <span class="size-2 rounded-full bg-hostile/70" />
+                                                <span class="size-2 rounded-full bg-active/70" />
+                                                <span class="size-2 rounded-full bg-empty/70" />
+                                            </span>
+                                        </template>
+                                    </MapPanelHeader>
+                                    <div class="relative h-[380px] w-full overflow-hidden sm:h-[460px]">
+                                        <MapReadonly
+                                            :solarsystems="MAP_SOLARSYSTEMS"
+                                            :connections="MAP_CONNECTIONS"
+                                            :pilots="MAP_PILOTS"
+                                            :home_solarsystem_id="1"
+                                            :scale="isCompact ? 0.58 : 0.8"
+                                        />
                                     </div>
-                                    <div class="flex items-center gap-1.5">
-                                        <span class="size-2 rounded-full bg-hostile/70" />
-                                        <span class="size-2 rounded-full bg-active/70" />
-                                        <span class="size-2 rounded-full bg-empty/70" />
-                                    </div>
-                                </div>
-                                <div class="relative h-[380px] w-full overflow-hidden sm:h-[460px]">
-                                    <MapReadonly
-                                        :solarsystems="MAP_SOLARSYSTEMS"
-                                        :connections="MAP_CONNECTIONS"
-                                        :pilots="MAP_PILOTS"
-                                        :home_solarsystem_id="1"
-                                        :scale="isCompact ? 0.58 : 0.8"
-                                    />
-                                </div>
+                                </MapPanel>
                             </div>
-                            <div class="console-glow" />
                         </div>
                     </div>
                 </section>
 
-                <!-- Stat strip -->
-                <section class="mx-auto max-w-7xl px-6 pb-10 sm:px-12 lg:px-24">
-                    <div v-reveal class="grid grid-cols-2 gap-px overflow-hidden border border-border/60 bg-border/40 text-center md:grid-cols-4">
-                        <div v-for="stat in stats" :key="stat.k" class="stat-cell relative bg-card/70 px-6 py-10 backdrop-blur-sm">
-                            <div class="stat-num font-display text-4xl font-extrabold tracking-tight text-foreground">
+                <!-- Stat strip: cards sharing hairline borders, like the map grid. -->
+                <section class="mx-auto max-w-7xl px-6 py-16 sm:px-10">
+                    <div v-reveal class="grid grid-cols-2 gap-px bg-border text-center ring-1 ring-border md:grid-cols-4">
+                        <div v-for="stat in stats" :key="stat.k" class="bg-card px-6 py-10">
+                            <div class="font-display text-4xl font-bold tracking-tight text-foreground">
                                 <CountUp :to="stat.to" :suffix="stat.suffix" :decimals="stat.decimals" />
                             </div>
-                            <div class="mt-2 font-hud text-[11px] tracking-[0.15em] text-muted-foreground uppercase">{{ stat.k }}</div>
+                            <div class="mt-2 font-mono text-[10px] tracking-wider text-muted-foreground uppercase">{{ stat.k }}</div>
                         </div>
                     </div>
                 </section>
 
                 <!-- Open source & self-hosting (surfaced early — it's a core differentiator).
                      Deliberately unboxed: a quiet statement with a link list, not a card. -->
-                <section class="mx-auto max-w-7xl px-6 py-24 sm:px-12 sm:py-32 lg:px-24">
+                <section class="mx-auto max-w-7xl px-6 py-20 sm:px-10 sm:py-28">
                     <div v-reveal class="grid items-start gap-14 lg:grid-cols-[1.1fr_1fr] lg:gap-24">
                         <div>
-                            <div
-                                class="inline-flex items-center gap-2 border-l-2 border-orange-400 pl-3 font-hud text-[11px] tracking-[0.2em] text-orange-300 uppercase"
-                            >
+                            <div class="section-label">
                                 <Github class="h-3.5 w-3.5" />
                                 100% open source
                             </div>
-                            <h2 class="mt-7 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+                            <h2 class="mt-6 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
                                 Free, open source, and yours to self-host
                             </h2>
-                            <p class="mt-6 max-w-xl text-[15px] leading-7 text-muted-foreground">
+                            <p class="mt-5 max-w-xl text-[15px] leading-7 text-muted-foreground">
                                 Use the hosted version, dig into the code, or spin up your own private instance with the ready-made container setup.
                                 No lock-in — it's all out in the open.
                             </p>
                         </div>
-                        <div class="lg:pt-9">
+                        <div class="lg:pt-8">
                             <a
                                 href="https://github.com/WormholeSystems/WormholeSystems"
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 class="oss-link group"
                             >
-                                <Github class="mt-0.5 h-5 w-5 shrink-0 text-orange-400" />
+                                <Github class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
                                 <span class="min-w-0 flex-1">
                                     <span class="block font-display text-base font-bold text-foreground">Source code</span>
                                     <span class="mt-1 block text-sm leading-6 text-muted-foreground">
@@ -349,7 +329,7 @@ const vReveal = {
                                 rel="noopener noreferrer"
                                 class="oss-link group"
                             >
-                                <Container class="mt-0.5 h-5 w-5 shrink-0 text-orange-400" />
+                                <Container class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
                                 <span class="min-w-0 flex-1">
                                     <span class="block font-display text-base font-bold text-foreground">Self-host</span>
                                     <span class="mt-1 block text-sm leading-6 text-muted-foreground">
@@ -362,15 +342,15 @@ const vReveal = {
                     </div>
                 </section>
 
-                <!-- Section 01: Shared mapping (copy left / map-style window right) -->
+                <!-- Section 01: Shared mapping (copy left / app panel right) -->
                 <section class="feature-section">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-12 lg:px-24">
+                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
                         <div v-reveal class="marker">
                             <span class="idx">01</span>
-                            <span class="tag"><Users class="h-3.5 w-3.5" /> Shared mapping</span>
-                            <span class="line" />
+                            <span class="section-label"><Users class="h-3.5 w-3.5" /> Shared mapping</span>
+                            <span class="h-px flex-1 bg-border" />
                         </div>
-                        <div class="grid items-center gap-16 pt-20 lg:grid-cols-2 lg:gap-24">
+                        <div class="grid items-center gap-14 pt-16 lg:grid-cols-2 lg:gap-24">
                             <div v-reveal="'left'">
                                 <h2 class="section-title">Everyone on the same map, live</h2>
                                 <p class="section-lead">
@@ -383,30 +363,30 @@ const vReveal = {
                                     <li><span class="dot" /> Every change shows up for everyone instantly</li>
                                 </ul>
                             </div>
-                            <div v-reveal="'right'" class="window">
-                                <div class="window-bar">
-                                    <span class="flex items-center gap-2 font-hud text-[11px] tracking-wide text-muted-foreground">
-                                        <span class="size-1.5 animate-pulse rounded-full bg-green-500" /> Pilots
-                                        <span class="text-amber-400">{{ CHARACTERS.length }}</span>
+                            <MapPanel v-reveal="'right'">
+                                <MapPanelHeader>
+                                    <span class="flex items-center gap-2">
+                                        <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
+                                        Pilots · {{ CHARACTERS.length }}
                                     </span>
-                                </div>
-                                <div class="overflow-x-auto bg-card/40">
+                                </MapPanelHeader>
+                                <div class="overflow-x-auto">
                                     <CharactersView :characters="CHARACTERS" />
                                 </div>
-                            </div>
+                            </MapPanel>
                         </div>
                     </div>
                 </section>
 
                 <!-- Section 02: Kill activity (full-width feed) -->
-                <section class="feature-section feature-section--alt">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-12 lg:px-24">
+                <section class="feature-section">
+                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
                         <div v-reveal class="marker">
                             <span class="idx">02</span>
-                            <span class="tag"><Activity class="h-3.5 w-3.5" /> Kill activity</span>
-                            <span class="line" />
+                            <span class="section-label"><Activity class="h-3.5 w-3.5" /> Kill activity</span>
+                            <span class="h-px flex-1 bg-border" />
                         </div>
-                        <div class="grid gap-8 pt-20 lg:grid-cols-2 lg:items-end">
+                        <div class="grid gap-8 pt-16 lg:grid-cols-2 lg:items-end">
                             <div v-reveal="'left'">
                                 <h2 class="section-title">See every kill in your chain</h2>
                                 <p class="section-lead">
@@ -422,39 +402,35 @@ const vReveal = {
                                 </ul>
                             </div>
                         </div>
-                        <div v-reveal class="window mt-16">
-                            <div class="window-bar">
-                                <span class="font-hud text-[11px] tracking-wide text-muted-foreground"
-                                    >Killmails <span class="text-amber-400">{{ KILLMAILS.length }}</span></span
-                                >
-                                <span class="font-hud text-[10px] tracking-wide text-muted-foreground/60">via zKillboard</span>
-                            </div>
-                            <div class="min-h-[13rem] overflow-x-auto bg-card/40 py-1">
+                        <MapPanel v-reveal class="mt-14">
+                            <MapPanelHeader>
+                                Killmails · {{ KILLMAILS.length }}
+                                <template #actions>
+                                    <span class="font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">via zKillboard</span>
+                                </template>
+                            </MapPanelHeader>
+                            <div class="min-h-[13rem] overflow-x-auto py-1">
                                 <KillmailsView v-if="mounted" :items="KILLMAILS" />
                             </div>
-                        </div>
+                        </MapPanel>
                     </div>
                 </section>
 
-                <!-- Section 03: Signatures (window left / copy right + paste hint) -->
+                <!-- Section 03: Signatures (panel left / copy right + paste hint) -->
                 <section class="feature-section">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-12 lg:px-24">
+                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
                         <div v-reveal class="marker">
                             <span class="idx">03</span>
-                            <span class="tag"><Crosshair class="h-3.5 w-3.5" /> Signatures</span>
-                            <span class="line" />
+                            <span class="section-label"><Crosshair class="h-3.5 w-3.5" /> Signatures</span>
+                            <span class="h-px flex-1 bg-border" />
                         </div>
-                        <div class="grid items-center gap-16 pt-20 lg:grid-cols-2 lg:gap-24">
-                            <div v-reveal="'left'" class="window lg:order-1">
-                                <div class="window-bar">
-                                    <span class="font-hud text-[11px] tracking-wide text-muted-foreground"
-                                        >Signatures <span class="text-amber-400">{{ SIGNATURES.length }}</span></span
-                                    >
-                                </div>
-                                <div class="min-h-[18rem] overflow-x-auto bg-card/40">
+                        <div class="grid items-center gap-14 pt-16 lg:grid-cols-2 lg:gap-24">
+                            <MapPanel v-reveal="'left'" class="lg:order-1">
+                                <MapPanelHeader>Signatures · {{ SIGNATURES.length }}</MapPanelHeader>
+                                <div class="min-h-[18rem] overflow-x-auto">
                                     <SignaturesView v-if="mounted" :signatures="SIGNATURES" :connections="MAP_CONNECTIONS" />
                                 </div>
-                            </div>
+                            </MapPanel>
                             <div v-reveal="'right'" class="lg:order-2">
                                 <h2 class="section-title">Scanning is just copy and paste</h2>
                                 <p class="section-lead">
@@ -478,14 +454,14 @@ const vReveal = {
                 </section>
 
                 <!-- Section 04: Customisable widget layout -->
-                <section class="feature-section feature-section--alt">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-12 lg:px-24">
+                <section class="feature-section">
+                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
                         <div v-reveal class="marker">
                             <span class="idx">04</span>
-                            <span class="tag"><LayoutGrid class="h-3.5 w-3.5" /> Customisable layout</span>
-                            <span class="line" />
+                            <span class="section-label"><LayoutGrid class="h-3.5 w-3.5" /> Customisable layout</span>
+                            <span class="h-px flex-1 bg-border" />
                         </div>
-                        <div class="grid items-center gap-16 pt-20 lg:grid-cols-2 lg:gap-24">
+                        <div class="grid items-center gap-14 pt-16 lg:grid-cols-2 lg:gap-24">
                             <div v-reveal="'left'">
                                 <h2 class="section-title">Build the map around you</h2>
                                 <p class="section-lead">
@@ -498,14 +474,17 @@ const vReveal = {
                                     <li><span class="dot" /> Responsive breakpoints from mobile to wide desktop, each with its own layout</li>
                                 </ul>
                             </div>
-                            <div v-reveal="'right'" class="window">
-                                <div class="window-bar">
-                                    <span class="flex items-center gap-2 font-hud text-[11px] tracking-wide text-muted-foreground">
-                                        <span class="size-1.5 animate-pulse rounded-full bg-empty" /> Editing layout
+                            <MapPanel v-reveal="'right'">
+                                <MapPanelHeader>
+                                    <span class="flex items-center gap-2">
+                                        <span class="size-1.5 animate-pulse rounded-full bg-empty" />
+                                        Editing layout
                                     </span>
-                                    <span class="font-hud text-[10px] tracking-wide text-muted-foreground/60">J152820</span>
-                                </div>
-                                <div class="relative bg-card/40 p-3 pb-20">
+                                    <template #actions>
+                                        <span class="font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">J152820</span>
+                                    </template>
+                                </MapPanelHeader>
+                                <div class="relative p-3 pb-20">
                                     <div class="wg-grid">
                                         <div class="wg-tile wg-map">Map</div>
                                         <div class="wg-tile">Signatures</div>
@@ -534,25 +513,23 @@ const vReveal = {
                                         <span class="le-btn"><MoreHorizontal class="size-4" /></span>
                                     </div>
                                 </div>
-                            </div>
+                            </MapPanel>
                         </div>
                     </div>
                 </section>
 
                 <!-- Section 05: Access control -->
                 <section class="feature-section">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-12 lg:px-24">
+                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
                         <div v-reveal class="marker">
                             <span class="idx">05</span>
-                            <span class="tag"><ShieldCheck class="h-3.5 w-3.5" /> Access control</span>
-                            <span class="line" />
+                            <span class="section-label"><ShieldCheck class="h-3.5 w-3.5" /> Access control</span>
+                            <span class="h-px flex-1 bg-border" />
                         </div>
-                        <div class="grid items-center gap-16 pt-20 lg:grid-cols-2 lg:gap-24">
-                            <div v-reveal="'left'" class="window lg:order-1">
-                                <div class="window-bar">
-                                    <span class="font-hud text-[11px] tracking-wide text-muted-foreground">Access · J152820</span>
-                                </div>
-                                <div class="rounded-b-xl bg-card/40 px-2 py-1">
+                        <div class="grid items-center gap-14 pt-16 lg:grid-cols-2 lg:gap-24">
+                            <MapPanel v-reveal="'left'" class="lg:order-1">
+                                <MapPanelHeader>Access · J152820</MapPanelHeader>
+                                <div class="px-2 py-1">
                                     <Table>
                                         <TableHeader>
                                             <TableRow class="border-border/50 hover:bg-transparent">
@@ -618,7 +595,7 @@ const vReveal = {
                                         </TableBody>
                                     </Table>
                                 </div>
-                            </div>
+                            </MapPanel>
                             <div v-reveal="'right'" class="lg:order-2">
                                 <h2 class="section-title">Decide exactly who sees what</h2>
                                 <p class="section-lead">
@@ -635,43 +612,47 @@ const vReveal = {
                     </div>
                 </section>
 
-                <!-- Section 06: Everything else -->
-                <section class="feature-section feature-section--alt">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-12 lg:px-24">
+                <!-- Section 06: Everything else, as adjoining cards sharing hairlines. -->
+                <section class="feature-section">
+                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
                         <div v-reveal class="marker">
                             <span class="idx">06</span>
-                            <span class="tag"><Sparkles class="h-3.5 w-3.5" /> Everything else</span>
-                            <span class="line" />
+                            <span class="section-label"><Sparkles class="h-3.5 w-3.5" /> Everything else</span>
+                            <span class="h-px flex-1 bg-border" />
                         </div>
-                        <div v-reveal="'left'" class="max-w-3xl pt-20">
+                        <div v-reveal="'left'" class="max-w-3xl pt-16">
                             <h2 class="section-title">Everything else you need to live in a wormhole</h2>
                             <p class="section-lead">The rest of the tools that make day-to-day wormhole life easier.</p>
                         </div>
-                        <div class="mt-20 grid gap-x-12 gap-y-16 sm:grid-cols-2 lg:grid-cols-3">
-                            <div v-for="feature in secondaryFeatures" :key="feature.title" v-reveal="'up'" class="group">
+                        <div v-reveal class="mt-14 grid gap-px bg-border ring-1 ring-border sm:grid-cols-2 lg:grid-cols-3">
+                            <div v-for="feature in secondaryFeatures" :key="feature.title" class="group bg-card p-7">
                                 <div class="feat-icon">
-                                    <component :is="feature.icon" class="h-5 w-5" :class="feature.color" />
+                                    <component
+                                        :is="feature.icon"
+                                        class="h-4.5 w-4.5 text-muted-foreground transition-colors group-hover:text-foreground"
+                                    />
                                 </div>
-                                <h3 class="mt-5 font-display text-xl font-bold text-foreground">{{ feature.title }}</h3>
-                                <p class="mt-3 text-[15px] leading-7 text-muted-foreground">{{ feature.body }}</p>
+                                <h3 class="mt-5 font-display text-lg font-bold text-foreground">{{ feature.title }}</h3>
+                                <p class="mt-2.5 text-[15px] leading-7 text-muted-foreground">{{ feature.body }}</p>
                             </div>
+                            <!-- Filler cell so the hairline grid stays rectangular on wide screens. -->
+                            <div class="hidden bg-card p-7 lg:block" aria-hidden="true" />
                         </div>
                     </div>
                 </section>
 
-                <!-- CTA: full-bleed cosmic finale -->
+                <!-- CTA -->
                 <section class="cta">
-                    <div class="cta-core" aria-hidden="true" />
                     <div class="cta-grid" aria-hidden="true" />
-                    <div v-reveal class="relative mx-auto max-w-3xl px-6 text-center sm:px-12 lg:px-24">
-                        <div class="cta-eyebrow">
-                            <span class="size-1.5 rounded-full bg-orange-400 shadow-[0_0_8px_var(--color-orange-400)]" />
+                    <div v-reveal class="relative mx-auto max-w-3xl px-6 text-center sm:px-10">
+                        <div class="section-label justify-center">
+                            <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
                             Drop your first probe
                         </div>
-                        <h2 class="cta-title">Ready to map the <span class="cta-void">void</span>?</h2>
+                        <h2 class="cta-title">Ready to map the <span class="text-orange-400">void</span>?</h2>
                         <p class="cta-lead">Set up a map for your corp, your alliance, or just yourself, and start mapping in minutes.</p>
-                        <div class="mt-12 flex justify-center">
-                            <Button asChild size="lg" class="hud-btn">
+                        <div class="mt-10 flex justify-center">
+                            <Button asChild size="lg">
                                 <a :href="Eve.show().url" class="group inline-flex items-center gap-2">
                                     Start exploring
                                     <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
@@ -682,8 +663,8 @@ const vReveal = {
                 </section>
             </main>
 
-            <footer class="relative border-t border-border/60 bg-background/70 backdrop-blur-sm">
-                <div class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 py-12 sm:flex-row sm:px-12 lg:px-24">
+            <footer class="relative border-t border-border bg-background/70">
+                <div class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 py-12 sm:flex-row sm:px-10">
                     <div class="flex items-center gap-3">
                         <Logo class="h-6 w-6 text-muted-foreground/60" />
                         <span class="font-display text-sm font-bold text-muted-foreground">WormholeSystems</span>
@@ -723,84 +704,24 @@ const vReveal = {
     font-family: var(--font-display);
 }
 
-.font-hud {
-    font-family: var(--font-hud);
-}
-
-.text-glow {
-    filter: drop-shadow(0 0 32px color-mix(in oklab, var(--color-orange-400) 55%, transparent));
-}
-
-/* Chamfered primary actions, matching the instrument-panel windows. */
-:deep(.hud-btn) {
-    border-radius: 2px;
-    clip-path: polygon(0 0, 100% 0, 100% calc(100% - 9px), calc(100% - 9px) 100%, 0 100%);
-}
-
-/* Hero: slow drift through the gradient on the key word. */
-.gradient-drift {
-    background-size: 220% 220%;
-    animation: gradient-drift 9s ease-in-out infinite alternate;
-}
-
-@keyframes gradient-drift {
-    from {
-        background-position: 0% 35%;
-    }
-    to {
-        background-position: 100% 65%;
-    }
-}
-
-/* Stat strip: a HUD tick above each figure, soft glow on the numerals. */
-.stat-cell::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    height: 2px;
-    width: 2.75rem;
-    background: linear-gradient(to right, transparent, color-mix(in oklab, var(--color-orange-400) 80%, transparent), transparent);
-}
-
-.stat-num {
-    text-shadow: 0 0 28px color-mix(in oklab, var(--color-orange-400) 35%, transparent);
-}
-
-.chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    border-left: 2px solid var(--color-orange-400);
-    padding-left: 0.85rem;
-    font-family: var(--font-hud);
-    font-size: 11px;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    color: color-mix(in oklab, var(--color-orange-300) 80%, var(--foreground));
-}
-
-/* Stronger blur band over the central content column. The rails mark its
-   edges, so the sharp blur boundary reads as part of the frame. */
-.center-veil {
+/* The map canvas grid, projected across the whole page and faded so it only
+   reads clearly behind the hero. */
+.page-grid {
     position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 50%;
-    z-index: -6;
-    width: min(100vw, 80rem);
-    transform: translateX(-50%);
-    pointer-events: none;
-    backdrop-filter: blur(18px);
-    background: color-mix(in oklab, var(--background) 22%, transparent);
+    inset: 0;
+    z-index: -10;
+    background-image: linear-gradient(to right, var(--grid) 1px, transparent 1px), linear-gradient(to bottom, var(--grid) 1px, transparent 1px);
+    background-size: 32px 32px;
+    -webkit-mask-image: linear-gradient(to bottom, #000, transparent 85%);
+    mask-image: linear-gradient(to bottom, #000, transparent 85%);
+    opacity: 0.6;
 }
 
-/* Nav: HUD link + status styling. */
+/* Nav links share the panel-header voice. */
 .nav-link {
-    font-family: var(--font-hud);
-    font-size: 0.72rem;
-    letter-spacing: 0.18em;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 10px;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--muted-foreground);
     transition: color 0.2s ease;
@@ -810,231 +731,65 @@ const vReveal = {
     color: var(--foreground);
 }
 
-/* Structural frame: two full-height rails mark the edges of the content column
-   (max-w-7xl = 80rem), with ruler ticks on their outer side, a fine diagonal
-   hatch in the margins, and signal pulses travelling down the rails. */
-.page-frame {
-    position: fixed;
-    inset: 0;
-    z-index: -5;
-    display: none;
-    pointer-events: none;
+/* Micro-label in the app's panel-header voice: mono, 10px, uppercase, muted. */
+.section-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
 }
 
-@media (min-width: 90rem) {
-    .page-frame {
-        display: block;
-    }
-}
-
-.rail {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 1px;
-    background: linear-gradient(
-        to bottom,
-        transparent,
-        color-mix(in oklab, var(--foreground) 25%, transparent) 10%,
-        color-mix(in oklab, var(--foreground) 25%, transparent) 90%,
-        transparent
-    );
-}
-
-.rail--left {
-    left: calc(50vw - 40rem);
-}
-
-.rail--right {
-    right: calc(50vw - 40rem);
-}
-
-/* Ruler ticks on the outer side of each rail. */
-.rail::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 9px;
-    background: repeating-linear-gradient(to bottom, color-mix(in oklab, var(--foreground) 45%, transparent) 0 1px, transparent 1px 48px);
-    -webkit-mask-image: linear-gradient(to bottom, transparent, #000 12%, #000 88%, transparent);
-    mask-image: linear-gradient(to bottom, transparent, #000 12%, #000 88%, transparent);
-}
-
-.rail--left::before {
-    left: -11px;
-}
-
-.rail--right::before {
-    right: -11px;
-}
-
-.frame-margin {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: calc(50vw - 40rem - 1rem);
-    background: repeating-linear-gradient(45deg, color-mix(in oklab, var(--foreground) 9%, transparent) 0 1px, transparent 1px 12px);
-}
-
-.frame-margin--left {
-    left: 0;
-    -webkit-mask-image: linear-gradient(to right, transparent 10%, #000);
-    mask-image: linear-gradient(to right, transparent 10%, #000);
-}
-
-.frame-margin--right {
-    right: 0;
-    -webkit-mask-image: linear-gradient(to left, transparent 10%, #000);
-    mask-image: linear-gradient(to left, transparent 10%, #000);
-}
-
-/* Signal pulses: a short glowing dash riding each rail, like traffic on the chain. */
-.rail-pulse {
-    position: absolute;
-    top: 0;
-    left: -1.5px;
-    width: 4px;
-    height: 110px;
-    background: linear-gradient(to bottom, transparent, color-mix(in oklab, var(--color-orange-400) 90%, transparent), transparent);
-    filter: drop-shadow(0 0 6px color-mix(in oklab, var(--color-orange-400) 70%, transparent));
-    animation: rail-travel 13s linear infinite;
-}
-
-.rail-pulse--alt {
-    background: linear-gradient(to bottom, transparent, color-mix(in oklab, var(--color-orange-400) 90%, transparent), transparent);
-    filter: drop-shadow(0 0 6px color-mix(in oklab, var(--color-orange-400) 70%, transparent));
-    animation-duration: 17s;
-    animation-delay: -9s;
-}
-
-@keyframes rail-travel {
-    from {
-        transform: translateY(-130px);
-    }
-    to {
-        transform: translateY(100vh);
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .rail-pulse {
-        display: none;
-    }
-}
-
-/* Section separation. Each section carries its accent in --sec: the marker, the
-   chain connector, the ambient light, and the window chrome all key off it. */
+/* Section separation: hairline top borders, like adjoining cards. */
 .feature-section {
-    position: relative;
-    isolation: isolate;
-    border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
-    padding-block: 9rem 6rem;
+    border-top: 1px solid var(--border);
+    padding-block: 7rem 5rem;
 }
 
 @media (min-width: 640px) {
     .feature-section {
-        padding-block: 12rem 8rem;
+        padding-block: 9rem 7rem;
     }
 }
 
-.feature-section--alt {
-    background: color-mix(in oklab, var(--card) 14%, transparent);
-}
-
-/* Ambient section light: a soft radial wash in the section's own wormhole-class
-   colour, so each scroll stop sits in its own atmosphere. Alt sections are lit
-   from the other side to keep the page from feeling stamped. */
-.feature-section::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: -1;
-    pointer-events: none;
-    background: radial-gradient(44% 48% at 78% 20%, color-mix(in oklab, var(--sec, var(--color-orange-400)) 6%, transparent), transparent 70%);
-}
-
-.feature-section--alt::before {
-    background: radial-gradient(44% 48% at 22% 20%, color-mix(in oklab, var(--sec, var(--color-orange-400)) 6%, transparent), transparent 70%);
-}
-
-/* Techy section marker: 01 // TAG ───────── (accent set per-section via --sec) */
+/* Section marker: 01 · TAG ───────── in the panel-header voice. */
 .marker {
-    position: relative;
     display: flex;
     align-items: center;
     gap: 1rem;
 }
 
-/* Chain connector: a dashed wormhole-style connection dropping into each marker,
-   the same visual language the map uses for connections between systems. */
-.marker::before {
-    content: '';
-    position: absolute;
-    bottom: calc(100% + 0.6rem);
-    left: clamp(0.8rem, 0.55rem + 1vw, 1.3rem);
-    width: 2px;
-    height: clamp(4rem, 3rem + 5vw, 9rem);
-    background: repeating-linear-gradient(
-        to bottom,
-        color-mix(in oklab, var(--sec, var(--color-orange-400)) 75%, transparent) 0 5px,
-        transparent 5px 11px
-    );
-    -webkit-mask-image: linear-gradient(to bottom, transparent, #000 70%);
-    mask-image: linear-gradient(to bottom, transparent, #000 70%);
-}
-
 .marker .idx {
-    font-family: var(--font-hud);
-    font-size: clamp(1.75rem, 1.2rem + 2vw, 2.75rem);
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: clamp(1.5rem, 1.1rem + 1.5vw, 2.25rem);
     font-weight: 700;
     line-height: 1;
-    color: var(--sec, var(--color-orange-400));
-    text-shadow: 0 0 24px color-mix(in oklab, var(--sec, var(--color-orange-400)) 60%, transparent);
+    color: color-mix(in oklab, var(--foreground) 30%, transparent);
 }
 
-.marker .tag {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-family: var(--font-hud);
-    font-size: 0.75rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: var(--foreground);
-}
-
-.marker .tag svg {
-    color: var(--sec, var(--color-orange-400));
-}
-
-.marker .line {
-    height: 1px;
-    flex: 1;
-    background: linear-gradient(to right, color-mix(in oklab, var(--sec, var(--color-orange-400)) 65%, transparent), transparent);
-}
-
-/* Section copy: big + bold */
+/* Section copy */
 .section-title {
     font-family: var(--font-display);
-    font-size: clamp(2.25rem, 1.5rem + 3vw, 3.75rem);
-    font-weight: 800;
-    line-height: 1.04;
+    font-size: clamp(2rem, 1.4rem + 2.5vw, 3.25rem);
+    font-weight: 700;
+    line-height: 1.06;
     letter-spacing: -0.02em;
     color: var(--foreground);
 }
 
 .section-lead {
-    margin-top: 1.5rem;
+    margin-top: 1.4rem;
     max-width: 36rem;
-    font-size: 1.2rem;
+    font-size: 1.125rem;
     line-height: 1.7;
-    font-weight: 500;
     color: var(--muted-foreground);
 }
 
 .points {
-    margin-top: 2.75rem;
+    margin-top: 2.5rem;
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -1045,19 +800,16 @@ const vReveal = {
     align-items: flex-start;
     gap: 0.875rem;
     font-size: 1.0625rem;
-    font-weight: 500;
     line-height: 1.5;
     color: color-mix(in oklab, var(--foreground) 82%, transparent);
 }
 
 .dot {
-    background: var(--sec, var(--color-orange-400));
-    margin-top: 0.55rem;
-    height: 0.45rem;
-    width: 0.45rem;
+    margin-top: 0.6rem;
+    height: 0.375rem;
+    width: 0.375rem;
     flex-shrink: 0;
-    border-radius: 9999px;
-    box-shadow: 0 0 10px currentColor;
+    background: var(--color-orange-400);
 }
 
 /* Open-source link list: hairline rows instead of cards. */
@@ -1065,17 +817,17 @@ const vReveal = {
     display: flex;
     align-items: flex-start;
     gap: 1rem;
-    border-top: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
+    border-top: 1px solid var(--border);
     padding-block: 1.5rem;
     transition: border-color 0.25s ease;
 }
 
 .oss-link:last-child {
-    border-bottom: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
+    border-bottom: 1px solid var(--border);
 }
 
 .oss-link:hover {
-    border-top-color: color-mix(in oklab, var(--color-orange-400) 50%, var(--border));
+    border-top-color: color-mix(in oklab, var(--foreground) 40%, var(--border));
 }
 
 /* Paste hint chip */
@@ -1084,26 +836,25 @@ const vReveal = {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    border-radius: 0.75rem;
-    border: 1px dashed color-mix(in oklab, var(--color-orange-400) 45%, var(--border));
-    background: color-mix(in oklab, var(--color-red-500) 7%, var(--card));
+    border: 1px dashed var(--border);
+    background: color-mix(in oklab, var(--muted) 30%, transparent);
     padding: 0.6rem 0.9rem;
 }
 
 .paste-hint .kbd {
     border-radius: 0.4rem;
-    border: 1px solid color-mix(in oklab, var(--border) 90%, transparent);
+    border: 1px solid var(--border);
     border-bottom-width: 2px;
     background: var(--background);
     padding: 0.1rem 0.45rem;
-    font-family: var(--font-hud);
+    font-family: var(--font-mono, ui-monospace, monospace);
     font-size: 0.75rem;
     font-weight: 700;
     color: var(--foreground);
 }
 
 .paste-hint .plus {
-    font-family: var(--font-hud);
+    font-family: var(--font-mono, ui-monospace, monospace);
     font-size: 0.75rem;
     color: var(--muted-foreground);
 }
@@ -1116,24 +867,12 @@ const vReveal = {
 
 .feat-icon {
     display: flex;
-    height: 3rem;
-    width: 3rem;
+    height: 2.5rem;
+    width: 2.5rem;
     align-items: center;
     justify-content: center;
-    border-radius: 0.85rem;
-    border: 1px solid color-mix(in oklab, var(--color-orange-400) 25%, var(--border));
-    background: color-mix(in oklab, var(--card) 70%, transparent);
-    backdrop-filter: blur(8px);
-    transition:
-        border-color 0.3s ease,
-        box-shadow 0.3s ease,
-        transform 0.3s ease;
-}
-
-.group:hover .feat-icon {
-    border-color: color-mix(in oklab, var(--color-orange-400) 60%, var(--border));
-    box-shadow: 0 0 28px -8px color-mix(in oklab, var(--color-orange-400) 60%, transparent);
-    transform: translateY(-2px);
+    border: 1px solid var(--border);
+    background: color-mix(in oklab, var(--muted) 30%, transparent);
 }
 
 /* Layout editor showcase: card grid + floating toolbar replica */
@@ -1148,11 +887,10 @@ const vReveal = {
     align-items: flex-start;
     justify-content: space-between;
     min-height: 3.25rem;
-    border-radius: 0.5rem;
-    border: 1px dashed color-mix(in oklab, var(--border) 95%, transparent);
+    border: 1px dashed var(--border);
     background: color-mix(in oklab, var(--muted) 30%, transparent);
     padding: 0.5rem 0.6rem;
-    font-family: var(--font-hud);
+    font-family: var(--font-mono, ui-monospace, monospace);
     font-size: 0.7rem;
     letter-spacing: 0.04em;
     color: var(--muted-foreground);
@@ -1163,17 +901,17 @@ const vReveal = {
     height: 0.5rem;
     width: 0.5rem;
     align-self: flex-end;
-    border-right: 2px solid color-mix(in oklab, var(--color-orange-400) 60%, transparent);
-    border-bottom: 2px solid color-mix(in oklab, var(--color-orange-400) 60%, transparent);
+    border-right: 2px solid color-mix(in oklab, var(--foreground) 35%, transparent);
+    border-bottom: 2px solid color-mix(in oklab, var(--foreground) 35%, transparent);
 }
 
 .wg-map {
     grid-column: 1 / -1;
     min-height: 5rem;
     border-style: solid;
-    border-color: color-mix(in oklab, var(--color-orange-400) 40%, var(--border));
-    background: color-mix(in oklab, var(--color-orange-500) 8%, transparent);
-    color: color-mix(in oklab, var(--color-orange-300) 70%, var(--foreground));
+    border-color: color-mix(in oklab, var(--foreground) 30%, var(--border));
+    background: color-mix(in oklab, var(--muted) 55%, transparent);
+    color: var(--foreground);
 }
 
 .le-toolbar {
@@ -1229,7 +967,7 @@ const vReveal = {
     gap: 0.3rem;
     border-radius: 0.5rem;
     padding: 0 0.4rem;
-    font-family: var(--font-hud);
+    font-family: var(--font-mono, ui-monospace, monospace);
     font-size: 0.7rem;
     color: var(--muted-foreground);
 }
@@ -1252,7 +990,7 @@ const vReveal = {
     border-radius: 9999px;
     background: var(--primary);
     padding: 0 0.2rem;
-    font-family: var(--font-hud);
+    font-family: var(--font-mono, ui-monospace, monospace);
     font-size: 10px;
     color: var(--primary-foreground);
 }
@@ -1286,168 +1024,40 @@ const vReveal = {
     color: var(--foreground);
 }
 
-/* App-window frame around real components, styled as a ship instrument panel:
-   sharp symmetric corners, hairline accent border, bracket details — no glow. */
-.window {
-    position: relative;
-    z-index: 1;
-    overflow: hidden;
-    border: 1px solid color-mix(in oklab, var(--sec, var(--color-orange-400)) 30%, var(--border));
-    background: color-mix(in oklab, var(--card) 88%, transparent);
-    box-shadow: inset 0 1px 0 color-mix(in oklab, var(--foreground) 6%, transparent);
-    backdrop-filter: blur(12px);
-}
-
-/* Corner brackets, top-left and bottom-right. */
-.window::before,
-.window::after {
-    content: '';
-    position: absolute;
-    z-index: 3;
-    height: 14px;
-    width: 14px;
-    border: 2px solid color-mix(in oklab, var(--sec, var(--color-orange-400)) 80%, transparent);
-    pointer-events: none;
-}
-
-.window::before {
-    top: 0;
-    left: 0;
-    border-right: 0;
-    border-bottom: 0;
-}
-
-.window::after {
-    right: 0;
-    bottom: 0;
-    border-left: 0;
-    border-top: 0;
-}
-
-.window-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-bottom: 1px solid color-mix(in oklab, var(--sec, var(--color-orange-400)) 14%, var(--border));
-    background: linear-gradient(
-        to bottom,
-        color-mix(in oklab, var(--sec, var(--color-orange-400)) 7%, color-mix(in oklab, var(--muted) 45%, transparent)),
-        color-mix(in oklab, var(--muted) 30%, transparent)
-    );
-    padding: 0.7rem 0.95rem;
-}
-
-/* Hero console */
-.hero-console {
-    position: relative;
-}
-
-.console-glow {
-    position: absolute;
-    inset: -14% -10% 0 -10%;
-    z-index: 0;
-    background: radial-gradient(60% 60% at 62% 35%, color-mix(in oklab, var(--color-orange-400) 32%, transparent), transparent 70%);
-    filter: blur(56px);
-}
-
-/* CTA: full-bleed cosmic finale */
+/* CTA: quiet finale on the map grid. */
 .cta {
     position: relative;
     overflow: hidden;
-    border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
-    padding-block: 12rem;
-}
-
-@media (min-width: 640px) {
-    .cta {
-        padding-block: 15rem;
-    }
-}
-
-.cta-core {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    height: 620px;
-    width: 620px;
-    transform: translate(-50%, -50%);
-    border-radius: 9999px;
-    background: radial-gradient(
-        circle,
-        color-mix(in oklab, var(--color-orange-400) 34%, transparent),
-        color-mix(in oklab, var(--color-red-500) 20%, transparent) 45%,
-        transparent 70%
-    );
-    filter: blur(56px);
-    animation: cta-pulse 6s ease-in-out infinite;
-    will-change: transform, opacity;
-}
-
-@keyframes cta-pulse {
-    0%,
-    100% {
-        opacity: 0.7;
-        transform: translate(-50%, -50%) scale(1);
-    }
-    50% {
-        opacity: 1;
-        transform: translate(-50%, -50%) scale(1.08);
-    }
+    border-top: 1px solid var(--border);
+    padding-block: 10rem;
 }
 
 .cta-grid {
     position: absolute;
     inset: 0;
     background-image: linear-gradient(to right, var(--grid) 1px, transparent 1px), linear-gradient(to bottom, var(--grid) 1px, transparent 1px);
-    background-size: 44px 44px;
-    opacity: 0.5;
-    -webkit-mask-image: radial-gradient(closest-side at 50% 50%, #000, transparent 78%);
-    mask-image: radial-gradient(closest-side at 50% 50%, #000, transparent 78%);
-}
-
-.cta-eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-family: var(--font-hud);
-    font-size: 0.7rem;
-    letter-spacing: 0.24em;
-    text-transform: uppercase;
-    color: color-mix(in oklab, var(--color-orange-300) 80%, var(--foreground));
+    background-size: 32px 32px;
+    -webkit-mask-image: radial-gradient(closest-side at 50% 50%, #000, transparent 80%);
+    mask-image: radial-gradient(closest-side at 50% 50%, #000, transparent 80%);
 }
 
 .cta-title {
     margin-top: 1.5rem;
     font-family: var(--font-display);
-    font-size: clamp(2.75rem, 1.8rem + 4vw, 5rem);
-    font-weight: 800;
-    line-height: 1;
+    font-size: clamp(2.5rem, 1.7rem + 3.5vw, 4.25rem);
+    font-weight: 700;
+    line-height: 1.02;
     letter-spacing: -0.02em;
     color: var(--foreground);
 }
 
-.cta-void {
-    background: linear-gradient(135deg, var(--color-orange-300), var(--color-orange-400), var(--color-red-500));
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-    filter: drop-shadow(0 0 36px color-mix(in oklab, var(--color-orange-400) 60%, transparent));
-}
-
 .cta-lead {
-    margin-top: 1.75rem;
+    margin-top: 1.5rem;
     margin-inline: auto;
     max-width: 34rem;
-    font-size: 1.2rem;
+    font-size: 1.125rem;
     line-height: 1.7;
-    font-weight: 500;
     color: var(--muted-foreground);
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .cta-core {
-        animation: none;
-    }
 }
 
 /* Entrance + scroll-reveal animations */
@@ -1522,8 +1132,7 @@ const vReveal = {
 
 @media (prefers-reduced-motion: reduce) {
     .hero-intro,
-    .hero-console,
-    .gradient-drift {
+    .hero-console {
         animation: none;
     }
 }

--- a/resources/js/pages/Landing.vue
+++ b/resources/js/pages/Landing.vue
@@ -167,8 +167,8 @@ const vReveal = {
         <div class="relative isolate min-h-screen overflow-x-hidden bg-background text-foreground">
             <SeoHead :title="seoData.title" :description="seoData.description" :keywords="seoData.keywords" />
 
-            <!-- The page sits on the same faint grid the map canvas uses, fading
-                 out towards the bottom so long sections rest on plain background. -->
+            <!-- The whole page is a map canvas: the same grid the map uses, with
+                 the sections floating on it as cards, chained down the middle. -->
             <div class="page-grid" aria-hidden="true" />
 
             <!-- Nav: the app's hairline-and-blur chrome. -->
@@ -200,86 +200,85 @@ const vReveal = {
 
             <main class="relative pt-14">
                 <!-- Hero -->
-                <section class="border-b border-border">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
-                        <div class="grid items-center gap-14 py-24 lg:grid-cols-[1.05fr_1fr] lg:py-36">
-                            <div class="hero-intro">
-                                <div class="section-label">
-                                    <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
-                                    Live, interactive wormhole maps
-                                </div>
-                                <h1
-                                    class="mt-7 font-display text-5xl leading-[0.98] font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl"
-                                >
-                                    Navigate the
-                                    <span class="text-orange-400">Unknown</span>
-                                </h1>
-                                <p class="mt-7 max-w-xl text-lg leading-8 text-muted-foreground">
-                                    Map your wormhole chain, track signatures, and watch for hostiles together. Fly solo, with your corp, or a whole
-                                    alliance. Everyone shares the same live map.
-                                </p>
-                                <div class="mt-9 flex flex-wrap items-center gap-3">
-                                    <template v-if="!user">
-                                        <Button asChild size="lg">
-                                            <a :href="Eve.show().url" class="group inline-flex items-center gap-2">
-                                                Sign in with EVE
-                                                <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-                                            </a>
-                                        </Button>
-                                        <Button asChild size="lg" variant="outline">
-                                            <a :href="Eve.show({ query: { without_scopes: true } }).url" class="inline-flex items-center gap-2">
-                                                Sign in without scopes
-                                            </a>
-                                        </Button>
-                                    </template>
-                                    <Button asChild size="lg" v-else>
-                                        <Link :href="home()" class="group inline-flex items-center gap-2" prefetch>
-                                            Explore Maps
+                <section class="mx-auto max-w-7xl px-6 sm:px-10">
+                    <div class="grid items-center gap-14 py-24 lg:grid-cols-[1.05fr_1fr] lg:py-32">
+                        <div class="hero-intro">
+                            <div class="section-label">
+                                <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
+                                Live, interactive wormhole maps
+                            </div>
+                            <h1 class="mt-7 font-display text-5xl leading-[0.98] font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+                                Navigate the
+                                <span class="text-orange-400">Unknown</span>
+                            </h1>
+                            <p class="mt-7 max-w-xl text-lg leading-8 text-muted-foreground">
+                                Map your wormhole chain, track signatures, and watch for hostiles together. Fly solo, with your corp, or a whole
+                                alliance. Everyone shares the same live map.
+                            </p>
+                            <div class="mt-9 flex flex-wrap items-center gap-3">
+                                <template v-if="!user">
+                                    <Button asChild size="lg">
+                                        <a :href="Eve.show().url" class="group inline-flex items-center gap-2">
+                                            Sign in with EVE
                                             <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-                                        </Link>
-                                    </Button>
-                                    <Button as-child size="lg" variant="ghost">
-                                        <a :href="page.props.discord.invite" class="inline-flex items-center gap-2">
-                                            <DiscordIcon class="h-4 w-4" />
-                                            Join the Discord
                                         </a>
                                     </Button>
-                                </div>
-                                <p class="mt-8 font-mono text-[10px] tracking-wider text-muted-foreground/70 uppercase">
-                                    ESI-secure · No client install · Free to use
-                                </p>
+                                    <Button asChild size="lg" variant="outline">
+                                        <a :href="Eve.show({ query: { without_scopes: true } }).url" class="inline-flex items-center gap-2">
+                                            Sign in without scopes
+                                        </a>
+                                    </Button>
+                                </template>
+                                <Button asChild size="lg" v-else>
+                                    <Link :href="home()" class="group inline-flex items-center gap-2" prefetch>
+                                        Explore Maps
+                                        <ArrowRight class="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                                    </Link>
+                                </Button>
+                                <Button as-child size="lg" variant="ghost">
+                                    <a :href="page.props.discord.invite" class="inline-flex items-center gap-2">
+                                        <DiscordIcon class="h-4 w-4" />
+                                        Join the Discord
+                                    </a>
+                                </Button>
                             </div>
+                            <p class="mt-8 font-mono text-[10px] tracking-wider text-muted-foreground/70 uppercase">
+                                ESI-secure · No client install · Free to use
+                            </p>
+                        </div>
 
-                            <!-- The real map, framed exactly like an in-app card. -->
-                            <div class="hero-console">
-                                <MapPanel>
-                                    <MapPanelHeader>
-                                        home.map · J152820
-                                        <template #actions>
-                                            <span class="flex items-center gap-1.5">
-                                                <span class="size-2 rounded-full bg-hostile/70" />
-                                                <span class="size-2 rounded-full bg-active/70" />
-                                                <span class="size-2 rounded-full bg-empty/70" />
-                                            </span>
-                                        </template>
-                                    </MapPanelHeader>
-                                    <div class="relative h-[380px] w-full overflow-hidden sm:h-[460px]">
-                                        <MapReadonly
-                                            :solarsystems="MAP_SOLARSYSTEMS"
-                                            :connections="MAP_CONNECTIONS"
-                                            :pilots="MAP_PILOTS"
-                                            :home_solarsystem_id="1"
-                                            :scale="isCompact ? 0.58 : 0.8"
-                                        />
-                                    </div>
-                                </MapPanel>
-                            </div>
+                        <!-- The real map, framed exactly like an in-app card. -->
+                        <div class="hero-console">
+                            <MapPanel>
+                                <MapPanelHeader>
+                                    home.map · J152820
+                                    <template #actions>
+                                        <span class="flex items-center gap-1.5">
+                                            <span class="size-2 rounded-full bg-hostile/70" />
+                                            <span class="size-2 rounded-full bg-active/70" />
+                                            <span class="size-2 rounded-full bg-empty/70" />
+                                        </span>
+                                    </template>
+                                </MapPanelHeader>
+                                <div class="relative h-[380px] w-full overflow-hidden sm:h-[460px]">
+                                    <MapReadonly
+                                        :solarsystems="MAP_SOLARSYSTEMS"
+                                        :connections="MAP_CONNECTIONS"
+                                        :pilots="MAP_PILOTS"
+                                        :home_solarsystem_id="1"
+                                        :scale="isCompact ? 0.58 : 0.8"
+                                    />
+                                </div>
+                            </MapPanel>
                         </div>
                     </div>
                 </section>
 
-                <!-- Stat strip: cards sharing hairline borders, like the map grid. -->
-                <section class="mx-auto max-w-7xl px-6 py-16 sm:px-10">
+                <!-- The chain: every section is a card on the map canvas, linked
+                     down the middle column like systems in a wormhole chain. -->
+                <div class="mx-auto max-w-6xl px-6 pb-8 sm:px-10">
+                    <!-- Stats -->
+                    <div class="chain" aria-hidden="true" />
                     <div v-reveal class="grid grid-cols-2 gap-px bg-border text-center ring-1 ring-border md:grid-cols-4">
                         <div v-for="stat in stats" :key="stat.k" class="bg-card px-6 py-10">
                             <div class="font-display text-4xl font-bold tracking-tight text-foreground">
@@ -288,70 +287,68 @@ const vReveal = {
                             <div class="mt-2 font-mono text-[10px] tracking-wider text-muted-foreground uppercase">{{ stat.k }}</div>
                         </div>
                     </div>
-                </section>
 
-                <!-- Open source & self-hosting (surfaced early — it's a core differentiator).
-                     Deliberately unboxed: a quiet statement with a link list, not a card. -->
-                <section class="mx-auto max-w-7xl px-6 py-20 sm:px-10 sm:py-28">
-                    <div v-reveal class="grid items-start gap-14 lg:grid-cols-[1.1fr_1fr] lg:gap-24">
-                        <div>
-                            <div class="section-label">
-                                <Github class="h-3.5 w-3.5" />
-                                100% open source
+                    <!-- Open source & self-hosting (surfaced early — it's a core differentiator). -->
+                    <div class="chain" aria-hidden="true" />
+                    <MapPanel v-reveal>
+                        <MapPanelHeader>
+                            <span class="flex items-center gap-2"><Github class="h-3.5 w-3.5" /> 100% open source</span>
+                        </MapPanelHeader>
+                        <div class="grid divide-y divide-border/50 lg:grid-cols-[1.1fr_1fr] lg:divide-x lg:divide-y-0">
+                            <div class="p-8 sm:p-12">
+                                <h2 class="section-title">Free, open source, and yours to self-host</h2>
+                                <p class="section-lead">
+                                    Use the hosted version, dig into the code, or spin up your own private instance with the ready-made container
+                                    setup. No lock-in — it's all out in the open.
+                                </p>
                             </div>
-                            <h2 class="mt-6 font-display text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-                                Free, open source, and yours to self-host
-                            </h2>
-                            <p class="mt-5 max-w-xl text-[15px] leading-7 text-muted-foreground">
-                                Use the hosted version, dig into the code, or spin up your own private instance with the ready-made container setup.
-                                No lock-in — it's all out in the open.
-                            </p>
-                        </div>
-                        <div class="lg:pt-8">
-                            <a
-                                href="https://github.com/WormholeSystems/WormholeSystems"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="oss-link group"
-                            >
-                                <Github class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
-                                <span class="min-w-0 flex-1">
-                                    <span class="block font-display text-base font-bold text-foreground">Source code</span>
-                                    <span class="mt-1 block text-sm leading-6 text-muted-foreground">
-                                        Browse the full source, open issues, and contribute on GitHub.
+                            <div class="flex flex-col divide-y divide-border/50">
+                                <a
+                                    href="https://github.com/WormholeSystems/WormholeSystems"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="oss-link group"
+                                >
+                                    <Github class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                                    <span class="min-w-0 flex-1">
+                                        <span class="block font-display text-base font-bold text-foreground">Source code</span>
+                                        <span class="mt-1 block text-sm leading-6 text-muted-foreground">
+                                            Browse the full source, open issues, and contribute on GitHub.
+                                        </span>
                                     </span>
-                                </span>
-                                <ArrowRight class="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-                            </a>
-                            <a
-                                href="https://github.com/WormholeSystems/wormholesystems-containers"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="oss-link group"
-                            >
-                                <Container class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
-                                <span class="min-w-0 flex-1">
-                                    <span class="block font-display text-base font-bold text-foreground">Self-host</span>
-                                    <span class="mt-1 block text-sm leading-6 text-muted-foreground">
-                                        A ready-to-run Docker setup for your own private instance.
+                                    <ArrowRight
+                                        class="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                                    />
+                                </a>
+                                <a
+                                    href="https://github.com/WormholeSystems/wormholesystems-containers"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="oss-link group"
+                                >
+                                    <Container class="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                                    <span class="min-w-0 flex-1">
+                                        <span class="block font-display text-base font-bold text-foreground">Self-host</span>
+                                        <span class="mt-1 block text-sm leading-6 text-muted-foreground">
+                                            A ready-to-run Docker setup for your own private instance.
+                                        </span>
                                     </span>
-                                </span>
-                                <ArrowRight class="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-                            </a>
+                                    <ArrowRight
+                                        class="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                                    />
+                                </a>
+                            </div>
                         </div>
-                    </div>
-                </section>
+                    </MapPanel>
 
-                <!-- Section 01: Shared mapping (copy left / app panel right) -->
-                <section class="feature-section">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
-                        <div v-reveal class="marker">
-                            <span class="idx">01</span>
-                            <span class="section-label"><Users class="h-3.5 w-3.5" /> Shared mapping</span>
-                            <span class="h-px flex-1 bg-border" />
-                        </div>
-                        <div class="grid items-center gap-14 pt-16 lg:grid-cols-2 lg:gap-24">
-                            <div v-reveal="'left'">
+                    <!-- 01: Shared mapping -->
+                    <div class="chain" aria-hidden="true" />
+                    <MapPanel v-reveal>
+                        <MapPanelHeader>
+                            <span class="flex items-center gap-2"><Users class="h-3.5 w-3.5" /> 01 · Shared mapping</span>
+                        </MapPanelHeader>
+                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                            <div class="p-8 sm:p-12">
                                 <h2 class="section-title">Everyone on the same map, live</h2>
                                 <p class="section-lead">
                                     When anyone moves, scans a connection, or updates a system, every pilot sees it right away. No pasting bookmarks
@@ -363,75 +360,65 @@ const vReveal = {
                                     <li><span class="dot" /> Every change shows up for everyone instantly</li>
                                 </ul>
                             </div>
-                            <MapPanel v-reveal="'right'">
-                                <MapPanelHeader>
-                                    <span class="flex items-center gap-2">
-                                        <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
-                                        Pilots · {{ CHARACTERS.length }}
-                                    </span>
-                                </MapPanelHeader>
-                                <div class="overflow-x-auto">
+                            <div class="flex flex-col">
+                                <div class="cell-header">
+                                    <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
+                                    Pilots · {{ CHARACTERS.length }}
+                                </div>
+                                <div class="flex-1 overflow-x-auto">
                                     <CharactersView :characters="CHARACTERS" />
                                 </div>
-                            </MapPanel>
+                            </div>
                         </div>
-                    </div>
-                </section>
+                    </MapPanel>
 
-                <!-- Section 02: Kill activity (full-width feed) -->
-                <section class="feature-section">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
-                        <div v-reveal class="marker">
-                            <span class="idx">02</span>
-                            <span class="section-label"><Activity class="h-3.5 w-3.5" /> Kill activity</span>
-                            <span class="h-px flex-1 bg-border" />
-                        </div>
-                        <div class="grid gap-8 pt-16 lg:grid-cols-2 lg:items-end">
-                            <div v-reveal="'left'">
+                    <!-- 02: Kill activity -->
+                    <div class="chain" aria-hidden="true" />
+                    <MapPanel v-reveal>
+                        <MapPanelHeader>
+                            <span class="flex items-center gap-2"><Activity class="h-3.5 w-3.5" /> 02 · Kill activity</span>
+                            <template #actions>
+                                <span class="font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">via zKillboard</span>
+                            </template>
+                        </MapPanelHeader>
+                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                            <div class="p-8 sm:p-12">
                                 <h2 class="section-title">See every kill in your chain</h2>
                                 <p class="section-lead">
                                     Killmails from your systems show up on their own, straight from zKillboard, so you always know where the fighting
                                     is and how much got blown up.
                                 </p>
                             </div>
-                            <div v-reveal="'right'">
-                                <ul class="points lg:pb-1">
+                            <div class="p-8 sm:p-12">
+                                <ul class="points mt-0">
                                     <li><span class="dot" /> Who died, who got the kill, how many were involved, and the ISK lost</li>
                                     <li><span class="dot" /> Filter to wormhole space, known space, or everything</li>
                                     <li><span class="dot" /> Click any kill to jump to that system on the map</li>
                                 </ul>
                             </div>
                         </div>
-                        <MapPanel v-reveal class="mt-14">
-                            <MapPanelHeader>
-                                Killmails · {{ KILLMAILS.length }}
-                                <template #actions>
-                                    <span class="font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">via zKillboard</span>
-                                </template>
-                            </MapPanelHeader>
+                        <div class="border-t border-border/50">
+                            <div class="cell-header">Killmails · {{ KILLMAILS.length }}</div>
                             <div class="min-h-[13rem] overflow-x-auto py-1">
                                 <KillmailsView v-if="mounted" :items="KILLMAILS" />
                             </div>
-                        </MapPanel>
-                    </div>
-                </section>
-
-                <!-- Section 03: Signatures (panel left / copy right + paste hint) -->
-                <section class="feature-section">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
-                        <div v-reveal class="marker">
-                            <span class="idx">03</span>
-                            <span class="section-label"><Crosshair class="h-3.5 w-3.5" /> Signatures</span>
-                            <span class="h-px flex-1 bg-border" />
                         </div>
-                        <div class="grid items-center gap-14 pt-16 lg:grid-cols-2 lg:gap-24">
-                            <MapPanel v-reveal="'left'" class="lg:order-1">
-                                <MapPanelHeader>Signatures · {{ SIGNATURES.length }}</MapPanelHeader>
-                                <div class="min-h-[18rem] overflow-x-auto">
+                    </MapPanel>
+
+                    <!-- 03: Signatures -->
+                    <div class="chain" aria-hidden="true" />
+                    <MapPanel v-reveal>
+                        <MapPanelHeader>
+                            <span class="flex items-center gap-2"><Crosshair class="h-3.5 w-3.5" /> 03 · Signatures</span>
+                        </MapPanelHeader>
+                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                            <div class="flex flex-col lg:order-1">
+                                <div class="cell-header">Signatures · {{ SIGNATURES.length }}</div>
+                                <div class="min-h-[18rem] flex-1 overflow-x-auto">
                                     <SignaturesView v-if="mounted" :signatures="SIGNATURES" :connections="MAP_CONNECTIONS" />
                                 </div>
-                            </MapPanel>
-                            <div v-reveal="'right'" class="lg:order-2">
+                            </div>
+                            <div class="p-8 sm:p-12 lg:order-2">
                                 <h2 class="section-title">Scanning is just copy and paste</h2>
                                 <p class="section-lead">
                                     Copy your probe scanner results in game, paste them in, and the map sorts it all out. New signatures get added,
@@ -450,19 +437,16 @@ const vReveal = {
                                 </ul>
                             </div>
                         </div>
-                    </div>
-                </section>
+                    </MapPanel>
 
-                <!-- Section 04: Customisable widget layout -->
-                <section class="feature-section">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
-                        <div v-reveal class="marker">
-                            <span class="idx">04</span>
-                            <span class="section-label"><LayoutGrid class="h-3.5 w-3.5" /> Customisable layout</span>
-                            <span class="h-px flex-1 bg-border" />
-                        </div>
-                        <div class="grid items-center gap-14 pt-16 lg:grid-cols-2 lg:gap-24">
-                            <div v-reveal="'left'">
+                    <!-- 04: Customisable widget layout -->
+                    <div class="chain" aria-hidden="true" />
+                    <MapPanel v-reveal>
+                        <MapPanelHeader>
+                            <span class="flex items-center gap-2"><LayoutGrid class="h-3.5 w-3.5" /> 04 · Customisable layout</span>
+                        </MapPanelHeader>
+                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                            <div class="p-8 sm:p-12">
                                 <h2 class="section-title">Build the map around you</h2>
                                 <p class="section-lead">
                                     The map is a grid of cards you can drag, resize, and hide. Keep the systems you watch front and centre and switch
@@ -474,17 +458,13 @@ const vReveal = {
                                     <li><span class="dot" /> Responsive breakpoints from mobile to wide desktop, each with its own layout</li>
                                 </ul>
                             </div>
-                            <MapPanel v-reveal="'right'">
-                                <MapPanelHeader>
-                                    <span class="flex items-center gap-2">
-                                        <span class="size-1.5 animate-pulse rounded-full bg-empty" />
-                                        Editing layout
-                                    </span>
-                                    <template #actions>
-                                        <span class="font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">J152820</span>
-                                    </template>
-                                </MapPanelHeader>
-                                <div class="relative p-3 pb-20">
+                            <div class="flex flex-col">
+                                <div class="cell-header">
+                                    <span class="size-1.5 animate-pulse rounded-full bg-empty" />
+                                    Editing layout
+                                    <span class="ml-auto font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">J152820</span>
+                                </div>
+                                <div class="relative flex-1 p-3 pb-20">
                                     <div class="wg-grid">
                                         <div class="wg-tile wg-map">Map</div>
                                         <div class="wg-tile">Signatures</div>
@@ -513,23 +493,20 @@ const vReveal = {
                                         <span class="le-btn"><MoreHorizontal class="size-4" /></span>
                                     </div>
                                 </div>
-                            </MapPanel>
+                            </div>
                         </div>
-                    </div>
-                </section>
+                    </MapPanel>
 
-                <!-- Section 05: Access control -->
-                <section class="feature-section">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
-                        <div v-reveal class="marker">
-                            <span class="idx">05</span>
-                            <span class="section-label"><ShieldCheck class="h-3.5 w-3.5" /> Access control</span>
-                            <span class="h-px flex-1 bg-border" />
-                        </div>
-                        <div class="grid items-center gap-14 pt-16 lg:grid-cols-2 lg:gap-24">
-                            <MapPanel v-reveal="'left'" class="lg:order-1">
-                                <MapPanelHeader>Access · J152820</MapPanelHeader>
-                                <div class="px-2 py-1">
+                    <!-- 05: Access control -->
+                    <div class="chain" aria-hidden="true" />
+                    <MapPanel v-reveal>
+                        <MapPanelHeader>
+                            <span class="flex items-center gap-2"><ShieldCheck class="h-3.5 w-3.5" /> 05 · Access control</span>
+                        </MapPanelHeader>
+                        <div class="grid divide-y divide-border/50 lg:grid-cols-2 lg:divide-x lg:divide-y-0">
+                            <div class="flex flex-col lg:order-1">
+                                <div class="cell-header">Access · J152820</div>
+                                <div class="flex-1 px-2 py-1">
                                     <Table>
                                         <TableHeader>
                                             <TableRow class="border-border/50 hover:bg-transparent">
@@ -595,8 +572,8 @@ const vReveal = {
                                         </TableBody>
                                     </Table>
                                 </div>
-                            </MapPanel>
-                            <div v-reveal="'right'" class="lg:order-2">
+                            </div>
+                            <div class="p-8 sm:p-12 lg:order-2">
                                 <h2 class="section-title">Decide exactly who sees what</h2>
                                 <p class="section-lead">
                                     Four levels of access, from view-only to full control. Viewers read the map, Members contribute signatures and
@@ -609,22 +586,19 @@ const vReveal = {
                                 </ul>
                             </div>
                         </div>
-                    </div>
-                </section>
+                    </MapPanel>
 
-                <!-- Section 06: Everything else, as adjoining cards sharing hairlines. -->
-                <section class="feature-section">
-                    <div class="mx-auto max-w-7xl px-6 sm:px-10">
-                        <div v-reveal class="marker">
-                            <span class="idx">06</span>
-                            <span class="section-label"><Sparkles class="h-3.5 w-3.5" /> Everything else</span>
-                            <span class="h-px flex-1 bg-border" />
-                        </div>
-                        <div v-reveal="'left'" class="max-w-3xl pt-16">
+                    <!-- 06: Everything else -->
+                    <div class="chain" aria-hidden="true" />
+                    <MapPanel v-reveal>
+                        <MapPanelHeader>
+                            <span class="flex items-center gap-2"><Sparkles class="h-3.5 w-3.5" /> 06 · Everything else</span>
+                        </MapPanelHeader>
+                        <div class="p-8 sm:p-12">
                             <h2 class="section-title">Everything else you need to live in a wormhole</h2>
                             <p class="section-lead">The rest of the tools that make day-to-day wormhole life easier.</p>
                         </div>
-                        <div v-reveal class="mt-14 grid gap-px bg-border ring-1 ring-border sm:grid-cols-2 lg:grid-cols-3">
+                        <div class="grid gap-px border-t border-border/50 bg-border/50 sm:grid-cols-2 lg:grid-cols-3">
                             <div v-for="feature in secondaryFeatures" :key="feature.title" class="group bg-card p-7">
                                 <div class="feat-icon">
                                     <component
@@ -638,12 +612,11 @@ const vReveal = {
                             <!-- Filler cell so the hairline grid stays rectangular on wide screens. -->
                             <div class="hidden bg-card p-7 lg:block" aria-hidden="true" />
                         </div>
-                    </div>
-                </section>
+                    </MapPanel>
+                </div>
 
-                <!-- CTA -->
+                <!-- CTA: the end of the chain. -->
                 <section class="cta">
-                    <div class="cta-grid" aria-hidden="true" />
                     <div v-reveal class="relative mx-auto max-w-3xl px-6 text-center sm:px-10">
                         <div class="section-label justify-center">
                             <span class="size-1.5 animate-pulse rounded-full bg-green-500" />
@@ -663,7 +636,7 @@ const vReveal = {
                 </section>
             </main>
 
-            <footer class="relative border-t border-border bg-background/70">
+            <footer class="relative border-t border-border bg-background/70 backdrop-blur-sm">
                 <div class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-6 py-12 sm:flex-row sm:px-10">
                     <div class="flex items-center gap-3">
                         <Logo class="h-6 w-6 text-muted-foreground/60" />
@@ -704,17 +677,51 @@ const vReveal = {
     font-family: var(--font-display);
 }
 
-/* The map canvas grid, projected across the whole page and faded so it only
-   reads clearly behind the hero. */
+/* The map canvas: the same grid the map uses, across the whole page. */
 .page-grid {
     position: fixed;
     inset: 0;
     z-index: -10;
     background-image: linear-gradient(to right, var(--grid) 1px, transparent 1px), linear-gradient(to bottom, var(--grid) 1px, transparent 1px);
     background-size: 32px 32px;
-    -webkit-mask-image: linear-gradient(to bottom, #000, transparent 85%);
-    mask-image: linear-gradient(to bottom, #000, transparent 85%);
-    opacity: 0.6;
+    opacity: 0.55;
+}
+
+/* Chain connector between section cards: the map's neutral connection stroke
+   with node endpoints, running down the middle column. */
+.chain {
+    position: relative;
+    margin-inline: auto;
+    height: 5rem;
+    width: 1.5px;
+    background: color-mix(in oklab, var(--foreground) 22%, transparent);
+}
+
+@media (min-width: 640px) {
+    .chain {
+        height: 7rem;
+    }
+}
+
+.chain::before,
+.chain::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    height: 7px;
+    width: 7px;
+    transform: translateX(-50%);
+    border-radius: 9999px;
+    border: 1.5px solid color-mix(in oklab, var(--foreground) 35%, transparent);
+    background: var(--background);
+}
+
+.chain::before {
+    top: -3px;
+}
+
+.chain::after {
+    bottom: -3px;
 }
 
 /* Nav links share the panel-header voice. */
@@ -743,53 +750,43 @@ const vReveal = {
     color: var(--muted-foreground);
 }
 
-/* Section separation: hairline top borders, like adjoining cards. */
-.feature-section {
-    border-top: 1px solid var(--border);
-    padding-block: 7rem 5rem;
-}
-
-@media (min-width: 640px) {
-    .feature-section {
-        padding-block: 9rem 7rem;
-    }
-}
-
-/* Section marker: 01 · TAG ───────── in the panel-header voice. */
-.marker {
+/* Sub-header for showcase cells inside a section card, mirroring MapPanelHeader. */
+.cell-header {
     display: flex;
+    height: 2.25rem;
+    flex-shrink: 0;
     align-items: center;
-    gap: 1rem;
-}
-
-.marker .idx {
+    gap: 0.5rem;
+    border-bottom: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
+    background: color-mix(in oklab, var(--muted) 30%, transparent);
+    padding-inline: 0.75rem;
     font-family: var(--font-mono, ui-monospace, monospace);
-    font-size: clamp(1.5rem, 1.1rem + 1.5vw, 2.25rem);
-    font-weight: 700;
-    line-height: 1;
-    color: color-mix(in oklab, var(--foreground) 30%, transparent);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
 }
 
 /* Section copy */
 .section-title {
     font-family: var(--font-display);
-    font-size: clamp(2rem, 1.4rem + 2.5vw, 3.25rem);
+    font-size: clamp(1.75rem, 1.3rem + 1.8vw, 2.75rem);
     font-weight: 700;
-    line-height: 1.06;
+    line-height: 1.08;
     letter-spacing: -0.02em;
     color: var(--foreground);
 }
 
 .section-lead {
-    margin-top: 1.4rem;
+    margin-top: 1.25rem;
     max-width: 36rem;
-    font-size: 1.125rem;
+    font-size: 1.0625rem;
     line-height: 1.7;
     color: var(--muted-foreground);
 }
 
 .points {
-    margin-top: 2.5rem;
+    margin-top: 2.25rem;
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -799,35 +796,31 @@ const vReveal = {
     display: flex;
     align-items: flex-start;
     gap: 0.875rem;
-    font-size: 1.0625rem;
+    font-size: 1rem;
     line-height: 1.5;
     color: color-mix(in oklab, var(--foreground) 82%, transparent);
 }
 
 .dot {
-    margin-top: 0.6rem;
+    margin-top: 0.55rem;
     height: 0.375rem;
     width: 0.375rem;
     flex-shrink: 0;
     background: var(--color-orange-400);
 }
 
-/* Open-source link list: hairline rows instead of cards. */
+/* Open-source link rows inside the card. */
 .oss-link {
     display: flex;
-    align-items: flex-start;
+    flex: 1;
+    align-items: center;
     gap: 1rem;
-    border-top: 1px solid var(--border);
-    padding-block: 1.5rem;
-    transition: border-color 0.25s ease;
-}
-
-.oss-link:last-child {
-    border-bottom: 1px solid var(--border);
+    padding: 1.75rem 2rem;
+    transition: background-color 0.2s ease;
 }
 
 .oss-link:hover {
-    border-top-color: color-mix(in oklab, var(--foreground) 40%, var(--border));
+    background: color-mix(in oklab, var(--muted) 25%, transparent);
 }
 
 /* Paste hint chip */
@@ -1024,21 +1017,10 @@ const vReveal = {
     color: var(--foreground);
 }
 
-/* CTA: quiet finale on the map grid. */
+/* CTA: quiet finale on the open canvas. */
 .cta {
     position: relative;
-    overflow: hidden;
-    border-top: 1px solid var(--border);
-    padding-block: 10rem;
-}
-
-.cta-grid {
-    position: absolute;
-    inset: 0;
-    background-image: linear-gradient(to right, var(--grid) 1px, transparent 1px), linear-gradient(to bottom, var(--grid) 1px, transparent 1px);
-    background-size: 32px 32px;
-    -webkit-mask-image: radial-gradient(closest-side at 50% 50%, #000, transparent 80%);
-    mask-image: radial-gradient(closest-side at 50% 50%, #000, transparent 80%);
+    padding-block: 9rem;
 }
 
 .cta-title {

--- a/tests/Browser/HomeTest.php
+++ b/tests/Browser/HomeTest.php
@@ -7,7 +7,7 @@ it('shows the homepage', function () {
         ->assertSee('WormholeSystems')
         ->assertSee('Sign In')
         ->assertSee('Sign in without scopes')
-        ->assertSee('Join the Discord')
+        ->assertSee('Discord')
         ->assertNoSmoke()
         ->assertNoConsoleLogs();
 });

--- a/tests/Feature/LandingTest.php
+++ b/tests/Feature/LandingTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+it('renders the landing page for guests', function () {
+    $response = $this->get(route('landing'));
+
+    $response->assertSuccessful();
+    $response->assertInertia(fn ($page) => $page->component('Landing'));
+});
+
+it('redirects authenticated users away from the landing page', function () {
+    $this->actingAs(User::factory()->create());
+
+    $response = $this->get(route('landing'));
+
+    $response->assertRedirect();
+});

--- a/tests/Feature/LandingTest.php
+++ b/tests/Feature/LandingTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use App\Models\Killmail;
 use App\Models\User;
 
-function makeKillmail(int $id, int $solarsystemId): Killmail
+function makeLandingKillmail(int $id, int $solarsystemId): Killmail
 {
     return Killmail::query()->forceCreate([
         'id' => $id,
@@ -40,8 +40,8 @@ it('serves the latest wormhole killmails', function () {
     $wormholeSystem = makeSolarsystem(31000001, -1.0, 'wormhole');
     $knownSpaceSystem = makeSolarsystem(30000142, 0.9, 'eve');
 
-    $wormholeKillmail = makeKillmail(1001, $wormholeSystem);
-    makeKillmail(1002, $knownSpaceSystem);
+    $wormholeKillmail = makeLandingKillmail(1001, $wormholeSystem);
+    makeLandingKillmail(1002, $knownSpaceSystem);
 
     $response = $this->get(route('landing'));
 

--- a/tests/Feature/LandingTest.php
+++ b/tests/Feature/LandingTest.php
@@ -2,13 +2,53 @@
 
 declare(strict_types=1);
 
+use App\Models\Killmail;
 use App\Models\User;
+
+function makeKillmail(int $id, int $solarsystemId): Killmail
+{
+    return Killmail::query()->forceCreate([
+        'id' => $id,
+        'hash' => 'hash-'.$id,
+        'solarsystem_id' => $solarsystemId,
+        'time' => now(),
+        'data' => [
+            'victim' => [
+                'character_id' => 90000001,
+                'corporation_id' => null,
+                'alliance_id' => null,
+                'faction_id' => null,
+                'ship_type_id' => 670,
+                'items' => [],
+            ],
+            'attackers' => [],
+        ],
+        'zkb' => ['totalValue' => 10_000_000, 'points' => 1],
+    ]);
+}
 
 it('renders the landing page for guests', function () {
     $response = $this->get(route('landing'));
 
     $response->assertSuccessful();
-    $response->assertInertia(fn ($page) => $page->component('Landing'));
+    $response->assertInertia(fn ($page) => $page
+        ->component('Landing')
+        ->has('killmails'));
+});
+
+it('serves the latest wormhole killmails', function () {
+    $wormholeSystem = makeSolarsystem(31000001, -1.0, 'wormhole');
+    $knownSpaceSystem = makeSolarsystem(30000142, 0.9, 'eve');
+
+    $wormholeKillmail = makeKillmail(1001, $wormholeSystem);
+    makeKillmail(1002, $knownSpaceSystem);
+
+    $response = $this->get(route('landing'));
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('Landing')
+        ->has('killmails', 1)
+        ->where('killmails.0.id', $wormholeKillmail->id));
 });
 
 it('redirects authenticated users away from the landing page', function () {


### PR DESCRIPTION
Restyles the landing and login pages to match the app's dark panel look and leans into the map metaphor.

- Hero shows a live-rendered demo map with fixed-width nodes, free-flow curved connections, and a static-accurate chain built from real systems
- Sections are elevated cards linked down the page like systems in a chain, on a dotted canvas backdrop
- Latest J-space killmails come from the database, poll live, and link to zKillboard
- Self-hosting card is highlighted with an orange accent and carries the one-command install with a copy button
- Login page gets the same treatment: panel header chrome, dotted backdrop with an orange glow, and mono labels