### PR TITLE
feat: restyle login page in the app's panel aesthetic

### DIFF
--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -2,13 +2,12 @@
 import LockIcon from '@/components/icons/LockIcon.vue';
 import Logo from '@/components/icons/Logo.vue';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Separator } from '@/components/ui/separator';
+import MapPanelHeader from '@/components/ui/map-panel/MapPanelHeader.vue';
 import Notifications from '@/components/user/Notifications.vue';
 import SeoHead from '@/layouts/SeoHead.vue';
 import Eve from '@/routes/eve';
 import { UTCDate } from '@date-fns/utc';
-import { usePage } from '@inertiajs/vue3';
+import { Link, usePage } from '@inertiajs/vue3';
 import { format } from 'date-fns';
 import { computed } from 'vue';
 
@@ -19,64 +18,71 @@ const currentYear = format(new UTCDate(), 'yyyy');
 </script>
 
 <template>
-    <div class="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-background via-muted to-background p-6">
+    <div class="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-background p-6">
         <SeoHead
             title="Login"
             description="Sign in to WormholeSystems with your EVE Online character to access advanced wormhole mapping tools."
             url="https://wormhole.systems/login"
         />
+        <div class="login-backdrop" aria-hidden="true" />
 
-        <div class="w-full max-w-md">
-            <!-- Logo and Brand -->
+        <div class="relative w-full max-w-md">
+            <!-- Logo and brand -->
             <div class="mb-8 flex flex-col items-center gap-4">
-                <div class="flex h-20 w-20 items-center justify-center rounded-xl border bg-accent">
+                <Link href="/" class="flex items-center justify-center">
                     <Logo class="text-4xl text-foreground" />
-                </div>
+                </Link>
                 <div class="text-center">
-                    <h1 class="text-2xl font-bold text-foreground">WormholeSystems</h1>
-                    <p class="text-sm text-muted-foreground">EVE Online Wormhole Mapping</p>
+                    <h1 class="font-display text-2xl font-bold tracking-tight text-foreground">WormholeSystems</h1>
+                    <p class="mt-1.5 font-mono text-[10px] tracking-wider text-muted-foreground uppercase">EVE Online wormhole mapping</p>
                 </div>
             </div>
 
-            <!-- Login Card -->
-            <Card class="border shadow-lg">
-                <CardHeader class="text-center">
-                    <CardTitle class="text-xl">Join the Fleet</CardTitle>
-                    <CardDescription> Sign in or create your account with EVE Online to start mapping wormhole systems </CardDescription>
-                </CardHeader>
-                <CardContent class="space-y-6">
-                    <!-- Access Denied Error -->
+            <!-- Login card, styled like a panel on the map -->
+            <div class="auth-card">
+                <MapPanelHeader>
+                    wormhole.systems · sign in
+                    <template #actions>
+                        <span class="flex items-center gap-1.5">
+                            <span class="size-2 rounded-full bg-hostile/70" />
+                            <span class="size-2 rounded-full bg-active/70" />
+                            <span class="size-2 rounded-full bg-empty/70" />
+                        </span>
+                    </template>
+                </MapPanelHeader>
+                <div class="flex flex-col gap-3 p-6 sm:p-8">
+                    <p class="mb-3 text-center text-sm leading-6 text-muted-foreground">
+                        Sign in or create your account with EVE Online to start mapping wormhole space.
+                    </p>
+
                     <div
                         v-if="error"
-                        class="rounded-md border border-red-500/50 bg-red-500/10 p-3 text-center text-sm text-red-600 dark:text-red-500"
+                        class="rounded border border-red-500/50 bg-red-500/10 px-3 py-2.5 text-center text-sm text-red-600 dark:text-red-400"
                     >
                         {{ error }}
                     </div>
 
-                    <!-- EVE Online SSO Button -->
-                    <Button asChild class="w-full" size="lg">
+                    <Button asChild size="lg">
                         <a :href="Eve.show().url" class="flex items-center justify-center gap-3">
                             <LockIcon />
                             Sign in with EVE Online
                         </a>
                     </Button>
-                    <Separator />
-                    <Button asChild class="w-full" size="lg" variant="outline">
+                    <Button asChild size="lg" variant="outline">
                         <a :href="Eve.show({ query: { without_scopes: true } }).url" class="flex items-center justify-center gap-3">
                             <LockIcon />
                             Sign in without scopes
                         </a>
                     </Button>
 
-                    <!-- Info Section -->
-                    <div class="text-center text-sm text-muted-foreground">
-                        <p>Secure authentication through CCP's official EVE Online SSO</p>
-                    </div>
-                </CardContent>
-            </Card>
+                    <p class="mt-3 text-center font-mono text-[10px] tracking-wider text-muted-foreground/70 uppercase">
+                        ESI-secure · Official EVE Online SSO · Free to use
+                    </p>
+                </div>
+            </div>
 
             <!-- Footer -->
-            <div class="mt-8 text-center text-xs text-muted-foreground">
+            <div class="mt-8 text-center font-mono text-[10px] tracking-wider text-muted-foreground/60 uppercase">
                 <p>© {{ currentYear }} WormholeSystems</p>
                 <p class="mt-1">EVE Online and the EVE logo are trademarks of CCP hf.</p>
             </div>
@@ -85,4 +91,38 @@ const currentYear = format(new UTCDate(), 'yyyy');
     <Notifications />
 </template>
 
-<style scoped></style>
+<style scoped>
+/* Same elevated surface as the landing page's section cards. */
+.auth-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: 0.25rem;
+    border: 1px solid var(--color-neutral-300);
+    background: var(--color-white);
+    box-shadow: 0 20px 45px -20px rgb(0 0 0 / 0.35);
+}
+
+.dark .auth-card {
+    border-color: var(--color-neutral-700);
+    background: var(--color-neutral-900);
+    box-shadow: 0 20px 45px -20px rgb(0 0 0 / 0.8);
+}
+
+/* Dotted map canvas with a soft orange glow, fading out toward the edges so
+   the card sits on a patch of "map" in the middle of the page. */
+.login-backdrop {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        radial-gradient(40rem 28rem at 50% 40%, color-mix(in oklab, var(--color-orange-400) 7%, transparent), transparent 70%),
+        radial-gradient(circle, var(--grid) 1px, transparent 1px);
+    background-size:
+        auto,
+        28px 28px;
+    -webkit-mask-image: radial-gradient(52rem 40rem at 50% 45%, #000 35%, transparent 78%);
+    mask-image: radial-gradient(52rem 40rem at 50% 45%, #000 35%, transparent 78%);
+}
+</style>


### PR DESCRIPTION
Restyles the login page to match the app's dark panel look.

- Login card uses the elevated panel surface with MapPanelHeader chrome and status dots
- Dotted map canvas backdrop with a soft orange glow behind the card
- Mono uppercase labels for the brand line, ESI note, and footer
- Bare logo linking back to the landing page