### PR TITLE
ci: run phpstan in the quality workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Run Pint
         run: vendor/bin/pint
 
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --no-progress --memory-limit=2G
+
       - name: Format Frontend
         run: npm run format
 

--- a/app/Http/Controllers/MapSearchController.php
+++ b/app/Http/Controllers/MapSearchController.php
@@ -13,6 +13,7 @@ use App\Models\Map;
 use App\Models\MapSolarsystemDetails;
 use App\Models\User;
 use App\Models\WormholeSystemThreat;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
@@ -48,7 +49,7 @@ final class MapSearchController extends Controller
     /**
      * EVE ids are unique across entity types, so entity_id alone identifies an organisation.
      *
-     * @return Collection<int, Collection<int, WormholeSystemThreat>>
+     * @return Collection<int, EloquentCollection<int, WormholeSystemThreat>>
      */
     private function threats(Map $map, string $needle, string $contains, string $prefix): Collection
     {
@@ -75,6 +76,7 @@ final class MapSearchController extends Controller
             ->orderByDesc('top_entities.total_kills')
             ->get()
             ->groupBy('entity_id')
+            ->toBase()
             ->values();
     }
 

--- a/app/Http/Resources/MapThreatSearchSystemResource.php
+++ b/app/Http/Resources/MapThreatSearchSystemResource.php
@@ -10,6 +10,8 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
  * @mixin WormholeSystemThreat
+ *
+ * @property string|null $occupier_alias Subquery alias selected by the threat search query.
  */
 final class MapThreatSearchSystemResource extends JsonResource
 {


### PR DESCRIPTION
Adds PHPStan to the lint workflow so type errors fail CI.

- New workflow step running vendor/bin/phpstan analyse
- Fixes the two existing findings: accurate collection generics in the threat search and a documented occupier_alias property on the search resource