### PR TITLE
feat: demote impossible signatures in the jump prompt

### DIFF
--- a/resources/js/components/map/MapStatusBar.vue
+++ b/resources/js/components/map/MapStatusBar.vue
@@ -325,6 +325,7 @@ const settingsUrl = computed(() => {
         v-model:open="show_signature_modal"
         :origin-map-solarsystem="origin_map_solarsystem"
         :target-solarsystem-name="targetSolarsystemName"
+        :target-solarsystem-class="target_solarsystem?.class ?? null"
         :signatures="signatures"
         :suggested-alias="suggested_alias"
         @select-signature="handleSelectSignature"

--- a/resources/js/components/map/TrackingSignatureDialog.vue
+++ b/resources/js/components/map/TrackingSignatureDialog.vue
@@ -9,9 +9,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useShowMap } from '@/composables/useShowMap';
 import { Data } from '@/lib/data';
+import { signatureCanLeadToClass } from '@/lib/signatureCompatibility';
 import { updateMapUserSettings } from '@/map/api';
 import { TMapSolarsystem } from '@/pages/maps';
-import { TLifetimeStatus, TMassStatus, TSignature } from '@/types/models';
+import { TLifetimeStatus, TMassStatus, TSignature, TStringedSolarsystemClass } from '@/types/models';
 import { UTCDate } from '@date-fns/utc';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { AcceptableValue } from 'reka-ui';
@@ -20,6 +21,7 @@ import { computed, ref, watch } from 'vue';
 const props = defineProps<{
     originMapSolarsystem: TMapSolarsystem | null;
     targetSolarsystemName: string | null;
+    targetSolarsystemClass?: TStringedSolarsystemClass | null;
     signatures: TSignature[] | null | undefined;
     suggestedAlias?: string | null;
 }>();
@@ -47,6 +49,17 @@ const filtered = computed(() => {
         return sig.includes(search.value) || type.includes(search.value) || rawType.includes(search.value);
     });
 });
+
+// Signatures whose assigned type can lead to the jumped-to system come first;
+// the rest (wrong destination class, non-wormhole sites) are demoted to a
+// clearly separated section but stay selectable in case a type was mis-assigned.
+const likelyOptions = computed(() => filtered.value.filter((signature) => signatureCanLeadToClass(signature, props.targetSolarsystemClass)));
+const unlikelyOptions = computed(() => filtered.value.filter((signature) => !signatureCanLeadToClass(signature, props.targetSolarsystemClass)));
+
+const sections = computed(() => [
+    { key: 'likely', label: null, options: likelyOptions.value },
+    { key: 'unlikely', label: 'Unlikely · leads elsewhere', options: unlikelyOptions.value },
+]);
 
 const open = defineModel<boolean>('open', { required: true });
 
@@ -150,22 +163,31 @@ function formatDate(date: string) {
                         <div class="text-muted-foreground">—</div>
                         <div class="text-right text-xs text-muted-foreground">—</div>
                     </label>
-                    <label
-                        v-for="option in filtered"
-                        :key="option.id"
-                        class="col-span-4 grid grid-cols-subgrid items-center-safe p-1.5 text-left text-xs data-connected:opacity-50"
-                        :data-connected="Data(Boolean(option.map_connection_id))"
-                    >
-                        <RadioGroupItem :value="option.id" />
-                        <div class="font-medium">{{ option.signature_id }}</div>
-                        <WormholeOption :wormhole="option.signature_type" v-if="option.signature_type" />
-                        <div class="text-muted-foreground" v-else-if="option.raw_type_name">{{ option.raw_type_name }}</div>
-                        <div class="text-muted-foreground" v-else-if="option.map_connection_id">Already connected</div>
-                        <div class="text-muted-foreground" v-else>Unknown</div>
-                        <div class="text-right text-xs text-muted-foreground">
-                            {{ option.created_at ? formatDate(option.created_at) : 'Unknown' }}
+                    <template v-for="section in sections" :key="section.key">
+                        <div
+                            v-if="section.label && section.options.length"
+                            class="col-span-4 bg-muted/30 p-1.5 font-mono text-[10px] tracking-wider text-muted-foreground uppercase"
+                        >
+                            {{ section.label }}
                         </div>
-                    </label>
+                        <label
+                            v-for="option in section.options"
+                            :key="option.id"
+                            class="col-span-4 grid grid-cols-subgrid items-center-safe p-1.5 text-left text-xs data-connected:opacity-50 data-demoted:opacity-60"
+                            :data-connected="Data(Boolean(option.map_connection_id))"
+                            :data-demoted="Data(section.key === 'unlikely')"
+                        >
+                            <RadioGroupItem :value="option.id" />
+                            <div class="font-medium">{{ option.signature_id }}</div>
+                            <WormholeOption :wormhole="option.signature_type" v-if="option.signature_type" />
+                            <div class="text-muted-foreground" v-else-if="option.raw_type_name">{{ option.raw_type_name }}</div>
+                            <div class="text-muted-foreground" v-else-if="option.map_connection_id">Already connected</div>
+                            <div class="text-muted-foreground" v-else>Unknown</div>
+                            <div class="text-right text-xs text-muted-foreground">
+                                {{ option.created_at ? formatDate(option.created_at) : 'Unknown' }}
+                            </div>
+                        </label>
+                    </template>
                 </RadioGroup>
                 <div class="grid gap-3">
                     <div class="grid gap-1.5">

--- a/resources/js/composables/signatures/useTracking.ts
+++ b/resources/js/composables/signatures/useTracking.ts
@@ -6,6 +6,7 @@ import { useStaticData } from '@/composables/useStaticData';
 import { useTrackingSystems } from '@/composables/useTrackingSystems';
 import { suggestAlias } from '@/lib/alias';
 import { formatBookmarkName } from '@/lib/bookmark';
+import { signatureCanLeadToClass } from '@/lib/signatureCompatibility';
 import { isWormholeSystem } from '@/lib/solarsystem';
 import { createTracking, updateMapUserSettings, useMapSolarsystems } from '@/map/api';
 import { TLifetimeStatus, TMassStatus, TSignature } from '@/types/models';
@@ -27,7 +28,12 @@ export function useTracking() {
     const { origin_map_solarsystem, target_solarsystem, update } = useTrackingSystems();
 
     const show_signature_modal = ref(false);
-    const signatures = computed(() => origin_map_solarsystem.value?.signatures?.toSorted(sortSignatures).filter(isPossibleSignature));
+    // All of the origin's signatures; the dialog demotes the ones that cannot
+    // lead to the target instead of hiding them.
+    const signatures = computed(() => origin_map_solarsystem.value?.signatures?.toSorted(sortSignatures));
+    const possible_signatures = computed(
+        () => signatures.value?.filter((signature) => signatureCanLeadToClass(signature, target_solarsystem.value?.class)) ?? [],
+    );
     const existing_map_solarsystem = computed(() => map_solarsystems.value.find((s) => s.solarsystem_id === target_solarsystem.value?.id));
     const existing_connection = computed(() => {
         if (!existing_map_solarsystem.value) return null;
@@ -96,18 +102,10 @@ export function useTracking() {
         return a.signature_id?.localeCompare(b.signature_id);
     }
 
-    function isPossibleSignature(signature: TSignature): boolean {
-        if (!signature.signature_type_id) return true;
-        if (!target_solarsystem.value) return true;
-        const solarsystem_class = target_solarsystem.value.class;
-        if (signature.signature_type?.target_class === solarsystem_class) return true;
-        return signature.signature_type?.target_class === null;
-    }
-
     function performJump() {
         if (existing_connection.value?.map_connection_id) return;
         const gate_connected = isGateConnected(origin_map_solarsystem.value?.solarsystem_id, target_solarsystem.value?.id);
-        if (gate_connected || !signatures.value?.length || !map_user_settings.value.prompt_for_signature_enabled) {
+        if (gate_connected || !possible_signatures.value.length || !map_user_settings.value.prompt_for_signature_enabled) {
             return createTracking(origin_map_solarsystem.value!.id, target_solarsystem.value!.id);
         }
 

--- a/resources/js/lib/signatureCompatibility.spec.ts
+++ b/resources/js/lib/signatureCompatibility.spec.ts
@@ -1,0 +1,49 @@
+import { signatureCanLeadToClass } from '@/lib/signatureCompatibility';
+import type { TSignature, TSignatureCategory, TSignatureType, TStringedSolarsystemClass } from '@/types/models';
+import { describe, expect, it } from 'vitest';
+
+function signature(overrides: { categoryCode?: string; targetClass?: TStringedSolarsystemClass | 'unknown' | null; hasType?: boolean }): TSignature {
+    const { categoryCode, targetClass = null, hasType = targetClass !== null } = overrides;
+
+    return {
+        id: 1,
+        signature_id: 'ABC-123',
+        signature_category: categoryCode ? ({ id: 1, name: categoryCode, code: categoryCode } as TSignatureCategory) : null,
+        signature_type: hasType ? ({ id: 1, name: 'Test', signature: 'X702', target_class: targetClass } as TSignatureType) : null,
+    } as TSignature;
+}
+
+describe('signatureCanLeadToClass', () => {
+    it('accepts signatures without any category or type', () => {
+        expect(signatureCanLeadToClass(signature({}), '4')).toBe(true);
+    });
+
+    it('rejects signatures categorised as non-wormhole sites', () => {
+        expect(signatureCanLeadToClass(signature({ categoryCode: 'gas' }), '4')).toBe(false);
+    });
+
+    it('accepts wormhole types leading to the target class', () => {
+        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: '4' }), '4')).toBe(true);
+    });
+
+    it('rejects wormhole types leading to a different class', () => {
+        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'n' }), '4')).toBe(false);
+    });
+
+    it('accepts wormhole types with an unknown destination', () => {
+        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'unknown' }), '4')).toBe(true);
+    });
+
+    it('accepts typed wormholes when the target class is not known', () => {
+        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'n' }), null)).toBe(true);
+    });
+
+    it('accepts wormhole-category signatures without a resolved type', () => {
+        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', hasType: false }), 'h')).toBe(true);
+    });
+
+    it('matches known-space classes exactly', () => {
+        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'h' }), 'h')).toBe(true);
+        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'h' }), 'l')).toBe(false);
+    });
+});

--- a/resources/js/lib/signatureCompatibility.ts
+++ b/resources/js/lib/signatureCompatibility.ts
@@ -1,0 +1,29 @@
+import type { TSignature, TStringedSolarsystemClass } from '@/types/models';
+
+/**
+ * Whether a scanned signature could be the wormhole that led into a system of
+ * the given class.
+ *
+ * A signature categorised as anything other than a wormhole cannot be a
+ * connection at all. A wormhole type with a concrete destination class only
+ * fits that exact class — jumping a "leads to Nullsec" hole cannot land you in
+ * a C4. Unscanned signatures, unresolved types, and types with an unknown
+ * destination (e.g. a bare K162) can always fit.
+ */
+export function signatureCanLeadToClass(signature: TSignature, targetClass: TStringedSolarsystemClass | null | undefined): boolean {
+    const categoryCode = signature.signature_category?.code;
+    if (categoryCode && categoryCode !== 'wormhole') {
+        return false;
+    }
+
+    const destinationClass = signature.signature_type?.target_class;
+    if (!destinationClass || destinationClass === 'unknown') {
+        return true;
+    }
+
+    if (!targetClass) {
+        return true;
+    }
+
+    return destinationClass === targetClass;
+}


### PR DESCRIPTION
Pre-sorts the "which signature did you jump" prompt by destination class.

- Signatures whose assigned wormhole type cannot lead to the jumped-to system (wrong class) and non-wormhole sites move to a separated Unlikely section instead of being hidden
- Demoted options stay selectable in case a signature was mistyped
- Types with an unknown destination are no longer hidden from the prompt
- The prompt is still skipped when no signature can possibly match