### PR TITLE
feat: overhaul the tracking signature jump prompt

### DIFF
--- a/app/Actions/MapConnections/CreateMapConnectionAction.php
+++ b/app/Actions/MapConnections/CreateMapConnectionAction.php
@@ -26,11 +26,11 @@ final readonly class CreateMapConnectionAction
         /* A known wormhole type dictates the ship size regardless of what the
          * caller passed; the hole's physics are not a matter of preference.
          */
-        $wormhole_ship_size = ShipSize::fromJumpMass(
-            Wormhole::query()->find($data['wormhole_id'] ?? null)?->maximum_jump_mass
-        );
-        if ($wormhole_ship_size instanceof ShipSize) {
-            $data['ship_size'] = $wormhole_ship_size;
+        if (isset($data['wormhole_id'])) {
+            $wormhole_ship_size = ShipSize::fromJumpMass(Wormhole::query()->whereKey($data['wormhole_id'])->value('maximum_jump_mass'));
+            if ($wormhole_ship_size instanceof ShipSize) {
+                $data['ship_size'] = $wormhole_ship_size;
+            }
         }
 
         $map_connection = MapConnection::create([

--- a/app/Actions/MapConnections/CreateMapConnectionAction.php
+++ b/app/Actions/MapConnections/CreateMapConnectionAction.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Actions\MapConnections;
 
+use App\Enums\ShipSize;
 use App\Models\MapConnection;
 use App\Models\MapSolarsystem;
+use App\Models\Wormhole;
 use App\Support\Broadcasting\MapBroadcaster;
 
 final readonly class CreateMapConnectionAction
@@ -20,6 +22,16 @@ final readonly class CreateMapConnectionAction
         $map_id = MapSolarsystem::query()
             ->where('id', $data['from_map_solarsystem_id'])
             ->value('map_id');
+
+        /* A known wormhole type dictates the ship size regardless of what the
+         * caller passed; the hole's physics are not a matter of preference.
+         */
+        $wormhole_ship_size = ShipSize::fromJumpMass(
+            Wormhole::query()->find($data['wormhole_id'] ?? null)?->maximum_jump_mass
+        );
+        if ($wormhole_ship_size instanceof ShipSize) {
+            $data['ship_size'] = $wormhole_ship_size;
+        }
 
         $map_connection = MapConnection::create([
             ...$data,

--- a/app/Actions/MapConnections/SyncConnectionShipSizeAction.php
+++ b/app/Actions/MapConnections/SyncConnectionShipSizeAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\MapConnections;
+
+use App\Enums\ShipSize;
+use App\Models\Signature;
+
+final readonly class SyncConnectionShipSizeAction
+{
+    /**
+     * Keep a signature's linked connection locked to the ship size dictated by
+     * its identified wormhole type. A no-op for untyped or unlinked signatures.
+     */
+    public function handle(Signature $signature): void
+    {
+        if ($signature->wormhole_id === null || $signature->map_connection_id === null) {
+            return;
+        }
+
+        $signature->unsetRelation('wormhole')->unsetRelation('mapConnection');
+
+        $ship_size = ShipSize::fromWormhole($signature->wormhole);
+        if (! $ship_size instanceof ShipSize) {
+            return;
+        }
+
+        $signature->mapConnection?->update(['ship_size' => $ship_size]);
+    }
+}

--- a/app/Actions/MapConnections/UpdateMapConnectionAction.php
+++ b/app/Actions/MapConnections/UpdateMapConnectionAction.php
@@ -62,13 +62,15 @@ final readonly class UpdateMapConnectionAction
     private function lockedShipSize(MapConnection $mapConnection, MapConnectionData $data): ?ShipSize
     {
         $wormhole_id = $data->wormhole_id instanceof Optional ? $mapConnection->wormhole_id : $data->wormhole_id;
-        $size = ShipSize::fromJumpMass(Wormhole::query()->find($wormhole_id)?->maximum_jump_mass);
-        if ($size instanceof ShipSize) {
-            return $size;
+        if ($wormhole_id !== null) {
+            $size = ShipSize::fromJumpMass(Wormhole::query()->whereKey($wormhole_id)->value('maximum_jump_mass'));
+            if ($size instanceof ShipSize) {
+                return $size;
+            }
         }
 
-        foreach ($mapConnection->signatures as $signature) {
-            $size = ShipSize::fromJumpMass($signature->wormhole?->maximum_jump_mass);
+        foreach ($mapConnection->signatures->whereNotNull('wormhole_id')->loadMissing('wormhole') as $signature) {
+            $size = ShipSize::fromWormhole($signature->wormhole);
             if ($size instanceof ShipSize) {
                 return $size;
             }

--- a/app/Actions/MapConnections/UpdateMapConnectionAction.php
+++ b/app/Actions/MapConnections/UpdateMapConnectionAction.php
@@ -7,7 +7,9 @@ namespace App\Actions\MapConnections;
 use App\Data\MapConnectionData;
 use App\Enums\LifetimeStatus;
 use App\Enums\MassStatus;
+use App\Enums\ShipSize;
 use App\Models\MapConnection;
+use App\Models\Wormhole;
 use App\Support\Broadcasting\MapBroadcaster;
 use Illuminate\Support\Facades\DB;
 use Spatie\LaravelData\Optional;
@@ -26,6 +28,14 @@ final readonly class UpdateMapConnectionAction
 
             $data_array = $data->toArray();
 
+            /* An identified wormhole type locks the ship size: manual changes
+             * (e.g. from a stale client) are overridden by the type's value.
+             */
+            $locked_ship_size = $this->lockedShipSize($mapConnection, $data);
+            if ($locked_ship_size instanceof ShipSize) {
+                $data_array['ship_size'] = $locked_ship_size;
+            }
+
             if (! $data->lifetime instanceof Optional && $mapConnection->lifetime !== $data->lifetime) {
                 $data_array['lifetime_updated_at'] = now();
             }
@@ -42,6 +52,29 @@ final readonly class UpdateMapConnectionAction
 
             return $mapConnection;
         });
+    }
+
+    /**
+     * The ship size dictated by the connection's identified wormhole type: the
+     * connection's own wormhole (incoming update included) or the first linked
+     * signature whose wormhole carries a jump mass. Null when nothing is known.
+     */
+    private function lockedShipSize(MapConnection $mapConnection, MapConnectionData $data): ?ShipSize
+    {
+        $wormhole_id = $data->wormhole_id instanceof Optional ? $mapConnection->wormhole_id : $data->wormhole_id;
+        $size = ShipSize::fromJumpMass(Wormhole::query()->find($wormhole_id)?->maximum_jump_mass);
+        if ($size instanceof ShipSize) {
+            return $size;
+        }
+
+        foreach ($mapConnection->signatures as $signature) {
+            $size = ShipSize::fromJumpMass($signature->wormhole?->maximum_jump_mass);
+            if ($size instanceof ShipSize) {
+                return $size;
+            }
+        }
+
+        return null;
     }
 
     private function syncMassAndLifetime(MapConnection $mapConnection, MapConnectionData $data): void

--- a/app/Actions/Signatures/PasteSignaturesAction.php
+++ b/app/Actions/Signatures/PasteSignaturesAction.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Actions\Signatures;
 
+use App\Actions\MapConnections\SyncConnectionShipSizeAction;
 use App\Data\NewSignatureData;
 use App\Data\RawSignatureData;
 use App\Data\SignaturesData;
-use App\Enums\ShipSize;
 use App\Models\MapSolarsystem;
 use App\Models\Signature;
 use App\Models\SignatureCategory;
@@ -26,6 +26,7 @@ final readonly class PasteSignaturesAction
         public StoreSignatureAction $storeSignatureAction,
         public UpdateSignatureAction $updateSignatureAction,
         private MapBroadcaster $mapBroadcaster,
+        private SyncConnectionShipSizeAction $syncConnectionShipSizeAction,
     ) {
         $this->wormholeCategory = SignatureCategory::query()->firstWhere('code', \App\Enums\SignatureCategory::Wormhole);
     }
@@ -83,7 +84,7 @@ final readonly class PasteSignaturesAction
                     'raw_type_name' => $raw_type_name,
                 ]);
 
-                $this->syncConnectionShipSize($existing_signature);
+                $this->syncConnectionShipSizeAction->handle($existing_signature);
             });
 
             // A paste of N signatures emits a single counts event for the system.
@@ -113,22 +114,6 @@ final readonly class PasteSignaturesAction
         }
 
         return null;
-    }
-
-    /**
-     * An identified wormhole type dictates the linked connection's ship size,
-     * mirroring the sync in UpdateSignatureAction.
-     */
-    private function syncConnectionShipSize(Signature $signature): void
-    {
-        $signature->refresh();
-
-        $wormhole_ship_size = ShipSize::fromJumpMass($signature->wormhole?->maximum_jump_mass);
-        if (! $wormhole_ship_size instanceof ShipSize || $signature->mapConnection === null) {
-            return;
-        }
-
-        $signature->mapConnection->update(['ship_size' => $wormhole_ship_size]);
     }
 
     private function getNewWormholeId(?int $signature_type_id): ?int

--- a/app/Actions/Signatures/PasteSignaturesAction.php
+++ b/app/Actions/Signatures/PasteSignaturesAction.php
@@ -7,6 +7,7 @@ namespace App\Actions\Signatures;
 use App\Data\NewSignatureData;
 use App\Data\RawSignatureData;
 use App\Data\SignaturesData;
+use App\Enums\ShipSize;
 use App\Models\MapSolarsystem;
 use App\Models\Signature;
 use App\Models\SignatureCategory;
@@ -81,6 +82,8 @@ final readonly class PasteSignaturesAction
                     'wormhole_id' => $wormhole_id,
                     'raw_type_name' => $raw_type_name,
                 ]);
+
+                $this->syncConnectionShipSize($existing_signature);
             });
 
             // A paste of N signatures emits a single counts event for the system.
@@ -110,6 +113,22 @@ final readonly class PasteSignaturesAction
         }
 
         return null;
+    }
+
+    /**
+     * An identified wormhole type dictates the linked connection's ship size,
+     * mirroring the sync in UpdateSignatureAction.
+     */
+    private function syncConnectionShipSize(Signature $signature): void
+    {
+        $signature->refresh();
+
+        $wormhole_ship_size = ShipSize::fromJumpMass($signature->wormhole?->maximum_jump_mass);
+        if (! $wormhole_ship_size instanceof ShipSize || $signature->mapConnection === null) {
+            return;
+        }
+
+        $signature->mapConnection->update(['ship_size' => $wormhole_ship_size]);
     }
 
     private function getNewWormholeId(?int $signature_type_id): ?int

--- a/app/Actions/Signatures/StoreSignatureAction.php
+++ b/app/Actions/Signatures/StoreSignatureAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Signatures;
 
+use App\Actions\MapConnections\SyncConnectionShipSizeAction;
 use App\Data\NewSignatureData;
 use App\Events\Signatures\SignatureCreatedEvent;
 use App\Models\MapSolarsystem;
@@ -16,7 +17,10 @@ use Throwable;
 
 final readonly class StoreSignatureAction
 {
-    public function __construct(private MapBroadcaster $mapBroadcaster) {}
+    public function __construct(
+        private MapBroadcaster $mapBroadcaster,
+        private SyncConnectionShipSizeAction $syncConnectionShipSizeAction,
+    ) {}
 
     /**
      * Store a signature. $without_signatures_changed_event lets bulk callers (paste) suppress
@@ -43,6 +47,8 @@ final readonly class StoreSignatureAction
                 'wormhole_id' => $wormhole_id,
                 'raw_type_name' => $raw_type_name,
             ]);
+
+            $this->syncConnectionShipSizeAction->handle($signature);
 
             broadcast(new SignatureCreatedEvent($mapSolarsystem->map_id))->toOthers();
 

--- a/app/Actions/Signatures/UpdateSignatureAction.php
+++ b/app/Actions/Signatures/UpdateSignatureAction.php
@@ -7,6 +7,7 @@ namespace App\Actions\Signatures;
 use App\Data\SignatureData;
 use App\Enums\LifetimeStatus;
 use App\Enums\MassStatus;
+use App\Enums\ShipSize;
 use App\Events\Signatures\SignatureUpdatedEvent;
 use App\Models\Signature;
 use App\Models\SignatureType;
@@ -56,6 +57,15 @@ final readonly class UpdateSignatureAction
 
         $connectionUpdateData = ['mass_status' => $mass];
         $signatureUpdateData = ['mass_status' => $mass];
+
+        /* An identified wormhole type dictates the connection's ship size:
+         * whenever the signature carries one, the connection is kept in sync.
+         */
+        $signature->unsetRelation('wormhole');
+        $wormhole_ship_size = ShipSize::fromJumpMass($signature->wormhole?->maximum_jump_mass);
+        if ($wormhole_ship_size instanceof ShipSize) {
+            $connectionUpdateData['ship_size'] = $wormhole_ship_size;
+        }
 
         // Only update lifetime and timestamp if lifetime actually changed
         if ($signature->mapConnection->lifetime !== $lifetime) {

--- a/app/Actions/Signatures/UpdateSignatureAction.php
+++ b/app/Actions/Signatures/UpdateSignatureAction.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Actions\Signatures;
 
+use App\Actions\MapConnections\SyncConnectionShipSizeAction;
 use App\Data\SignatureData;
 use App\Enums\LifetimeStatus;
 use App\Enums\MassStatus;
-use App\Enums\ShipSize;
 use App\Events\Signatures\SignatureUpdatedEvent;
 use App\Models\Signature;
 use App\Models\SignatureType;
@@ -18,7 +18,10 @@ use Throwable;
 
 final readonly class UpdateSignatureAction
 {
-    public function __construct(private MapBroadcaster $mapBroadcaster) {}
+    public function __construct(
+        private MapBroadcaster $mapBroadcaster,
+        private SyncConnectionShipSizeAction $syncConnectionShipSizeAction,
+    ) {}
 
     /**
      * @throws Throwable
@@ -37,6 +40,7 @@ final readonly class UpdateSignatureAction
             $signature->update($updateData);
 
             $this->syncMassAndLifetime($signature, $data);
+            $this->syncConnectionShipSizeAction->handle($signature);
 
             broadcast(new SignatureUpdatedEvent($signature->mapSolarsystem->map_id))->toOthers();
 
@@ -57,15 +61,6 @@ final readonly class UpdateSignatureAction
 
         $connectionUpdateData = ['mass_status' => $mass];
         $signatureUpdateData = ['mass_status' => $mass];
-
-        /* An identified wormhole type dictates the connection's ship size:
-         * whenever the signature carries one, the connection is kept in sync.
-         */
-        $signature->unsetRelation('wormhole');
-        $wormhole_ship_size = ShipSize::fromJumpMass($signature->wormhole?->maximum_jump_mass);
-        if ($wormhole_ship_size instanceof ShipSize) {
-            $connectionUpdateData['ship_size'] = $wormhole_ship_size;
-        }
 
         // Only update lifetime and timestamp if lifetime actually changed
         if ($signature->mapConnection->lifetime !== $lifetime) {

--- a/app/Actions/Tracking/StoreTrackingAction.php
+++ b/app/Actions/Tracking/StoreTrackingAction.php
@@ -281,27 +281,14 @@ final readonly class StoreTrackingAction
             ->value('id');
     }
 
-    /**
-     * The size dictated by the signature's identified wormhole type. When it
-     * is known it wins over every other source, because the hole's physics
-     * are not a matter of preference.
-     */
     private function getWormholeShipSize(?Signature $signature): ?ShipSize
     {
-        if (! $signature instanceof Signature) {
-            return null;
-        }
-
-        return ShipSize::fromJumpMass($signature->wormhole?->maximum_jump_mass);
+        return ShipSize::fromWormhole($signature?->wormhole);
     }
 
     private function getShipSizeForSignature(?Signature $signature): ?ShipSize
     {
-        if (! $signature instanceof Signature) {
-            return null;
-        }
-
-        return $signature->ship_size;
+        return $signature?->ship_size;
     }
 
     private function getMassStatusForSignature(?Signature $signature): MassStatus

--- a/app/Actions/Tracking/StoreTrackingAction.php
+++ b/app/Actions/Tracking/StoreTrackingAction.php
@@ -106,7 +106,7 @@ final readonly class StoreTrackingAction
                     'to_map_solarsystem_id' => $target_map_solarsystem->id,
                     'wormhole_id' => null,
                     'mass_status' => $mass_status,
-                    'ship_size' => $ship_size ?? ShipSize::Large,
+                    'ship_size' => $data->ship_size ?? $this->getShipSizeForSignature($signature) ?? $ship_size ?? ShipSize::Large,
                     'lifetime' => $lifetime_status,
                 ]
             );
@@ -279,6 +279,15 @@ final readonly class StoreTrackingAction
         return SignatureCategory::query()
             ->where('code', SignatureCategoryEnum::Wormhole)
             ->value('id');
+    }
+
+    private function getShipSizeForSignature(?Signature $signature): ?ShipSize
+    {
+        if (! $signature instanceof Signature) {
+            return null;
+        }
+
+        return $signature->ship_size;
     }
 
     private function getMassStatusForSignature(?Signature $signature): MassStatus

--- a/app/Actions/Tracking/StoreTrackingAction.php
+++ b/app/Actions/Tracking/StoreTrackingAction.php
@@ -106,7 +106,7 @@ final readonly class StoreTrackingAction
                     'to_map_solarsystem_id' => $target_map_solarsystem->id,
                     'wormhole_id' => null,
                     'mass_status' => $mass_status,
-                    'ship_size' => $data->ship_size ?? $this->getShipSizeForSignature($signature) ?? $ship_size ?? ShipSize::Large,
+                    'ship_size' => $this->getWormholeShipSize($signature) ?? $data->ship_size ?? $this->getShipSizeForSignature($signature) ?? $ship_size ?? ShipSize::Large,
                     'lifetime' => $lifetime_status,
                 ]
             );
@@ -279,6 +279,20 @@ final readonly class StoreTrackingAction
         return SignatureCategory::query()
             ->where('code', SignatureCategoryEnum::Wormhole)
             ->value('id');
+    }
+
+    /**
+     * The size dictated by the signature's identified wormhole type. When it
+     * is known it wins over every other source, because the hole's physics
+     * are not a matter of preference.
+     */
+    private function getWormholeShipSize(?Signature $signature): ?ShipSize
+    {
+        if (! $signature instanceof Signature) {
+            return null;
+        }
+
+        return ShipSize::fromJumpMass($signature->wormhole?->maximum_jump_mass);
     }
 
     private function getShipSizeForSignature(?Signature $signature): ?ShipSize

--- a/app/Data/TrackingData.php
+++ b/app/Data/TrackingData.php
@@ -7,6 +7,7 @@ namespace App\Data;
 use App\Enums\LifetimeStatus;
 use App\Enums\MassStatus;
 use App\Enums\Permission;
+use App\Enums\ShipSize;
 use App\Models\Map;
 use App\Models\User;
 use Illuminate\Container\Attributes\CurrentUser;
@@ -29,6 +30,7 @@ final class TrackingData extends Data
         public ?string $alias = null,
         public ?LifetimeStatus $lifetime = null,
         public ?MassStatus $mass_status = null,
+        public ?ShipSize $ship_size = null,
     ) {}
 
     /**

--- a/app/Enums/ShipSize.php
+++ b/app/Enums/ShipSize.php
@@ -10,4 +10,22 @@ enum ShipSize: string
     case Medium = 'medium';
     case Large = 'large';
     case ExtraLarge = 'xlarge';
+
+    /**
+     * The largest ship class that fits through a wormhole with the given
+     * maximum jump mass, using the standard 5M / 62M / <2B / 2B+ kg tiers.
+     * Unknown or zero masses resolve to null.
+     *
+     * Mirrored on the frontend in resources/js/lib/shipSize.ts.
+     */
+    public static function fromJumpMass(?float $maximum_jump_mass): ?self
+    {
+        return match (true) {
+            $maximum_jump_mass === null, $maximum_jump_mass <= 0.0 => null,
+            $maximum_jump_mass <= 5_000_000.0 => self::Frigate,
+            $maximum_jump_mass <= 62_000_000.0 => self::Medium,
+            $maximum_jump_mass < 2_000_000_000.0 => self::Large,
+            default => self::ExtraLarge,
+        };
+    }
 }

--- a/app/Enums/ShipSize.php
+++ b/app/Enums/ShipSize.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
+use App\Models\Wormhole;
+
 enum ShipSize: string
 {
     case Frigate = 'frigate';
@@ -18,6 +20,16 @@ enum ShipSize: string
      *
      * Mirrored on the frontend in resources/js/lib/shipSize.ts.
      */
+    /**
+     * The size dictated by an identified wormhole type. When it is known it
+     * wins over every other source, because the hole's physics are not a
+     * matter of preference.
+     */
+    public static function fromWormhole(?Wormhole $wormhole): ?self
+    {
+        return $wormhole instanceof Wormhole ? self::fromJumpMass($wormhole->maximum_jump_mass) : null;
+    }
+
     public static function fromJumpMass(?float $maximum_jump_mass): ?self
     {
         return match (true) {

--- a/app/Features/MapSettingsFeature.php
+++ b/app/Features/MapSettingsFeature.php
@@ -24,6 +24,7 @@ final readonly class MapSettingsFeature implements ProvidesInertiaProperties
         'security_penalty' => 50,
         'killmail_filter' => 'all',
         'prompt_for_signature_enabled' => false,
+        'preselect_signature_enabled' => false,
         'suggest_alias_enabled' => false,
         'copy_bookmark_enabled' => false,
         'layout_breakpoints' => null,

--- a/app/Http/Requests/UpdateMapUserSettingRequest.php
+++ b/app/Http/Requests/UpdateMapUserSettingRequest.php
@@ -52,6 +52,7 @@ final class UpdateMapUserSettingRequest extends FormRequest
             'killmail_filter' => ['nullable', 'string', Rule::enum(KillmailFilter::class)],
             'introduction_confirmed_at' => ['nullable', 'string', 'date'],
             'prompt_for_signature_enabled' => ['nullable', 'boolean'],
+            'preselect_signature_enabled' => ['boolean'],
             'suggest_alias_enabled' => ['boolean'],
             'copy_bookmark_enabled' => ['boolean'],
             'layout_breakpoints' => ['nullable', 'array'],

--- a/app/Http/Resources/MapUserSettingResource.php
+++ b/app/Http/Resources/MapUserSettingResource.php
@@ -36,6 +36,7 @@ final class MapUserSettingResource extends JsonResource
             'killmail_filter' => $this->killmail_filter,
             'introduction_confirmed_at' => $this->introduction_confirmed_at?->toISOString(),
             'prompt_for_signature_enabled' => $this->prompt_for_signature_enabled,
+            'preselect_signature_enabled' => $this->preselect_signature_enabled ?? false,
             'suggest_alias_enabled' => $this->suggest_alias_enabled,
             'copy_bookmark_enabled' => $this->copy_bookmark_enabled,
             'layout_breakpoints' => $this->layout_breakpoints,

--- a/app/Http/Resources/WormholeResource.php
+++ b/app/Http/Resources/WormholeResource.php
@@ -19,7 +19,6 @@ final class WormholeResource extends JsonResource
             'name' => $this->name,
             'total_mass' => $this->total_mass,
             'maximum_jump_mass' => $this->maximum_jump_mass,
-            'ship_size' => $this->ship_size,
             'maximum_lifetime' => $this->maximum_lifetime,
             'leads_to' => $this->leads_to,
             'signature_strength' => $this->signature_strength,

--- a/app/Models/MapUserSetting.php
+++ b/app/Models/MapUserSetting.php
@@ -30,6 +30,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string|KillmailFilter $killmail_filter
  * @property CarbonImmutable|string|null $introduction_confirmed_at
  * @property bool $prompt_for_signature_enabled
+ * @property bool $preselect_signature_enabled
  * @property bool $suggest_alias_enabled
  * @property bool $copy_bookmark_enabled
  * @property array|null $layout_breakpoints
@@ -80,6 +81,7 @@ final class MapUserSetting extends Model
             'route_use_evescout' => 'boolean',
             'introduction_confirmed_at' => 'immutable_datetime',
             'prompt_for_signature_enabled' => 'boolean',
+            'preselect_signature_enabled' => 'boolean',
             'suggest_alias_enabled' => 'boolean',
             'copy_bookmark_enabled' => 'boolean',
             'layout_breakpoints' => 'array',

--- a/app/Models/Wormhole.php
+++ b/app/Models/Wormhole.php
@@ -15,7 +15,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $name
  * @property float $total_mass
  * @property float $maximum_jump_mass
- * @property string $ship_size
  * @property int $maximum_lifetime
  * @property string $leads_to
  * @property float|null $signature_strength

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -9,6 +9,7 @@ use App\Http\Middleware\TrackUserActivityMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -17,6 +18,11 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         channels: __DIR__.'/../routes/channels.php',
         health: '/up',
+        then: function (): void {
+            if (app()->environment(['local', 'testing'])) {
+                Route::middleware('web')->group(__DIR__.'/../routes/debug.php');
+            }
+        },
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->encryptCookies(except: ['appearance', 'layout', 'sort_preferences']);

--- a/database/migrations/2026_07_17_144813_add_preselect_signature_to_map_user_settings_table.php
+++ b/database/migrations/2026_07_17_144813_add_preselect_signature_to_map_user_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('map_user_settings', function (Blueprint $table): void {
+            $table->boolean('preselect_signature_enabled')->default(false)->after('prompt_for_signature_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('map_user_settings', function (Blueprint $table): void {
+            $table->dropColumn('preselect_signature_enabled');
+        });
+    }
+};

--- a/database/migrations/2026_07_17_171245_drop_ship_size_from_wormholes_table.php
+++ b/database/migrations/2026_07_17_171245_drop_ship_size_from_wormholes_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('wormholes', function (Blueprint $table): void {
+            $table->dropColumn('ship_size');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('wormholes', function (Blueprint $table): void {
+            $table->string('ship_size')->nullable()->index();
+        });
+    }
+};

--- a/resources/js/components/map/MapStatusBar.vue
+++ b/resources/js/components/map/MapStatusBar.vue
@@ -329,6 +329,7 @@ const settingsUrl = computed(() => {
         :target-solarsystem-name="targetSolarsystemName"
         :target-solarsystem-class="target_solarsystem?.class ?? null"
         :map-solarsystems="map_solarsystems"
+        :preselect-first-signature="map_user_settings.preselect_signature_enabled"
         :signatures="signatures"
         :suggested-alias="suggested_alias"
         @select-signature="handleSelectSignature"

--- a/resources/js/components/map/MapStatusBar.vue
+++ b/resources/js/components/map/MapStatusBar.vue
@@ -14,7 +14,7 @@ import { UseMapLayoutReturn } from '@/composables/useMapLayout';
 import usePermission from '@/composables/usePermission';
 import { usePing } from '@/composables/usePing';
 import { useStaticSolarsystem } from '@/composables/useStaticSolarsystems';
-import { updateMapUserSettings } from '@/map/api';
+import { updateMapUserSettings, useMapSolarsystems } from '@/map/api';
 import type { TMap } from '@/pages/maps';
 import type { TMapUserSetting } from '@/types/models';
 import { Link } from '@inertiajs/vue3';
@@ -56,6 +56,8 @@ const {
     target_solarsystem,
     suggested_alias,
 } = useTracking();
+
+const { map_solarsystems } = useMapSolarsystems();
 
 const targetSolarsystemName = computed(() => target_solarsystem.value?.name || currentSolarsystem.value?.name || null);
 
@@ -326,6 +328,7 @@ const settingsUrl = computed(() => {
         :origin-map-solarsystem="origin_map_solarsystem"
         :target-solarsystem-name="targetSolarsystemName"
         :target-solarsystem-class="target_solarsystem?.class ?? null"
+        :map-solarsystems="map_solarsystems"
         :signatures="signatures"
         :suggested-alias="suggested_alias"
         @select-signature="handleSelectSignature"

--- a/resources/js/components/map/TrackingSignatureDialog.spec.ts
+++ b/resources/js/components/map/TrackingSignatureDialog.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import TrackingSignatureDialog from '@/components/map/TrackingSignatureDialog.vue';
-import type { TMapConnection, TMapSolarsystem } from '@/pages/maps';
+import type { TMapConnection, TMapSolarsystem, TWormhole } from '@/pages/maps';
 import type { TSignature } from '@/types/models';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -26,6 +26,7 @@ function sig(input: {
     connectedToId?: number;
     lifetime?: TSignature['lifetime'];
     shipSize?: TSignature['ship_size'];
+    jumpMass?: number;
 }): TSignature {
     const id = nextId++;
 
@@ -40,6 +41,7 @@ function sig(input: {
             : null,
         signature_type: input.targetClass ? { id, name: `X702 - ${input.targetClass}`, signature: 'X702', target_class: input.targetClass } : null,
         signature_category: input.category ? { id, name: input.category, code: input.category } : null,
+        wormhole: input.jumpMass ? ({ id, name: 'X702', maximum_jump_mass: input.jumpMass } as TWormhole) : null,
         lifetime: input.lifetime ?? 'healthy',
         mass_status: null,
         ship_size: input.shipSize ?? null,
@@ -194,5 +196,29 @@ describe('TrackingSignatureDialog', () => {
         await wrapper.vm.$nextTick();
 
         expect(document.body.textContent).toContain('No signatures match');
+    });
+
+    it('locks the ship size to the identified wormhole type', async () => {
+        const wrapper = await mountOpenDialog({
+            signatures: [sig({ signatureId: 'AAA-111', category: 'wormhole', targetClass: '4', jumpMass: 2_000_000_000, shipSize: 'frigate' })],
+            preselectFirstSignature: true,
+        });
+
+        submitForm();
+
+        expect(lastSelection(wrapper)).toMatchObject({ shipSize: 'xlarge' });
+
+        const triggers = [...document.body.querySelectorAll('button')];
+        expect(triggers.some((button) => button.textContent?.includes('Extra Large') && button.hasAttribute('disabled'))).toBe(true);
+    });
+
+    it('keeps the ship size editable for signatures without an identified wormhole', async () => {
+        await mountOpenDialog({
+            signatures: [sig({ signatureId: 'AAA-111', category: 'wormhole', targetClass: '4' })],
+            preselectFirstSignature: true,
+        });
+
+        const triggers = [...document.body.querySelectorAll('button')];
+        expect(triggers.some((button) => button.textContent?.includes('Auto') && !button.hasAttribute('disabled'))).toBe(true);
     });
 });

--- a/resources/js/components/map/TrackingSignatureDialog.spec.ts
+++ b/resources/js/components/map/TrackingSignatureDialog.spec.ts
@@ -1,0 +1,198 @@
+// @vitest-environment happy-dom
+import TrackingSignatureDialog from '@/components/map/TrackingSignatureDialog.vue';
+import type { TMapConnection, TMapSolarsystem } from '@/pages/maps';
+import type { TSignature } from '@/types/models';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/composables/useShowMap', () => ({
+    useShowMap: () => ({ props: { map: { slug: 'test-map' } } }),
+}));
+
+vi.mock('@/map/api', () => ({
+    updateMapUserSettings: vi.fn(),
+}));
+
+const ORIGIN = { id: 1, alias: 'HOME', solarsystem: { name: 'J152820' } } as TMapSolarsystem;
+
+const MAP_SOLARSYSTEMS = [ORIGIN, { id: 2, alias: 'HOME-A', solarsystem: { name: 'J145510' } } as TMapSolarsystem];
+
+let nextId = 1;
+
+function sig(input: {
+    signatureId: string;
+    category?: string;
+    targetClass?: string;
+    connectedToId?: number;
+    lifetime?: TSignature['lifetime'];
+    shipSize?: TSignature['ship_size'];
+}): TSignature {
+    const id = nextId++;
+
+    return {
+        id,
+        signature_id: input.signatureId,
+        signature_type_id: input.targetClass ? id : null,
+        raw_type_name: null,
+        map_connection_id: input.connectedToId ? id : null,
+        map_connection: input.connectedToId
+            ? ({ id, from_map_solarsystem_id: ORIGIN.id, to_map_solarsystem_id: input.connectedToId } as TMapConnection)
+            : null,
+        signature_type: input.targetClass ? { id, name: `X702 - ${input.targetClass}`, signature: 'X702', target_class: input.targetClass } : null,
+        signature_category: input.category ? { id, name: input.category, code: input.category } : null,
+        lifetime: input.lifetime ?? 'healthy',
+        mass_status: null,
+        ship_size: input.shipSize ?? null,
+    } as TSignature;
+}
+
+// Alphabetical likely order: AAA (typed C4, eol, frigate), BBB (unscanned).
+// CCC is connected, DDD leads elsewhere, EEE is a gas site and must not render.
+function makeSignatures(): TSignature[] {
+    nextId = 1;
+    return [
+        sig({ signatureId: 'AAA-111', category: 'wormhole', targetClass: '4', lifetime: 'eol', shipSize: 'frigate' }),
+        sig({ signatureId: 'BBB-222' }),
+        sig({ signatureId: 'CCC-333', category: 'wormhole', targetClass: '4', connectedToId: 2 }),
+        sig({ signatureId: 'DDD-444', category: 'wormhole', targetClass: 'n' }),
+        sig({ signatureId: 'EEE-555', category: 'gas' }),
+    ];
+}
+
+type DialogProps = Partial<InstanceType<typeof TrackingSignatureDialog>['$props']>;
+
+async function mountOpenDialog(props: DialogProps = {}): Promise<VueWrapper> {
+    const wrapper = mount(TrackingSignatureDialog, {
+        props: {
+            open: false,
+            originMapSolarsystem: ORIGIN,
+            targetSolarsystemName: 'J145510',
+            targetSolarsystemClass: '4',
+            signatures: makeSignatures(),
+            mapSolarsystems: MAP_SOLARSYSTEMS,
+            ...props,
+        },
+        global: {
+            // The Disable button's tooltip needs a TooltipProvider; stub it away.
+            stubs: {
+                Tooltip: { template: '<div><slot /></div>' },
+                TooltipTrigger: { template: '<div><slot /></div>' },
+                TooltipContent: { template: '<div><slot /></div>' },
+            },
+        },
+        attachTo: document.body,
+    });
+
+    // Open after mounting so the dialog's open watcher (reset + preselect) runs.
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+
+    return wrapper;
+}
+
+function submitForm(): void {
+    document.body.querySelector('form')!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+}
+
+function lastSelection(wrapper: VueWrapper): Record<string, unknown> {
+    const events = wrapper.emitted('selectSignature')!;
+    return events[events.length - 1][0] as Record<string, unknown>;
+}
+
+function searchInput(): HTMLInputElement {
+    return document.body.querySelector('#tracking-search') as HTMLInputElement;
+}
+
+afterEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+});
+
+describe('TrackingSignatureDialog', () => {
+    it('renders wormhole and unscanned signatures but never site signatures', async () => {
+        await mountOpenDialog();
+
+        const text = document.body.textContent!;
+        expect(text).toContain('AAA-111');
+        expect(text).toContain('BBB-222');
+        expect(text).toContain('CCC-333');
+        expect(text).toContain('DDD-444');
+        expect(text).not.toContain('EEE-555');
+    });
+
+    it('labels the connected and unlikely sections', async () => {
+        await mountOpenDialog();
+
+        const text = document.body.textContent!;
+        expect(text).toContain('Already connected');
+        expect(text).toContain('Unlikely · leads elsewhere');
+    });
+
+    it('shows where an already connected signature leads', async () => {
+        await mountOpenDialog();
+
+        expect(document.body.textContent).toContain('→ HOME-A (J145510)');
+    });
+
+    it('emits the unknown selection when confirmed without a choice', async () => {
+        const wrapper = await mountOpenDialog();
+
+        submitForm();
+
+        expect(lastSelection(wrapper)).toMatchObject({ signatureId: null, lifetime: 'healthy', massStatus: 'fresh', shipSize: null });
+    });
+
+    it('preselects the first likely signature and adopts its values when enabled', async () => {
+        const wrapper = await mountOpenDialog({ preselectFirstSignature: true });
+
+        submitForm();
+
+        expect(lastSelection(wrapper)).toMatchObject({ signatureId: 1, lifetime: 'eol', shipSize: 'frigate' });
+    });
+
+    it('does not preselect anything when the setting is off', async () => {
+        const wrapper = await mountOpenDialog({ preselectFirstSignature: false });
+
+        submitForm();
+
+        expect(lastSelection(wrapper)).toMatchObject({ signatureId: null });
+    });
+
+    it('walks the options with arrow keys from the search field', async () => {
+        const wrapper = await mountOpenDialog();
+
+        searchInput().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+        await wrapper.vm.$nextTick();
+        submitForm();
+
+        expect(lastSelection(wrapper)).toMatchObject({ signatureId: 1 });
+    });
+
+    it('wraps backwards from unknown to the last option', async () => {
+        const wrapper = await mountOpenDialog();
+
+        searchInput().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+        await wrapper.vm.$nextTick();
+        submitForm();
+
+        expect(lastSelection(wrapper)).toMatchObject({ signatureId: 4 });
+    });
+
+    it('filters the list through the search field and shows an empty state', async () => {
+        const wrapper = await mountOpenDialog();
+
+        const input = searchInput();
+        input.value = 'bbb';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await wrapper.vm.$nextTick();
+
+        expect(document.body.textContent).toContain('BBB-222');
+        expect(document.body.textContent).not.toContain('AAA-111');
+
+        input.value = 'zzz';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await wrapper.vm.$nextTick();
+
+        expect(document.body.textContent).toContain('No signatures match');
+    });
+});

--- a/resources/js/components/map/TrackingSignatureDialog.spec.ts
+++ b/resources/js/components/map/TrackingSignatureDialog.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import TrackingSignatureDialog from '@/components/map/TrackingSignatureDialog.vue';
-import type { TMapConnection, TMapSolarsystem, TWormhole } from '@/pages/maps';
+import { MAP_SOLARSYSTEMS, ORIGIN, resetSignatureIds, sig } from '@/components/map/trackingSignatureFixtures';
 import type { TSignature } from '@/types/models';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -13,45 +13,10 @@ vi.mock('@/map/api', () => ({
     updateMapUserSettings: vi.fn(),
 }));
 
-const ORIGIN = { id: 1, alias: 'HOME', solarsystem: { name: 'J152820' } } as TMapSolarsystem;
-
-const MAP_SOLARSYSTEMS = [ORIGIN, { id: 2, alias: 'HOME-A', solarsystem: { name: 'J145510' } } as TMapSolarsystem];
-
-let nextId = 1;
-
-function sig(input: {
-    signatureId: string;
-    category?: string;
-    targetClass?: string;
-    connectedToId?: number;
-    lifetime?: TSignature['lifetime'];
-    shipSize?: TSignature['ship_size'];
-    jumpMass?: number;
-}): TSignature {
-    const id = nextId++;
-
-    return {
-        id,
-        signature_id: input.signatureId,
-        signature_type_id: input.targetClass ? id : null,
-        raw_type_name: null,
-        map_connection_id: input.connectedToId ? id : null,
-        map_connection: input.connectedToId
-            ? ({ id, from_map_solarsystem_id: ORIGIN.id, to_map_solarsystem_id: input.connectedToId } as TMapConnection)
-            : null,
-        signature_type: input.targetClass ? { id, name: `X702 - ${input.targetClass}`, signature: 'X702', target_class: input.targetClass } : null,
-        signature_category: input.category ? { id, name: input.category, code: input.category } : null,
-        wormhole: input.jumpMass ? ({ id, name: 'X702', maximum_jump_mass: input.jumpMass } as TWormhole) : null,
-        lifetime: input.lifetime ?? 'healthy',
-        mass_status: null,
-        ship_size: input.shipSize ?? null,
-    } as TSignature;
-}
-
 // Alphabetical likely order: AAA (typed C4, eol, frigate), BBB (unscanned).
 // CCC is connected, DDD leads elsewhere, EEE is a gas site and must not render.
 function makeSignatures(): TSignature[] {
-    nextId = 1;
+    resetSignatureIds();
     return [
         sig({ signatureId: 'AAA-111', category: 'wormhole', targetClass: '4', lifetime: 'eol', shipSize: 'frigate' }),
         sig({ signatureId: 'BBB-222' }),

--- a/resources/js/components/map/TrackingSignatureDialog.vue
+++ b/resources/js/components/map/TrackingSignatureDialog.vue
@@ -5,18 +5,17 @@ import { Dialog, DialogDescription, DialogFooter, DialogHeader, DialogScrollCont
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useShowMap } from '@/composables/useShowMap';
 import { Data } from '@/lib/data';
-import { signatureCanLeadToClass } from '@/lib/signatureCompatibility';
+import { groupSignatureOptions } from '@/lib/signatureCompatibility';
 import { updateMapUserSettings } from '@/map/api';
 import { TMapSolarsystem } from '@/pages/maps';
-import { TLifetimeStatus, TMassStatus, TSignature, TStringedSolarsystemClass } from '@/types/models';
-import { UTCDate } from '@date-fns/utc';
-import { formatDistanceToNowStrict } from 'date-fns';
+import { TLifetimeStatus, TMassStatus, TShipSize, TSignature, TStringedSolarsystemClass } from '@/types/models';
+import { SearchIcon } from 'lucide-vue-next';
 import { AcceptableValue } from 'reka-ui';
-import { computed, ref, watch } from 'vue';
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue';
 
 const props = defineProps<{
     originMapSolarsystem: TMapSolarsystem | null;
@@ -24,6 +23,8 @@ const props = defineProps<{
     targetSolarsystemClass?: TStringedSolarsystemClass | null;
     signatures: TSignature[] | null | undefined;
     suggestedAlias?: string | null;
+    /** The map's systems, used to name where already-connected signatures lead. */
+    mapSolarsystems?: TMapSolarsystem[];
 }>();
 
 const page = useShowMap();
@@ -50,27 +51,76 @@ const filtered = computed(() => {
     });
 });
 
-// Signatures whose assigned type can lead to the jumped-to system come first;
-// the rest (wrong destination class, non-wormhole sites) are demoted to a
-// clearly separated section but stay selectable in case a type was mis-assigned.
-const likelyOptions = computed(() => filtered.value.filter((signature) => signatureCanLeadToClass(signature, props.targetSolarsystemClass)));
-const unlikelyOptions = computed(() => filtered.value.filter((signature) => !signatureCanLeadToClass(signature, props.targetSolarsystemClass)));
+// Three sections: unmapped signatures that can be the jumped hole, ones already
+// tied to a mapped connection, and ones typed with a destination class that
+// cannot match. Site signatures are dropped entirely. Everything stays
+// selectable in case a signature was mistyped or a connection is stale.
+const groups = computed(() => groupSignatureOptions(filtered.value, props.targetSolarsystemClass));
 
 const sections = computed(() => [
-    { key: 'likely', label: null, options: likelyOptions.value },
-    { key: 'unlikely', label: 'Unlikely · leads elsewhere', options: unlikelyOptions.value },
+    { key: 'likely', label: null, options: groups.value.likely },
+    { key: 'connected', label: 'Already connected', options: groups.value.connected },
+    { key: 'unlikely', label: 'Unlikely · leads elsewhere', options: groups.value.unlikely },
 ]);
+
+const listElement = useTemplateRef<InstanceType<typeof RadioGroup>>('signatureList');
+
+/** All selectable option ids in visual order, starting with the Unknown row. */
+const orderedIds = computed<(number | null)[]>(() => [null, ...sections.value.flatMap((section) => section.options.map((option) => option.id))]);
+
+/**
+ * Arrow keys in the search field walk the visible options without leaving the
+ * field, wrapping at both ends. The checked row is kept scrolled into view.
+ */
+function moveSelection(delta: number): void {
+    const ids = orderedIds.value;
+    if (!ids.length) return;
+
+    const index = ids.indexOf(selectedSignatureId.value);
+    selectedSignatureId.value = ids[(index + delta + ids.length) % ids.length];
+
+    void nextTick(() => {
+        listElement.value?.$el?.querySelector('[data-state="checked"]')?.closest('label')?.scrollIntoView({ block: 'nearest' });
+    });
+}
+
+/** Focus the search field when the dialog opens instead of the first input. */
+function focusSearch(): void {
+    document.getElementById('tracking-search')?.focus();
+}
+
+/** The system on the far side of an already-connected signature's connection. */
+function connectionDestinationLabel(signature: TSignature): string | null {
+    const connection = signature.map_connection;
+    const origin = props.originMapSolarsystem;
+    if (!connection || !origin) return null;
+
+    const destinationId = connection.to_map_solarsystem_id === origin.id ? connection.from_map_solarsystem_id : connection.to_map_solarsystem_id;
+    const destination = props.mapSolarsystems?.find((solarsystem) => solarsystem.id === destinationId);
+    if (!destination) return null;
+
+    return destination.alias ? `${destination.alias} (${destination.solarsystem.name})` : destination.solarsystem.name;
+}
 
 const open = defineModel<boolean>('open', { required: true });
 
 const emit = defineEmits<{
-    selectSignature: [selection: { signatureId: number | null; alias: string | null; lifetime: TLifetimeStatus; massStatus: TMassStatus }];
+    selectSignature: [
+        selection: {
+            signatureId: number | null;
+            alias: string | null;
+            lifetime: TLifetimeStatus;
+            massStatus: TMassStatus;
+            shipSize: TShipSize | null;
+        },
+    ];
 }>();
 
 const selectedSignatureId = ref<number | null>(null);
 const alias = ref('');
 const lifetime = ref<TLifetimeStatus>('healthy');
 const massStatus = ref<TMassStatus>('fresh');
+const shipSize = ref<TShipSize | 'auto'>('auto');
 
 // Reset inputs when the dialog opens. The alias is prefilled with the suggested
 // chain alias (or the target's existing alias when it is already on the map).
@@ -80,11 +130,12 @@ watch(open, (isOpen) => {
         alias.value = props.suggestedAlias ?? '';
         lifetime.value = 'healthy';
         massStatus.value = 'fresh';
+        shipSize.value = 'auto';
     }
 });
 
-// Adopt the signature's lifetime / mass when it carries a meaningful value,
-// otherwise keep whatever the user manually selected.
+// Adopt the signature's lifetime / mass / ship size when it carries a
+// meaningful value, otherwise keep whatever the user manually selected.
 watch(selectedSignatureId, (id) => {
     const signature = props.signatures?.find((s) => s.id === id);
     if (!signature) return;
@@ -94,6 +145,9 @@ watch(selectedSignatureId, (id) => {
     if (signature.mass_status) {
         massStatus.value = signature.mass_status;
     }
+    if (signature.ship_size) {
+        shipSize.value = signature.ship_size;
+    }
 });
 
 function buildSelection(signatureId: number | null) {
@@ -102,6 +156,7 @@ function buildSelection(signatureId: number | null) {
         alias: alias.value.trim() || null,
         lifetime: lifetime.value,
         massStatus: massStatus.value,
+        shipSize: shipSize.value === 'auto' ? null : shipSize.value,
     };
 }
 
@@ -134,77 +189,150 @@ function handleMassStatusChange(value: AcceptableValue) {
     }
 }
 
-function formatDate(date: string) {
-    return formatDistanceToNowStrict(new UTCDate(date)) + ' ago';
+function handleShipSizeChange(value: AcceptableValue) {
+    if (value === 'auto' || value === 'frigate' || value === 'medium' || value === 'large' || value === 'xlarge') {
+        shipSize.value = value;
+    }
 }
+
+/* The same indicators the options carry, mirrored on the closed triggers. */
+const lifetimeMeta: Record<TLifetimeStatus, { label: string; dot: string }> = {
+    healthy: { label: 'Healthy', dot: 'bg-neutral-500' },
+    eol: { label: 'End of Life', dot: 'bg-purple-500' },
+    critical: { label: 'Critical', dot: 'bg-red-500' },
+};
+
+const massMeta: Record<TMassStatus, { label: string; dot: string }> = {
+    fresh: { label: 'Fresh', dot: 'bg-neutral-500' },
+    reduced: { label: 'Reduced', dot: 'bg-amber-500' },
+    critical: { label: 'Critical', dot: 'bg-red-500' },
+};
+
+const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }> = {
+    auto: { label: 'Auto', badge: '·' },
+    frigate: { label: 'Frigate', badge: 'S' },
+    medium: { label: 'Medium', badge: 'M' },
+    large: { label: 'Large', badge: 'L' },
+    xlarge: { label: 'Extra Large', badge: 'XL' },
+};
 </script>
 
 <template>
     <Dialog v-model:open="open" @update:open="handleOpenChange">
-        <DialogScrollContent v-if="originMapSolarsystem && targetSolarsystemName" class="max-w-md translate-y-0">
-            <DialogHeader>
+        <DialogScrollContent
+            v-if="originMapSolarsystem && targetSolarsystemName"
+            class="max-w-lg translate-y-0 gap-0 overflow-hidden p-0"
+            @open-auto-focus.prevent="focusSearch"
+        >
+            <!-- Header -->
+            <DialogHeader class="gap-1.5 border-b border-border/50 bg-muted/30 px-6 py-4 text-left">
                 <DialogTitle>Which signature did you jump?</DialogTitle>
                 <DialogDescription>
                     You jumped from <strong>{{ originSystemLabel }}</strong> to <strong>{{ targetSolarsystemName }}</strong
-                    >. Please select which wormhole connection you used.
+                    >. Select the wormhole connection you used.
                 </DialogDescription>
             </DialogHeader>
             <form @submit.prevent="handleConfirm" class="contents">
-                <Input v-model:model-value="search" placeholder="Search" />
-                <RadioGroup
-                    class="grid max-h-full grid-cols-[auto_auto_auto_1fr] gap-0 gap-x-4 divide-y overflow-y-auto rounded-lg border"
-                    v-model:model-value="selectedSignatureId"
-                    @keydown.enter="handleConfirm"
-                    autofocus
-                >
-                    <label class="col-span-4 grid grid-cols-subgrid items-center-safe p-1.5 text-left text-xs">
-                        <RadioGroupItem :value="null" />
-                        <div class="font-medium">Unknown</div>
-                        <div class="text-muted-foreground">—</div>
-                        <div class="text-right text-xs text-muted-foreground">—</div>
-                    </label>
-                    <template v-for="section in sections" :key="section.key">
-                        <div
-                            v-if="section.label && section.options.length"
-                            class="col-span-4 bg-muted/30 p-1.5 font-mono text-[10px] tracking-wider text-muted-foreground uppercase"
-                        >
-                            {{ section.label }}
+                <!-- Connection details -->
+                <div class="grid gap-3 px-6 py-5">
+                    <div class="grid grid-cols-3 gap-3">
+                        <div class="col-span-2 grid gap-1.5">
+                            <Label for="tracking-alias" class="text-xs">Alias</Label>
+                            <Input id="tracking-alias" v-model:model-value="alias" placeholder="Optional system alias" />
                         </div>
-                        <label
-                            v-for="option in section.options"
-                            :key="option.id"
-                            class="col-span-4 grid grid-cols-subgrid items-center-safe p-1.5 text-left text-xs data-connected:opacity-50 data-demoted:opacity-60"
-                            :data-connected="Data(Boolean(option.map_connection_id))"
-                            :data-demoted="Data(section.key === 'unlikely')"
-                        >
-                            <RadioGroupItem :value="option.id" />
-                            <div class="font-medium">{{ option.signature_id }}</div>
-                            <WormholeOption :wormhole="option.signature_type" v-if="option.signature_type" />
-                            <div class="text-muted-foreground" v-else-if="option.raw_type_name">{{ option.raw_type_name }}</div>
-                            <div class="text-muted-foreground" v-else-if="option.map_connection_id">Already connected</div>
-                            <div class="text-muted-foreground" v-else>Unknown</div>
-                            <div class="text-right text-xs text-muted-foreground">
-                                {{ option.created_at ? formatDate(option.created_at) : 'Unknown' }}
-                            </div>
-                        </label>
-                    </template>
-                </RadioGroup>
-                <div class="grid gap-3">
-                    <div class="grid gap-1.5">
-                        <Label for="tracking-alias" class="text-xs">Alias</Label>
-                        <Input id="tracking-alias" v-model:model-value="alias" placeholder="Optional system alias" />
+                        <div class="grid content-start gap-1.5">
+                            <Label class="text-xs">Ship size</Label>
+                            <Select :model-value="shipSize" @update:model-value="handleShipSizeChange">
+                                <SelectTrigger class="w-full">
+                                    <span class="flex items-center gap-2">
+                                        <span
+                                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                            >{{ shipSizeMeta[shipSize].badge }}</span
+                                        >
+                                        {{ shipSizeMeta[shipSize].label }}
+                                    </span>
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="auto">
+                                        <span class="flex items-center gap-2">
+                                            <span
+                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                                >·</span
+                                            >
+                                            Auto
+                                        </span>
+                                    </SelectItem>
+                                    <SelectItem value="frigate">
+                                        <span class="flex items-center gap-2">
+                                            <span
+                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                                >S</span
+                                            >
+                                            Frigate
+                                        </span>
+                                    </SelectItem>
+                                    <SelectItem value="medium">
+                                        <span class="flex items-center gap-2">
+                                            <span
+                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                                >M</span
+                                            >
+                                            Medium
+                                        </span>
+                                    </SelectItem>
+                                    <SelectItem value="large">
+                                        <span class="flex items-center gap-2">
+                                            <span
+                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                                >L</span
+                                            >
+                                            Large
+                                        </span>
+                                    </SelectItem>
+                                    <SelectItem value="xlarge">
+                                        <span class="flex items-center gap-2">
+                                            <span
+                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                                >XL</span
+                                            >
+                                            Extra Large
+                                        </span>
+                                    </SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
                     </div>
                     <div class="grid grid-cols-2 gap-3">
                         <div class="grid gap-1.5">
                             <Label class="text-xs">Lifetime</Label>
                             <Select :model-value="lifetime" @update:model-value="handleLifetimeChange">
                                 <SelectTrigger class="w-full">
-                                    <SelectValue />
+                                    <span class="flex items-center gap-2">
+                                        <span class="inline-block size-2 rounded-full" :class="lifetimeMeta[lifetime].dot" />
+                                        {{ lifetimeMeta[lifetime].label }}
+                                    </span>
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="healthy">Healthy</SelectItem>
-                                    <SelectItem value="eol">End of Life</SelectItem>
-                                    <SelectItem value="critical">Critical</SelectItem>
+                                    <SelectItem value="healthy">
+                                        <span class="flex items-center gap-2">
+                                            <span class="inline-block size-2 rounded-full bg-neutral-500" />
+                                            Healthy
+                                        </span>
+                                    </SelectItem>
+                                    <SelectItem value="eol">
+                                        <span class="flex items-center gap-2">
+                                            <span class="inline-block size-2 rounded-full bg-purple-500" />
+                                            End of Life
+                                            <span class="text-muted-foreground">&lt; 4h</span>
+                                        </span>
+                                    </SelectItem>
+                                    <SelectItem value="critical">
+                                        <span class="flex items-center gap-2">
+                                            <span class="inline-block size-2 rounded-full bg-red-500" />
+                                            Critical
+                                            <span class="text-muted-foreground">&lt; 1h</span>
+                                        </span>
+                                    </SelectItem>
                                 </SelectContent>
                             </Select>
                         </div>
@@ -212,18 +340,95 @@ function formatDate(date: string) {
                             <Label class="text-xs">Mass</Label>
                             <Select :model-value="massStatus" @update:model-value="handleMassStatusChange">
                                 <SelectTrigger class="w-full">
-                                    <SelectValue />
+                                    <span class="flex items-center gap-2">
+                                        <span class="inline-block size-2 rounded-full" :class="massMeta[massStatus].dot" />
+                                        {{ massMeta[massStatus].label }}
+                                    </span>
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="fresh">Fresh</SelectItem>
-                                    <SelectItem value="reduced">Reduced</SelectItem>
-                                    <SelectItem value="critical">Critical</SelectItem>
+                                    <SelectItem value="fresh">
+                                        <span class="flex items-center gap-2">
+                                            <span class="inline-block size-2 rounded-full bg-neutral-500" />
+                                            Fresh
+                                            <span class="text-muted-foreground">&ge; 50%</span>
+                                        </span>
+                                    </SelectItem>
+                                    <SelectItem value="reduced">
+                                        <span class="flex items-center gap-2">
+                                            <span class="inline-block size-2 rounded-full bg-amber-500" />
+                                            Reduced
+                                            <span class="text-muted-foreground">&lt; 50%</span>
+                                        </span>
+                                    </SelectItem>
+                                    <SelectItem value="critical">
+                                        <span class="flex items-center gap-2">
+                                            <span class="inline-block size-2 rounded-full bg-red-500" />
+                                            Critical
+                                            <span class="text-muted-foreground">&le; 15%</span>
+                                        </span>
+                                    </SelectItem>
                                 </SelectContent>
                             </Select>
                         </div>
                     </div>
                 </div>
-                <DialogFooter class="sm:justify-between">
+                <!-- Signature list -->
+                <div class="flex flex-col gap-3 px-6 pb-5">
+                    <div class="relative">
+                        <SearchIcon class="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
+                        <Input
+                            id="tracking-search"
+                            v-model:model-value="search"
+                            placeholder="Search signatures"
+                            class="pl-9"
+                            @keydown.down.prevent="moveSelection(1)"
+                            @keydown.up.prevent="moveSelection(-1)"
+                        />
+                    </div>
+                    <RadioGroup
+                        ref="signatureList"
+                        class="grid h-64 grid-cols-[auto_auto_auto_1fr] content-start gap-0 gap-x-4 overflow-y-auto"
+                        v-model:model-value="selectedSignatureId"
+                        @keydown.enter="handleConfirm"
+                    >
+                        <label
+                            class="col-span-4 grid grid-cols-subgrid items-center-safe rounded-sm p-2 text-left text-xs transition-colors hover:bg-muted/40 has-data-[state=checked]:bg-muted/60"
+                        >
+                            <RadioGroupItem :value="null" />
+                            <div class="font-medium">Unknown</div>
+                            <div class="text-muted-foreground">—</div>
+                            <div />
+                        </label>
+                        <template v-for="section in sections" :key="section.key">
+                            <div
+                                v-if="section.label && section.options.length"
+                                class="col-span-4 mt-2 border-t border-border/50 px-2 pt-2.5 pb-1 font-mono text-[10px] tracking-wider text-muted-foreground uppercase"
+                            >
+                                {{ section.label }}
+                            </div>
+                            <label
+                                v-for="option in section.options"
+                                :key="option.id"
+                                class="col-span-4 grid grid-cols-subgrid items-center-safe rounded-sm p-2 text-left text-xs transition-colors hover:bg-muted/40 has-data-[state=checked]:bg-muted/60 has-data-[state=checked]:opacity-100 data-demoted:opacity-60"
+                                :data-demoted="Data(section.key !== 'likely')"
+                            >
+                                <RadioGroupItem :value="option.id" />
+                                <div class="font-medium">{{ option.signature_id }}</div>
+                                <WormholeOption :wormhole="option.signature_type" v-if="option.signature_type" />
+                                <div class="text-muted-foreground" v-else-if="option.raw_type_name">{{ option.raw_type_name }}</div>
+                                <div class="text-muted-foreground" v-else>Unknown</div>
+                                <div class="truncate text-right text-xs text-muted-foreground">
+                                    <template v-if="connectionDestinationLabel(option)">→ {{ connectionDestinationLabel(option) }}</template>
+                                </div>
+                            </label>
+                        </template>
+                        <div v-if="search && !filtered.length" class="col-span-4 px-2 py-3 text-xs text-muted-foreground">
+                            No signatures match "{{ search }}"
+                        </div>
+                    </RadioGroup>
+                </div>
+                <!-- Footer -->
+                <DialogFooter class="border-t border-border/50 bg-muted/30 px-6 py-4 sm:justify-between">
                     <Tooltip>
                         <TooltipTrigger as-child>
                             <Button @click="handleDontAskAgain" variant="outline" role="button" type="button">Disable</Button>

--- a/resources/js/components/map/TrackingSignatureDialog.vue
+++ b/resources/js/components/map/TrackingSignatureDialog.vue
@@ -9,8 +9,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/u
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useShowMap } from '@/composables/useShowMap';
 import { Data } from '@/lib/data';
-import { shipSizeFromJumpMass } from '@/lib/shipSize';
+import { SHIP_SIZE_OPTIONS, shipSizeFromJumpMass } from '@/lib/shipSize';
 import { groupSignatureOptions } from '@/lib/signatureCompatibility';
+import { aliasedSolarsystemLabel } from '@/lib/solarsystem';
 import { updateMapUserSettings } from '@/map/api';
 import { TMapSolarsystem } from '@/pages/maps';
 import { TLifetimeStatus, TMassStatus, TShipSize, TSignature, TStringedSolarsystemClass } from '@/types/models';
@@ -35,11 +36,7 @@ const search = ref('');
 
 const originSystemLabel = computed(() => {
     const origin = props.originMapSolarsystem;
-    if (!origin) {
-        return '';
-    }
-
-    return origin.alias ? `${origin.alias} (${origin.solarsystem.name})` : origin.solarsystem.name;
+    return origin ? aliasedSolarsystemLabel(origin.alias, origin.solarsystem.name) : '';
 });
 
 const filtered = computed(() => {
@@ -92,18 +89,25 @@ function focusSearch(): void {
     document.getElementById('tracking-search')?.focus();
 }
 
-/** The system on the far side of an already-connected signature's connection. */
-function connectionDestinationLabel(signature: TSignature): string | null {
-    const connection = signature.map_connection;
+/** Where each already-connected signature's connection leads, keyed by signature id. */
+const destinationLabels = computed<Map<number, string>>(() => {
+    const labels = new Map<number, string>();
     const origin = props.originMapSolarsystem;
-    if (!connection || !origin) return null;
+    if (!origin) return labels;
 
-    const destinationId = connection.to_map_solarsystem_id === origin.id ? connection.from_map_solarsystem_id : connection.to_map_solarsystem_id;
-    const destination = props.mapSolarsystems?.find((solarsystem) => solarsystem.id === destinationId);
-    if (!destination) return null;
+    for (const signature of props.signatures ?? []) {
+        const connection = signature.map_connection;
+        if (!connection) continue;
 
-    return destination.alias ? `${destination.alias} (${destination.solarsystem.name})` : destination.solarsystem.name;
-}
+        const destinationId = connection.to_map_solarsystem_id === origin.id ? connection.from_map_solarsystem_id : connection.to_map_solarsystem_id;
+        const destination = props.mapSolarsystems?.find((solarsystem) => solarsystem.id === destinationId);
+        if (destination) {
+            labels.set(signature.id, aliasedSolarsystemLabel(destination.alias, destination.solarsystem.name));
+        }
+    }
+
+    return labels;
+});
 
 const open = defineModel<boolean>('open', { required: true });
 
@@ -133,6 +137,8 @@ const selectedSignature = computed(() => props.signatures?.find((s) => s.id === 
  */
 const lockedShipSize = computed(() => shipSizeFromJumpMass(selectedSignature.value?.wormhole?.maximum_jump_mass));
 
+const effectiveShipSize = computed<TShipSize | 'auto'>(() => lockedShipSize.value ?? shipSize.value);
+
 // Reset inputs when the dialog opens. The alias is prefilled with the suggested
 // chain alias (or the target's existing alias when it is already on the map),
 // and with the preselect setting the first likely signature starts checked so
@@ -148,11 +154,10 @@ watch(open, (isOpen) => {
     }
 });
 
-// Adopt the signature's lifetime / mass / ship size when it carries a
-// meaningful value, otherwise keep whatever the user manually selected. The
-// wormhole type's size wins over a stored signature size.
-watch(selectedSignatureId, (id) => {
-    const signature = props.signatures?.find((s) => s.id === id);
+// Adopt the signature's lifetime / mass / stored ship size when it carries a
+// meaningful value, otherwise keep whatever the user manually selected. A
+// wormhole type's size is not adopted here — it is derived as lockedShipSize.
+watch(selectedSignature, (signature) => {
     if (!signature) return;
     if (signature.lifetime && signature.lifetime !== 'healthy') {
         lifetime.value = signature.lifetime;
@@ -160,10 +165,7 @@ watch(selectedSignatureId, (id) => {
     if (signature.mass_status) {
         massStatus.value = signature.mass_status;
     }
-    const wormholeShipSize = shipSizeFromJumpMass(signature.wormhole?.maximum_jump_mass);
-    if (wormholeShipSize) {
-        shipSize.value = wormholeShipSize;
-    } else if (signature.ship_size) {
+    if (!lockedShipSize.value && signature.ship_size) {
         shipSize.value = signature.ship_size;
     }
 });
@@ -174,7 +176,7 @@ function buildSelection(signatureId: number | null) {
         alias: alias.value.trim() || null,
         lifetime: lifetime.value,
         massStatus: massStatus.value,
-        shipSize: shipSize.value === 'auto' ? null : shipSize.value,
+        shipSize: lockedShipSize.value ?? (shipSize.value === 'auto' ? null : shipSize.value),
     };
 }
 
@@ -213,26 +215,25 @@ function handleShipSizeChange(value: AcceptableValue) {
     }
 }
 
-/* The same indicators the options carry, mirrored on the closed triggers. */
-const lifetimeMeta: Record<TLifetimeStatus, { label: string; dot: string }> = {
+/* One source for each select's options: dot / badge, label, and threshold hint. */
+const lifetimeMeta: Record<TLifetimeStatus, { label: string; dot: string; hint?: string }> = {
     healthy: { label: 'Healthy', dot: 'bg-neutral-500' },
-    eol: { label: 'End of Life', dot: 'bg-purple-500' },
-    critical: { label: 'Critical', dot: 'bg-red-500' },
+    eol: { label: 'End of Life', dot: 'bg-purple-500', hint: '< 4h' },
+    critical: { label: 'Critical', dot: 'bg-red-500', hint: '< 1h' },
 };
 
-const massMeta: Record<TMassStatus, { label: string; dot: string }> = {
-    fresh: { label: 'Fresh', dot: 'bg-neutral-500' },
-    reduced: { label: 'Reduced', dot: 'bg-amber-500' },
-    critical: { label: 'Critical', dot: 'bg-red-500' },
+const massMeta: Record<TMassStatus, { label: string; dot: string; hint?: string }> = {
+    fresh: { label: 'Fresh', dot: 'bg-neutral-500', hint: '≥ 50%' },
+    reduced: { label: 'Reduced', dot: 'bg-amber-500', hint: '< 50%' },
+    critical: { label: 'Critical', dot: 'bg-red-500', hint: '≤ 15%' },
 };
 
-const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }> = {
-    auto: { label: 'Auto', badge: '·' },
-    frigate: { label: 'Frigate', badge: 'S' },
-    medium: { label: 'Medium', badge: 'M' },
-    large: { label: 'Large', badge: 'L' },
-    xlarge: { label: 'Extra Large', badge: 'XL' },
-};
+const shipSizeOptions: { value: TShipSize | 'auto'; label: string; letter: string }[] = [
+    { value: 'auto', label: 'Auto', letter: '·' },
+    ...SHIP_SIZE_OPTIONS,
+];
+
+const selectedShipSizeOption = computed(() => shipSizeOptions.find((option) => option.value === effectiveShipSize.value) ?? shipSizeOptions[0]);
 </script>
 
 <template>
@@ -260,54 +261,22 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                         </div>
                         <div class="grid content-start gap-1.5">
                             <Label class="text-xs">Ship size</Label>
-                            <Select :model-value="shipSize" :disabled="lockedShipSize !== null" @update:model-value="handleShipSizeChange">
+                            <Select :model-value="effectiveShipSize" :disabled="lockedShipSize !== null" @update:model-value="handleShipSizeChange">
                                 <SelectTrigger class="w-full">
                                     <span class="flex items-center gap-2">
                                         <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">{{
-                                            shipSizeMeta[shipSize].badge
+                                            selectedShipSizeOption.letter
                                         }}</span>
-                                        {{ shipSizeMeta[shipSize].label }}
+                                        {{ selectedShipSizeOption.label }}
                                     </span>
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="auto">
+                                    <SelectItem v-for="option in shipSizeOptions" :key="option.value" :value="option.value">
                                         <span class="flex items-center gap-2">
-                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
-                                                >·</span
-                                            >
-                                            Auto
-                                        </span>
-                                    </SelectItem>
-                                    <SelectItem value="frigate">
-                                        <span class="flex items-center gap-2">
-                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
-                                                >S</span
-                                            >
-                                            Frigate
-                                        </span>
-                                    </SelectItem>
-                                    <SelectItem value="medium">
-                                        <span class="flex items-center gap-2">
-                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
-                                                >M</span
-                                            >
-                                            Medium
-                                        </span>
-                                    </SelectItem>
-                                    <SelectItem value="large">
-                                        <span class="flex items-center gap-2">
-                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
-                                                >L</span
-                                            >
-                                            Large
-                                        </span>
-                                    </SelectItem>
-                                    <SelectItem value="xlarge">
-                                        <span class="flex items-center gap-2">
-                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
-                                                >XL</span
-                                            >
-                                            Extra Large
+                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">{{
+                                                option.letter
+                                            }}</span>
+                                            {{ option.label }}
                                         </span>
                                     </SelectItem>
                                 </SelectContent>
@@ -325,24 +294,11 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                                     </span>
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="healthy">
+                                    <SelectItem v-for="(meta, value) in lifetimeMeta" :key="value" :value="value">
                                         <span class="flex items-center gap-2">
-                                            <span class="inline-block size-2 rounded-full bg-neutral-500" />
-                                            Healthy
-                                        </span>
-                                    </SelectItem>
-                                    <SelectItem value="eol">
-                                        <span class="flex items-center gap-2">
-                                            <span class="inline-block size-2 rounded-full bg-purple-500" />
-                                            End of Life
-                                            <span class="text-muted-foreground">&lt; 4h</span>
-                                        </span>
-                                    </SelectItem>
-                                    <SelectItem value="critical">
-                                        <span class="flex items-center gap-2">
-                                            <span class="inline-block size-2 rounded-full bg-red-500" />
-                                            Critical
-                                            <span class="text-muted-foreground">&lt; 1h</span>
+                                            <span class="inline-block size-2 rounded-full" :class="meta.dot" />
+                                            {{ meta.label }}
+                                            <span v-if="meta.hint" class="text-muted-foreground">{{ meta.hint }}</span>
                                         </span>
                                     </SelectItem>
                                 </SelectContent>
@@ -358,25 +314,11 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                                     </span>
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="fresh">
+                                    <SelectItem v-for="(meta, value) in massMeta" :key="value" :value="value">
                                         <span class="flex items-center gap-2">
-                                            <span class="inline-block size-2 rounded-full bg-neutral-500" />
-                                            Fresh
-                                            <span class="text-muted-foreground">&ge; 50%</span>
-                                        </span>
-                                    </SelectItem>
-                                    <SelectItem value="reduced">
-                                        <span class="flex items-center gap-2">
-                                            <span class="inline-block size-2 rounded-full bg-amber-500" />
-                                            Reduced
-                                            <span class="text-muted-foreground">&lt; 50%</span>
-                                        </span>
-                                    </SelectItem>
-                                    <SelectItem value="critical">
-                                        <span class="flex items-center gap-2">
-                                            <span class="inline-block size-2 rounded-full bg-red-500" />
-                                            Critical
-                                            <span class="text-muted-foreground">&le; 15%</span>
+                                            <span class="inline-block size-2 rounded-full" :class="meta.dot" />
+                                            {{ meta.label }}
+                                            <span v-if="meta.hint" class="text-muted-foreground">{{ meta.hint }}</span>
                                         </span>
                                     </SelectItem>
                                 </SelectContent>
@@ -430,7 +372,7 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                                 <div class="text-muted-foreground" v-else-if="option.raw_type_name">{{ option.raw_type_name }}</div>
                                 <div class="text-muted-foreground" v-else>Unknown</div>
                                 <div class="truncate text-right text-xs text-muted-foreground">
-                                    <template v-if="connectionDestinationLabel(option)">→ {{ connectionDestinationLabel(option) }}</template>
+                                    <template v-if="destinationLabels.has(option.id)">→ {{ destinationLabels.get(option.id) }}</template>
                                 </div>
                             </label>
                         </template>

--- a/resources/js/components/map/TrackingSignatureDialog.vue
+++ b/resources/js/components/map/TrackingSignatureDialog.vue
@@ -25,6 +25,8 @@ const props = defineProps<{
     suggestedAlias?: string | null;
     /** The map's systems, used to name where already-connected signatures lead. */
     mapSolarsystems?: TMapSolarsystem[];
+    /** Pre-select the first likely signature on open so Enter confirms it immediately. */
+    preselectFirstSignature?: boolean;
 }>();
 
 const page = useShowMap();
@@ -123,10 +125,13 @@ const massStatus = ref<TMassStatus>('fresh');
 const shipSize = ref<TShipSize | 'auto'>('auto');
 
 // Reset inputs when the dialog opens. The alias is prefilled with the suggested
-// chain alias (or the target's existing alias when it is already on the map).
+// chain alias (or the target's existing alias when it is already on the map),
+// and with the preselect setting the first likely signature starts checked so
+// jumping holes in alphabetical order only takes Enter.
 watch(open, (isOpen) => {
     if (isOpen) {
-        selectedSignatureId.value = null;
+        search.value = '';
+        selectedSignatureId.value = props.preselectFirstSignature ? (groups.value.likely[0]?.id ?? null) : null;
         alias.value = props.suggestedAlias ?? '';
         lifetime.value = 'healthy';
         massStatus.value = 'fresh';
@@ -245,18 +250,16 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                             <Select :model-value="shipSize" @update:model-value="handleShipSizeChange">
                                 <SelectTrigger class="w-full">
                                     <span class="flex items-center gap-2">
-                                        <span
-                                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
-                                            >{{ shipSizeMeta[shipSize].badge }}</span
-                                        >
+                                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">{{
+                                            shipSizeMeta[shipSize].badge
+                                        }}</span>
                                         {{ shipSizeMeta[shipSize].label }}
                                     </span>
                                 </SelectTrigger>
                                 <SelectContent>
                                     <SelectItem value="auto">
                                         <span class="flex items-center gap-2">
-                                            <span
-                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
                                                 >·</span
                                             >
                                             Auto
@@ -264,8 +267,7 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                                     </SelectItem>
                                     <SelectItem value="frigate">
                                         <span class="flex items-center gap-2">
-                                            <span
-                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
                                                 >S</span
                                             >
                                             Frigate
@@ -273,8 +275,7 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                                     </SelectItem>
                                     <SelectItem value="medium">
                                         <span class="flex items-center gap-2">
-                                            <span
-                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
                                                 >M</span
                                             >
                                             Medium
@@ -282,8 +283,7 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                                     </SelectItem>
                                     <SelectItem value="large">
                                         <span class="flex items-center gap-2">
-                                            <span
-                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
                                                 >L</span
                                             >
                                             Large
@@ -291,8 +291,7 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                                     </SelectItem>
                                     <SelectItem value="xlarge">
                                         <span class="flex items-center gap-2">
-                                            <span
-                                                class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                                            <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
                                                 >XL</span
                                             >
                                             Extra Large

--- a/resources/js/components/map/TrackingSignatureDialog.vue
+++ b/resources/js/components/map/TrackingSignatureDialog.vue
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger } from '@/components/u
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useShowMap } from '@/composables/useShowMap';
 import { Data } from '@/lib/data';
+import { shipSizeFromJumpMass } from '@/lib/shipSize';
 import { groupSignatureOptions } from '@/lib/signatureCompatibility';
 import { updateMapUserSettings } from '@/map/api';
 import { TMapSolarsystem } from '@/pages/maps';
@@ -124,6 +125,14 @@ const lifetime = ref<TLifetimeStatus>('healthy');
 const massStatus = ref<TMassStatus>('fresh');
 const shipSize = ref<TShipSize | 'auto'>('auto');
 
+const selectedSignature = computed(() => props.signatures?.find((s) => s.id === selectedSignatureId.value) ?? null);
+
+/**
+ * An identified wormhole type dictates the hole's ship size, so the select is
+ * locked to it while such a signature is chosen.
+ */
+const lockedShipSize = computed(() => shipSizeFromJumpMass(selectedSignature.value?.wormhole?.maximum_jump_mass));
+
 // Reset inputs when the dialog opens. The alias is prefilled with the suggested
 // chain alias (or the target's existing alias when it is already on the map),
 // and with the preselect setting the first likely signature starts checked so
@@ -140,7 +149,8 @@ watch(open, (isOpen) => {
 });
 
 // Adopt the signature's lifetime / mass / ship size when it carries a
-// meaningful value, otherwise keep whatever the user manually selected.
+// meaningful value, otherwise keep whatever the user manually selected. The
+// wormhole type's size wins over a stored signature size.
 watch(selectedSignatureId, (id) => {
     const signature = props.signatures?.find((s) => s.id === id);
     if (!signature) return;
@@ -150,7 +160,10 @@ watch(selectedSignatureId, (id) => {
     if (signature.mass_status) {
         massStatus.value = signature.mass_status;
     }
-    if (signature.ship_size) {
+    const wormholeShipSize = shipSizeFromJumpMass(signature.wormhole?.maximum_jump_mass);
+    if (wormholeShipSize) {
+        shipSize.value = wormholeShipSize;
+    } else if (signature.ship_size) {
         shipSize.value = signature.ship_size;
     }
 });
@@ -247,7 +260,7 @@ const shipSizeMeta: Record<TShipSize | 'auto', { label: string; badge: string }>
                         </div>
                         <div class="grid content-start gap-1.5">
                             <Label class="text-xs">Ship size</Label>
-                            <Select :model-value="shipSize" @update:model-value="handleShipSizeChange">
+                            <Select :model-value="shipSize" :disabled="lockedShipSize !== null" @update:model-value="handleShipSizeChange">
                                 <SelectTrigger class="w-full">
                                     <span class="flex items-center gap-2">
                                         <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">{{

--- a/resources/js/components/map/trackingSignatureFixtures.ts
+++ b/resources/js/components/map/trackingSignatureFixtures.ts
@@ -1,0 +1,78 @@
+import type { TMapConnection, TMapSolarsystem, TWormhole } from '@/pages/maps';
+import type { TLifetimeStatus, TMassStatus, TShipSize, TSignature, TSignatureCategory, TStringedSolarsystemClass } from '@/types/models';
+
+/**
+ * Shared TSignature fixtures for the tracking signature dialog: consumed by the
+ * component spec and the local debug preview page so both feed the dialog the
+ * same shapes.
+ */
+
+export const ORIGIN_ID = 1;
+
+export const ORIGIN = {
+    id: ORIGIN_ID,
+    alias: 'HOME',
+    solarsystem: { name: 'J152820' },
+} as TMapSolarsystem;
+
+/** Map systems the connected fixtures can lead to. */
+export const MAP_SOLARSYSTEMS = [
+    ORIGIN,
+    { id: 2, alias: 'HOME-A', solarsystem: { name: 'J145510' } } as TMapSolarsystem,
+    { id: 3, alias: null, solarsystem: { name: 'J104859' } } as TMapSolarsystem,
+];
+
+let nextId = 1;
+
+export function resetSignatureIds(): void {
+    nextId = 1;
+}
+
+export function sig(input: {
+    signatureId: string;
+    category?: string;
+    /** Wormhole code shown in the type column; defaults to X702 when only a target class is given. */
+    code?: string;
+    targetClass?: TStringedSolarsystemClass | 'unknown';
+    /** Maximum jump mass of the identified wormhole type; locks the ship size select. */
+    jumpMass?: number;
+    extra?: string | null;
+    rawTypeName?: string;
+    /** Marks the signature as already tied to a connection leading to this map solarsystem id. */
+    connectedToId?: number;
+    lifetime?: TLifetimeStatus;
+    massStatus?: TMassStatus;
+    shipSize?: TShipSize;
+}): TSignature {
+    const id = nextId++;
+    const code = input.code ?? (input.targetClass ? 'X702' : undefined);
+
+    return {
+        id,
+        signature_id: input.signatureId,
+        signature_type_id: code ? id : null,
+        signature_category_id: input.category ? id : null,
+        raw_type_name: input.rawTypeName ?? null,
+        map_connection_id: input.connectedToId ? id : null,
+        map_connection: input.connectedToId
+            ? ({ id, from_map_solarsystem_id: ORIGIN_ID, to_map_solarsystem_id: input.connectedToId } as TMapConnection)
+            : null,
+        signature_type: code
+            ? {
+                  id,
+                  name: `${code} - ${input.targetClass ?? '?'}`,
+                  signature: code,
+                  signature_category_id: id,
+                  category_name: input.category === 'wormhole' ? 'Wormhole' : (input.category ?? null),
+                  target_class: input.targetClass ?? null,
+                  extra: input.extra ?? null,
+                  spawn_areas: null,
+              }
+            : null,
+        signature_category: input.category ? ({ id, name: input.category, code: input.category } as TSignatureCategory) : null,
+        wormhole: input.jumpMass ? ({ id, name: code ?? 'K162', maximum_jump_mass: input.jumpMass } as TWormhole) : null,
+        lifetime: input.lifetime ?? 'healthy',
+        mass_status: input.massStatus ?? null,
+        ship_size: input.shipSize ?? null,
+    } as TSignature;
+}

--- a/resources/js/composables/signatures/useTracking.ts
+++ b/resources/js/composables/signatures/useTracking.ts
@@ -6,10 +6,10 @@ import { useStaticData } from '@/composables/useStaticData';
 import { useTrackingSystems } from '@/composables/useTrackingSystems';
 import { suggestAlias } from '@/lib/alias';
 import { formatBookmarkName } from '@/lib/bookmark';
-import { signatureCanLeadToClass } from '@/lib/signatureCompatibility';
+import { groupSignatureOptions } from '@/lib/signatureCompatibility';
 import { isWormholeSystem } from '@/lib/solarsystem';
 import { createTracking, updateMapUserSettings, useMapSolarsystems } from '@/map/api';
-import { TLifetimeStatus, TMassStatus, TSignature } from '@/types/models';
+import { TLifetimeStatus, TMassStatus, TShipSize, TSignature } from '@/types/models';
 import { computed, ref, watch } from 'vue';
 import { toast } from 'vue-sonner';
 
@@ -31,9 +31,7 @@ export function useTracking() {
     // All of the origin's signatures; the dialog demotes the ones that cannot
     // lead to the target instead of hiding them.
     const signatures = computed(() => origin_map_solarsystem.value?.signatures?.toSorted(sortSignatures));
-    const possible_signatures = computed(
-        () => signatures.value?.filter((signature) => signatureCanLeadToClass(signature, target_solarsystem.value?.class)) ?? [],
-    );
+    const possible_signatures = computed(() => groupSignatureOptions(signatures.value ?? [], target_solarsystem.value?.class).likely);
     const existing_map_solarsystem = computed(() => map_solarsystems.value.find((s) => s.solarsystem_id === target_solarsystem.value?.id));
     const existing_connection = computed(() => {
         if (!existing_map_solarsystem.value) return null;
@@ -125,6 +123,7 @@ export function useTracking() {
         alias: string | null;
         lifetime: TLifetimeStatus;
         massStatus: TMassStatus;
+        shipSize: TShipSize | null;
     }) {
         show_signature_modal.value = false;
         if (!origin_map_solarsystem.value || !target_solarsystem.value) return;
@@ -134,6 +133,7 @@ export function useTracking() {
             alias: selection.alias,
             lifetime: selection.lifetime,
             mass_status: selection.massStatus,
+            ship_size: selection.shipSize,
         });
     }
 

--- a/resources/js/composables/signatures/useTracking.ts
+++ b/resources/js/composables/signatures/useTracking.ts
@@ -95,9 +95,7 @@ export function useTracking() {
 
     function sortSignatures(a: TSignature, b: TSignature) {
         if (!a.signature_id || !b.signature_id) return 0;
-        if (a.map_connection_id && !b.map_connection_id) return 1;
-        if (!a.map_connection_id && b.map_connection_id) return -1;
-        return a.signature_id?.localeCompare(b.signature_id);
+        return a.signature_id.localeCompare(b.signature_id);
     }
 
     function performJump() {

--- a/resources/js/lib/shipSize.spec.ts
+++ b/resources/js/lib/shipSize.spec.ts
@@ -1,0 +1,18 @@
+import { shipSizeFromJumpMass } from '@/lib/shipSize';
+import { describe, expect, it } from 'vitest';
+
+describe('shipSizeFromJumpMass', () => {
+    it('maps the standard jump mass tiers to ship sizes', function () {
+        expect(shipSizeFromJumpMass(5_000_000)).toBe('frigate');
+        expect(shipSizeFromJumpMass(62_000_000)).toBe('medium');
+        expect(shipSizeFromJumpMass(375_000_000)).toBe('large');
+        expect(shipSizeFromJumpMass(1_000_000_000)).toBe('large');
+        expect(shipSizeFromJumpMass(2_000_000_000)).toBe('xlarge');
+    });
+
+    it('resolves unknown and zero masses to null', function () {
+        expect(shipSizeFromJumpMass(0)).toBeNull();
+        expect(shipSizeFromJumpMass(null)).toBeNull();
+        expect(shipSizeFromJumpMass(undefined)).toBeNull();
+    });
+});

--- a/resources/js/lib/shipSize.ts
+++ b/resources/js/lib/shipSize.ts
@@ -3,6 +3,14 @@ import type { TShipSize } from '@/types/models';
 /** The compact letters the map edges use for ship sizes. */
 export const SHIP_SIZE_LETTERS = { frigate: 'S', medium: 'M', large: 'L', xlarge: 'XL' } as const satisfies Record<TShipSize, string>;
 
+/** The selectable ship sizes with their display label and letter, in size order. */
+export const SHIP_SIZE_OPTIONS = [
+    { value: 'frigate', label: 'Frigate', letter: SHIP_SIZE_LETTERS.frigate },
+    { value: 'medium', label: 'Medium', letter: SHIP_SIZE_LETTERS.medium },
+    { value: 'large', label: 'Large', letter: SHIP_SIZE_LETTERS.large },
+    { value: 'xlarge', label: 'Extra Large', letter: SHIP_SIZE_LETTERS.xlarge },
+] as const satisfies ReadonlyArray<{ value: TShipSize; label: string; letter: string }>;
+
 /**
  * The largest ship class that fits through a wormhole with the given maximum
  * jump mass, using the standard 5M / 62M / <2B / 2B+ kg tiers. Unknown or

--- a/resources/js/lib/shipSize.ts
+++ b/resources/js/lib/shipSize.ts
@@ -1,0 +1,31 @@
+import type { TShipSize } from '@/types/models';
+
+/** The compact letters the map edges use for ship sizes. */
+export const SHIP_SIZE_LETTERS = { frigate: 'S', medium: 'M', large: 'L', xlarge: 'XL' } as const satisfies Record<TShipSize, string>;
+
+/**
+ * The largest ship class that fits through a wormhole with the given maximum
+ * jump mass, using the standard 5M / 62M / <2B / 2B+ kg tiers. Unknown or
+ * zero masses resolve to null.
+ *
+ * Mirrored on the backend in App\Enums\ShipSize::fromJumpMass().
+ */
+export function shipSizeFromJumpMass(maximumJumpMass: number | null | undefined): TShipSize | null {
+    if (!maximumJumpMass || maximumJumpMass <= 0) {
+        return null;
+    }
+
+    if (maximumJumpMass <= 5_000_000) {
+        return 'frigate';
+    }
+
+    if (maximumJumpMass <= 62_000_000) {
+        return 'medium';
+    }
+
+    if (maximumJumpMass < 2_000_000_000) {
+        return 'large';
+    }
+
+    return 'xlarge';
+}

--- a/resources/js/lib/signatureCompatibility.spec.ts
+++ b/resources/js/lib/signatureCompatibility.spec.ts
@@ -1,49 +1,95 @@
-import { signatureCanLeadToClass } from '@/lib/signatureCompatibility';
+import { groupSignatureOptions, signatureCanBeConnection, signatureCanLeadToClass } from '@/lib/signatureCompatibility';
 import type { TSignature, TSignatureCategory, TSignatureType, TStringedSolarsystemClass } from '@/types/models';
 import { describe, expect, it } from 'vitest';
 
-function signature(overrides: { categoryCode?: string; targetClass?: TStringedSolarsystemClass | 'unknown' | null; hasType?: boolean }): TSignature {
-    const { categoryCode, targetClass = null, hasType = targetClass !== null } = overrides;
+function signature(overrides: {
+    id?: number;
+    categoryCode?: string;
+    targetClass?: TStringedSolarsystemClass | 'unknown' | null;
+    hasType?: boolean;
+    connected?: boolean;
+}): TSignature {
+    const { id = 1, categoryCode, targetClass = null, hasType = targetClass !== null, connected = false } = overrides;
 
     return {
-        id: 1,
+        id,
         signature_id: 'ABC-123',
+        map_connection_id: connected ? id : null,
         signature_category: categoryCode ? ({ id: 1, name: categoryCode, code: categoryCode } as TSignatureCategory) : null,
         signature_type: hasType ? ({ id: 1, name: 'Test', signature: 'X702', target_class: targetClass } as TSignatureType) : null,
     } as TSignature;
 }
 
-describe('signatureCanLeadToClass', () => {
-    it('accepts signatures without any category or type', () => {
-        expect(signatureCanLeadToClass(signature({}), '4')).toBe(true);
+describe('signatureCanBeConnection', () => {
+    it('accepts wormhole-category signatures', () => {
+        expect(signatureCanBeConnection(signature({ categoryCode: 'wormhole' }))).toBe(true);
     });
 
-    it('rejects signatures categorised as non-wormhole sites', () => {
-        expect(signatureCanLeadToClass(signature({ categoryCode: 'gas' }), '4')).toBe(false);
+    it('accepts uncategorised signatures', () => {
+        expect(signatureCanBeConnection(signature({}))).toBe(true);
+    });
+
+    it('rejects site categories', () => {
+        for (const categoryCode of ['gas', 'data', 'relic', 'combat', 'ore']) {
+            expect(signatureCanBeConnection(signature({ categoryCode }))).toBe(false);
+        }
+    });
+});
+
+describe('signatureCanLeadToClass', () => {
+    it('accepts signatures without a resolved type', () => {
+        expect(signatureCanLeadToClass(signature({ hasType: false }), '4')).toBe(true);
     });
 
     it('accepts wormhole types leading to the target class', () => {
-        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: '4' }), '4')).toBe(true);
+        expect(signatureCanLeadToClass(signature({ targetClass: '4' }), '4')).toBe(true);
     });
 
     it('rejects wormhole types leading to a different class', () => {
-        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'n' }), '4')).toBe(false);
+        expect(signatureCanLeadToClass(signature({ targetClass: 'n' }), '4')).toBe(false);
     });
 
     it('accepts wormhole types with an unknown destination', () => {
-        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'unknown' }), '4')).toBe(true);
+        expect(signatureCanLeadToClass(signature({ targetClass: 'unknown' }), '4')).toBe(true);
     });
 
     it('accepts typed wormholes when the target class is not known', () => {
-        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'n' }), null)).toBe(true);
-    });
-
-    it('accepts wormhole-category signatures without a resolved type', () => {
-        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', hasType: false }), 'h')).toBe(true);
+        expect(signatureCanLeadToClass(signature({ targetClass: 'n' }), null)).toBe(true);
     });
 
     it('matches known-space classes exactly', () => {
-        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'h' }), 'h')).toBe(true);
-        expect(signatureCanLeadToClass(signature({ categoryCode: 'wormhole', targetClass: 'h' }), 'l')).toBe(false);
+        expect(signatureCanLeadToClass(signature({ targetClass: 'h' }), 'h')).toBe(true);
+        expect(signatureCanLeadToClass(signature({ targetClass: 'h' }), 'l')).toBe(false);
+    });
+});
+
+describe('groupSignatureOptions', () => {
+    it('splits signatures into likely, connected and unlikely sections', () => {
+        const matching = signature({ id: 1, categoryCode: 'wormhole', targetClass: '4' });
+        const unscanned = signature({ id: 2 });
+        const connected = signature({ id: 3, categoryCode: 'wormhole', targetClass: '4', connected: true });
+        const wrongClass = signature({ id: 4, categoryCode: 'wormhole', targetClass: 'n' });
+        const site = signature({ id: 5, categoryCode: 'gas' });
+
+        const groups = groupSignatureOptions([matching, unscanned, connected, wrongClass, site], '4');
+
+        expect(groups.likely).toEqual([matching, unscanned]);
+        expect(groups.connected).toEqual([connected]);
+        expect(groups.unlikely).toEqual([wrongClass]);
+    });
+
+    it('puts connected signatures into the connected section even when their class cannot match', () => {
+        const connectedWrongClass = signature({ id: 1, categoryCode: 'wormhole', targetClass: 'n', connected: true });
+
+        const groups = groupSignatureOptions([connectedWrongClass], '4');
+
+        expect(groups.connected).toEqual([connectedWrongClass]);
+        expect(groups.unlikely).toEqual([]);
+    });
+
+    it('drops site signatures entirely', () => {
+        const groups = groupSignatureOptions([signature({ id: 1, categoryCode: 'relic' })], '4');
+
+        expect(groups).toEqual({ likely: [], connected: [], unlikely: [] });
     });
 });

--- a/resources/js/lib/signatureCompatibility.ts
+++ b/resources/js/lib/signatureCompatibility.ts
@@ -1,21 +1,24 @@
 import type { TSignature, TStringedSolarsystemClass } from '@/types/models';
 
 /**
- * Whether a scanned signature could be the wormhole that led into a system of
- * the given class.
- *
- * A signature categorised as anything other than a wormhole cannot be a
- * connection at all. A wormhole type with a concrete destination class only
- * fits that exact class — jumping a "leads to Nullsec" hole cannot land you in
- * a C4. Unscanned signatures, unresolved types, and types with an unknown
- * destination (e.g. a bare K162) can always fit.
+ * Whether a scanned signature can be a wormhole connection at all: only
+ * signatures categorised as wormholes, or not yet categorised, qualify.
+ * Gas, data, relic, combat and ore sites are never connections.
+ */
+export function signatureCanBeConnection(signature: TSignature): boolean {
+    const categoryCode = signature.signature_category?.code;
+
+    return !categoryCode || categoryCode === 'wormhole';
+}
+
+/**
+ * Whether a signature's assigned wormhole type could lead into a system of the
+ * given class. A type with a concrete destination class only fits that exact
+ * class — jumping a "leads to Nullsec" hole cannot land you in a C4.
+ * Unresolved types and types with an unknown destination (e.g. a bare K162)
+ * can always fit.
  */
 export function signatureCanLeadToClass(signature: TSignature, targetClass: TStringedSolarsystemClass | null | undefined): boolean {
-    const categoryCode = signature.signature_category?.code;
-    if (categoryCode && categoryCode !== 'wormhole') {
-        return false;
-    }
-
     const destinationClass = signature.signature_type?.target_class;
     if (!destinationClass || destinationClass === 'unknown') {
         return true;
@@ -26,4 +29,28 @@ export function signatureCanLeadToClass(signature: TSignature, targetClass: TStr
     }
 
     return destinationClass === targetClass;
+}
+
+export type TSignatureOptionGroups = {
+    /** Unmapped signatures whose type (if any) can lead to the target class. */
+    likely: TSignature[];
+    /** Signatures already tied to a mapped connection. */
+    connected: TSignature[];
+    /** Unmapped signatures typed with a destination class that cannot match. */
+    unlikely: TSignature[];
+};
+
+/**
+ * Group a system's signatures into the jump prompt's three sections. Site
+ * signatures are dropped entirely; a signature that is already part of a
+ * mapped connection cannot be the newly jumped hole regardless of its type.
+ */
+export function groupSignatureOptions(signatures: TSignature[], targetClass: TStringedSolarsystemClass | null | undefined): TSignatureOptionGroups {
+    const candidates = signatures.filter(signatureCanBeConnection);
+
+    return {
+        likely: candidates.filter((signature) => !signature.map_connection_id && signatureCanLeadToClass(signature, targetClass)),
+        connected: candidates.filter((signature) => Boolean(signature.map_connection_id)),
+        unlikely: candidates.filter((signature) => !signature.map_connection_id && !signatureCanLeadToClass(signature, targetClass)),
+    };
 }

--- a/resources/js/lib/signatureCompatibility.ts
+++ b/resources/js/lib/signatureCompatibility.ts
@@ -46,11 +46,21 @@ export type TSignatureOptionGroups = {
  * mapped connection cannot be the newly jumped hole regardless of its type.
  */
 export function groupSignatureOptions(signatures: TSignature[], targetClass: TStringedSolarsystemClass | null | undefined): TSignatureOptionGroups {
-    const candidates = signatures.filter(signatureCanBeConnection);
+    const groups: TSignatureOptionGroups = { likely: [], connected: [], unlikely: [] };
 
-    return {
-        likely: candidates.filter((signature) => !signature.map_connection_id && signatureCanLeadToClass(signature, targetClass)),
-        connected: candidates.filter((signature) => Boolean(signature.map_connection_id)),
-        unlikely: candidates.filter((signature) => !signature.map_connection_id && !signatureCanLeadToClass(signature, targetClass)),
-    };
+    for (const signature of signatures) {
+        if (!signatureCanBeConnection(signature)) {
+            continue;
+        }
+
+        if (signature.map_connection_id) {
+            groups.connected.push(signature);
+        } else if (signatureCanLeadToClass(signature, targetClass)) {
+            groups.likely.push(signature);
+        } else {
+            groups.unlikely.push(signature);
+        }
+    }
+
+    return groups;
 }

--- a/resources/js/lib/solarsystem.ts
+++ b/resources/js/lib/solarsystem.ts
@@ -7,3 +7,8 @@ import { TSolarsystemType } from '@/types/models';
 export function isWormholeSystem(solarsystem?: { type: TSolarsystemType } | null): boolean {
     return solarsystem?.type === 'wh';
 }
+
+/** "ALIAS (Name)" when the system carries an alias, otherwise just the name. */
+export function aliasedSolarsystemLabel(alias: string | null | undefined, name: string): string {
+    return alias ? `${alias} (${name})` : name;
+}

--- a/resources/js/map/actions/createTracking.ts
+++ b/resources/js/map/actions/createTracking.ts
@@ -1,5 +1,5 @@
 import Tracking from '@/routes/tracking';
-import { TLifetimeStatus, TMassStatus } from '@/types/models';
+import { TLifetimeStatus, TMassStatus, TShipSize } from '@/types/models';
 import { router } from '@inertiajs/vue3';
 
 type TrackingOptions = {
@@ -7,6 +7,7 @@ type TrackingOptions = {
     alias?: string | null;
     lifetime?: TLifetimeStatus | null;
     mass_status?: TMassStatus | null;
+    ship_size?: TShipSize | null;
 };
 
 export function createTracking(from_map_solarsystem_id: number, to_solarsystem_id: number, options: TrackingOptions = {}): void {

--- a/resources/js/map/components/edges/Edge.vue
+++ b/resources/js/map/components/edges/Edge.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import EdgeBadges, { type EdgeIndicator } from '@/map/components/edges/EdgeBadges.vue';
 import { scalePoint } from '@/map/core/coords';
+import { SHIP_SIZE_LETTERS } from '@/lib/shipSize';
 import { edgePathAndCenter } from '@/map/core/geometry/paths';
 import type { EdgeGeometry } from '@/map/core/types';
 import type { TMapConnection } from '@/pages/maps';
@@ -42,11 +43,9 @@ const scaledFrom = computed(() => scalePoint(geometry.from, scale));
 const scaledTo = computed(() => scalePoint(geometry.to, scale));
 
 function getShipSizeLabel(size?: TShipSize | null): string | null {
-    if (size === 'frigate') return 'S';
-    if (size === 'medium') return 'M';
-    if (size === 'xlarge') return 'XL';
+    if (!size || size === 'large') return null;
 
-    return null;
+    return SHIP_SIZE_LETTERS[size];
 }
 
 const indicators = computed<EdgeIndicator[]>(() => {

--- a/resources/js/map/components/overlays/MapConnectionContextMenu.vue
+++ b/resources/js/map/components/overlays/MapConnectionContextMenu.vue
@@ -135,31 +135,19 @@ function handleLifetimeChange(lifetime: AcceptableValue) {
             <ContextMenuSubContent>
                 <ContextMenuRadioGroup :model-value="map_connection.ship_size" @update:model-value="handleShipSizeChange">
                     <ContextMenuRadioItem value="frigate" class="flex items-center gap-2">
-                        <span
-                            class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
-                            >S</span
-                        >
+                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">S</span>
                         Frigate
                     </ContextMenuRadioItem>
                     <ContextMenuRadioItem value="medium" class="flex items-center gap-2">
-                        <span
-                            class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
-                            >M</span
-                        >
+                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">M</span>
                         Medium
                     </ContextMenuRadioItem>
                     <ContextMenuRadioItem value="large" class="flex items-center gap-2">
-                        <span
-                            class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
-                            >L</span
-                        >
+                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">L</span>
                         Large
                     </ContextMenuRadioItem>
                     <ContextMenuRadioItem value="xlarge" class="flex items-center gap-2">
-                        <span
-                            class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
-                            >XL</span
-                        >
+                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">XL</span>
                         Extra Large
                     </ContextMenuRadioItem>
                 </ContextMenuRadioGroup>

--- a/resources/js/map/components/overlays/MapConnectionContextMenu.vue
+++ b/resources/js/map/components/overlays/MapConnectionContextMenu.vue
@@ -10,7 +10,7 @@ import {
     ContextMenuSubTrigger,
 } from '@/components/ui/context-menu';
 import { useStaticData } from '@/composables/useStaticData';
-import { shipSizeFromJumpMass } from '@/lib/shipSize';
+import { SHIP_SIZE_OPTIONS, shipSizeFromJumpMass } from '@/lib/shipSize';
 import { formatDateToISO } from '@/lib/utils';
 import { deleteMapConnection } from '@/map/actions/deleteMapConnection';
 import { updateMapConnection } from '@/map/actions/updateMapConnection';
@@ -145,21 +145,15 @@ function handleLifetimeChange(lifetime: AcceptableValue) {
             </ContextMenuSubTrigger>
             <ContextMenuSubContent>
                 <ContextMenuRadioGroup :model-value="map_connection.ship_size" @update:model-value="handleShipSizeChange">
-                    <ContextMenuRadioItem value="frigate" class="flex items-center gap-2" :disabled="locked_ship_size !== null">
-                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">S</span>
-                        Frigate
-                    </ContextMenuRadioItem>
-                    <ContextMenuRadioItem value="medium" class="flex items-center gap-2" :disabled="locked_ship_size !== null">
-                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">M</span>
-                        Medium
-                    </ContextMenuRadioItem>
-                    <ContextMenuRadioItem value="large" class="flex items-center gap-2" :disabled="locked_ship_size !== null">
-                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">L</span>
-                        Large
-                    </ContextMenuRadioItem>
-                    <ContextMenuRadioItem value="xlarge" class="flex items-center gap-2" :disabled="locked_ship_size !== null">
-                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">XL</span>
-                        Extra Large
+                    <ContextMenuRadioItem
+                        v-for="option in SHIP_SIZE_OPTIONS"
+                        :key="option.value"
+                        :value="option.value"
+                        class="flex items-center gap-2"
+                        :disabled="locked_ship_size !== null"
+                    >
+                        <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">{{ option.letter }}</span>
+                        {{ option.label }}
                     </ContextMenuRadioItem>
                 </ContextMenuRadioGroup>
                 <div v-if="locked_ship_size" class="px-2 py-1 text-[10px] text-muted-foreground">Locked by the identified wormhole type</div>

--- a/resources/js/map/components/overlays/MapConnectionContextMenu.vue
+++ b/resources/js/map/components/overlays/MapConnectionContextMenu.vue
@@ -134,10 +134,34 @@ function handleLifetimeChange(lifetime: AcceptableValue) {
             </ContextMenuSubTrigger>
             <ContextMenuSubContent>
                 <ContextMenuRadioGroup :model-value="map_connection.ship_size" @update:model-value="handleShipSizeChange">
-                    <ContextMenuRadioItem value="frigate">Frigate</ContextMenuRadioItem>
-                    <ContextMenuRadioItem value="medium">Medium</ContextMenuRadioItem>
-                    <ContextMenuRadioItem value="large">Large</ContextMenuRadioItem>
-                    <ContextMenuRadioItem value="xlarge">Extra Large</ContextMenuRadioItem>
+                    <ContextMenuRadioItem value="frigate" class="flex items-center gap-2">
+                        <span
+                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                            >S</span
+                        >
+                        Frigate
+                    </ContextMenuRadioItem>
+                    <ContextMenuRadioItem value="medium" class="flex items-center gap-2">
+                        <span
+                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                            >M</span
+                        >
+                        Medium
+                    </ContextMenuRadioItem>
+                    <ContextMenuRadioItem value="large" class="flex items-center gap-2">
+                        <span
+                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                            >L</span
+                        >
+                        Large
+                    </ContextMenuRadioItem>
+                    <ContextMenuRadioItem value="xlarge" class="flex items-center gap-2">
+                        <span
+                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                            >XL</span
+                        >
+                        Extra Large
+                    </ContextMenuRadioItem>
                 </ContextMenuRadioGroup>
             </ContextMenuSubContent>
         </ContextMenuSub>

--- a/resources/js/map/components/overlays/MapConnectionContextMenu.vue
+++ b/resources/js/map/components/overlays/MapConnectionContextMenu.vue
@@ -10,6 +10,7 @@ import {
     ContextMenuSubTrigger,
 } from '@/components/ui/context-menu';
 import { useStaticData } from '@/composables/useStaticData';
+import { shipSizeFromJumpMass } from '@/lib/shipSize';
 import { formatDateToISO } from '@/lib/utils';
 import { deleteMapConnection } from '@/map/actions/deleteMapConnection';
 import { updateMapConnection } from '@/map/actions/updateMapConnection';
@@ -27,6 +28,16 @@ const { map_connection } = defineProps<{
 
 const { staticData, loadStaticData } = useStaticData();
 void loadStaticData();
+
+// An identified wormhole type on a linked signature dictates the ship size,
+// so the manual options are locked while one is present.
+const locked_ship_size = computed(() => {
+    for (const signature of map_connection.signatures ?? []) {
+        const size = shipSizeFromJumpMass(signature.wormhole?.maximum_jump_mass);
+        if (size) return size;
+    }
+    return null;
+});
 
 // Whether the two systems are actually joined by a stargate in the static data.
 // Used to warn (but not block) when marking a connection as a stargate.
@@ -134,23 +145,24 @@ function handleLifetimeChange(lifetime: AcceptableValue) {
             </ContextMenuSubTrigger>
             <ContextMenuSubContent>
                 <ContextMenuRadioGroup :model-value="map_connection.ship_size" @update:model-value="handleShipSizeChange">
-                    <ContextMenuRadioItem value="frigate" class="flex items-center gap-2">
+                    <ContextMenuRadioItem value="frigate" class="flex items-center gap-2" :disabled="locked_ship_size !== null">
                         <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">S</span>
                         Frigate
                     </ContextMenuRadioItem>
-                    <ContextMenuRadioItem value="medium" class="flex items-center gap-2">
+                    <ContextMenuRadioItem value="medium" class="flex items-center gap-2" :disabled="locked_ship_size !== null">
                         <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">M</span>
                         Medium
                     </ContextMenuRadioItem>
-                    <ContextMenuRadioItem value="large" class="flex items-center gap-2">
+                    <ContextMenuRadioItem value="large" class="flex items-center gap-2" :disabled="locked_ship_size !== null">
                         <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">L</span>
                         Large
                     </ContextMenuRadioItem>
-                    <ContextMenuRadioItem value="xlarge" class="flex items-center gap-2">
+                    <ContextMenuRadioItem value="xlarge" class="flex items-center gap-2" :disabled="locked_ship_size !== null">
                         <span class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground">XL</span>
                         Extra Large
                     </ContextMenuRadioItem>
                 </ContextMenuRadioGroup>
+                <div v-if="locked_ship_size" class="px-2 py-1 text-[10px] text-muted-foreground">Locked by the identified wormhole type</div>
             </ContextMenuSubContent>
         </ContextMenuSub>
         <ContextMenuSub>

--- a/resources/js/map/components/overlays/MapConnectionContextMenu.vue
+++ b/resources/js/map/components/overlays/MapConnectionContextMenu.vue
@@ -136,28 +136,28 @@ function handleLifetimeChange(lifetime: AcceptableValue) {
                 <ContextMenuRadioGroup :model-value="map_connection.ship_size" @update:model-value="handleShipSizeChange">
                     <ContextMenuRadioItem value="frigate" class="flex items-center gap-2">
                         <span
-                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                            class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
                             >S</span
                         >
                         Frigate
                     </ContextMenuRadioItem>
                     <ContextMenuRadioItem value="medium" class="flex items-center gap-2">
                         <span
-                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                            class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
                             >M</span
                         >
                         Medium
                     </ContextMenuRadioItem>
                     <ContextMenuRadioItem value="large" class="flex items-center gap-2">
                         <span
-                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                            class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
                             >L</span
                         >
                         Large
                     </ContextMenuRadioItem>
                     <ContextMenuRadioItem value="xlarge" class="flex items-center gap-2">
                         <span
-                            class="inline-flex w-6 justify-center rounded-sm border border-border/60 font-mono text-[10px] leading-4 text-muted-foreground"
+                            class="inline-flex w-6 justify-center font-mono text-[10px] leading-4 text-muted-foreground"
                             >XL</span
                         >
                         Extra Large

--- a/resources/js/map/components/overlays/connection/WormholeProperties.vue
+++ b/resources/js/map/components/overlays/connection/WormholeProperties.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SHIP_SIZE_LETTERS, shipSizeFromJumpMass } from '@/lib/shipSize';
 import { formatKilotons } from '@/lib/utils';
 import { computed } from 'vue';
 
@@ -14,13 +15,8 @@ const { wormhole } = defineProps<{
 const maximumLifetime = computed(() => wormhole.maximum_lifetime / 3600);
 
 const ship_size = computed(() => {
-    const jump_mass = wormhole.maximum_jump_mass / 1_000_000;
-
-    if (jump_mass >= 1_000) return 'XL';
-    if (jump_mass >= 62) return 'L';
-    if (jump_mass >= 5) return 'M';
-
-    return 'S';
+    const size = shipSizeFromJumpMass(wormhole.maximum_jump_mass);
+    return size ? SHIP_SIZE_LETTERS[size] : '—';
 });
 </script>
 

--- a/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
+++ b/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import Appearance from '@/layouts/Appearance.vue';
-import { TMapConnection, TMapSolarsystem } from '@/pages/maps';
+import { TMapConnection, TMapSolarsystem, TWormhole } from '@/pages/maps';
 import { TLifetimeStatus, TMassStatus, TSignature, TStringedSolarsystemClass } from '@/types/models';
 import { RotateCcw } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
@@ -36,6 +36,8 @@ function sig(input: {
     category?: 'wormhole' | 'gas' | 'data' | 'relic' | 'combat' | 'ore';
     code?: string;
     targetClass?: TStringedSolarsystemClass | 'unknown';
+    /** Maximum jump mass of the identified wormhole type; locks the ship size select. */
+    jumpMass?: number;
     extra?: string | null;
     rawTypeName?: string;
     /** Marks the signature as already tied to a connection leading to this map solarsystem id. */
@@ -72,6 +74,7 @@ function sig(input: {
         signature_category: input.category
             ? { id, name: input.category, code: input.category, created_at: minutesAgo(0), updated_at: minutesAgo(0) }
             : null,
+        wormhole: input.jumpMass ? ({ id, name: input.code ?? 'K162', maximum_jump_mass: input.jumpMass } as TWormhole) : null,
         lifetime: input.lifetime ?? 'healthy',
         mass_status: input.massStatus ?? null,
         created_at: minutesAgo(input.createdMinutesAgo ?? 30),
@@ -103,7 +106,7 @@ const scenarios: TScenario[] = [
         targetClass: '4',
         suggestedAlias: 'HOME-A',
         signatures: [
-            sig({ signatureId: 'ABC-123', category: 'wormhole', code: 'X877', targetClass: '4', createdMinutesAgo: 12 }),
+            sig({ signatureId: 'ABC-123', category: 'wormhole', code: 'X877', targetClass: '4', jumpMass: 375_000_000, createdMinutesAgo: 12 }),
             sig({ signatureId: 'DEF-456', category: 'wormhole', code: 'K162', targetClass: 'unknown', createdMinutesAgo: 45 }),
             sig({ signatureId: 'GHI-789', category: 'wormhole', code: 'U210', targetClass: 'l', createdMinutesAgo: 80 }),
             sig({ signatureId: 'JKL-012', category: 'wormhole', code: 'Z142', targetClass: 'n', createdMinutesAgo: 200 }),
@@ -120,7 +123,7 @@ const scenarios: TScenario[] = [
         targetClass: 'h',
         suggestedAlias: null,
         signatures: [
-            sig({ signatureId: 'AAA-111', category: 'wormhole', code: 'B274', targetClass: 'h', createdMinutesAgo: 20 }),
+            sig({ signatureId: 'AAA-111', category: 'wormhole', code: 'B274', targetClass: 'h', jumpMass: 375_000_000, createdMinutesAgo: 20 }),
             sig({ signatureId: 'BBB-222', category: 'wormhole', code: 'U210', targetClass: 'l', createdMinutesAgo: 60 }),
             sig({ signatureId: 'CCC-333', category: 'wormhole', code: 'D845', targetClass: 'h', lifetime: 'eol', createdMinutesAgo: 900 }),
             sig({ signatureId: 'DDD-444', category: 'relic', rawTypeName: 'Forgotten Frontier Quarantine Outpost' }),
@@ -158,7 +161,15 @@ const scenarios: TScenario[] = [
         signatures: Array.from({ length: 24 }, (_, index) => {
             const signatureId = `${String.fromCharCode(75 + (index % 12))}${String.fromCharCode(65 + (index % 8))}Q-${String(100 + index * 7).slice(0, 3)}`;
             if (index % 5 === 4) return sig({ signatureId, category: 'gas', rawTypeName: 'Vast Frontier Reservoir' });
-            if (index % 3 === 2) return sig({ signatureId, category: 'wormhole', code: 'H296', targetClass: '5', createdMinutesAgo: index * 30 });
+            if (index % 3 === 2)
+                return sig({
+                    signatureId,
+                    category: 'wormhole',
+                    code: 'H296',
+                    targetClass: '5',
+                    jumpMass: 2_000_000_000,
+                    createdMinutesAgo: index * 30,
+                });
             if (index % 3 === 1)
                 return sig({
                     signatureId,
@@ -179,7 +190,15 @@ const scenarios: TScenario[] = [
         targetClass: '3',
         suggestedAlias: null,
         signatures: [
-            sig({ signatureId: 'KKK-111', category: 'wormhole', code: 'C247', targetClass: '3', lifetime: 'eol', massStatus: 'reduced' }),
+            sig({
+                signatureId: 'KKK-111',
+                category: 'wormhole',
+                code: 'C247',
+                targetClass: '3',
+                jumpMass: 375_000_000,
+                lifetime: 'eol',
+                massStatus: 'reduced',
+            }),
             sig({ signatureId: 'LLL-222', category: 'wormhole', code: 'K162', targetClass: 'unknown', lifetime: 'critical', massStatus: 'critical' }),
         ],
     },

--- a/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
+++ b/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
@@ -3,7 +3,7 @@ import TrackingSignatureDialog from '@/components/map/TrackingSignatureDialog.vu
 import { Button } from '@/components/ui/button';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import Appearance from '@/layouts/Appearance.vue';
-import { TMapSolarsystem } from '@/pages/maps';
+import { TMapConnection, TMapSolarsystem } from '@/pages/maps';
 import { TLifetimeStatus, TMassStatus, TSignature, TStringedSolarsystemClass } from '@/types/models';
 import { RotateCcw } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
@@ -37,7 +37,8 @@ function sig(input: {
     targetClass?: TStringedSolarsystemClass | 'unknown';
     extra?: string | null;
     rawTypeName?: string;
-    connected?: boolean;
+    /** Marks the signature as already tied to a connection leading to this map solarsystem id. */
+    connectedToId?: number;
     lifetime?: TLifetimeStatus;
     massStatus?: TMassStatus;
     createdMinutesAgo?: number;
@@ -51,7 +52,10 @@ function sig(input: {
         signature_type_id: input.code ? id : null,
         signature_category_id: input.category ? id : null,
         raw_type_name: input.rawTypeName ?? null,
-        map_connection_id: input.connected ? id : null,
+        map_connection_id: input.connectedToId ? id : null,
+        map_connection: input.connectedToId
+            ? ({ id, from_map_solarsystem_id: ORIGIN_ID, to_map_solarsystem_id: input.connectedToId } as TMapConnection)
+            : null,
         signature_type: input.code
             ? {
                   id,
@@ -74,17 +78,26 @@ function sig(input: {
     } as TSignature;
 }
 
+const ORIGIN_ID = 1;
+
 const ORIGIN = {
-    id: 1,
+    id: ORIGIN_ID,
     alias: 'HOME',
     solarsystem: { name: 'J152820' },
 } as TMapSolarsystem;
+
+/** Map systems the connected fixtures can lead to. */
+const MAP_SOLARSYSTEMS = [
+    ORIGIN,
+    { id: 2, alias: 'HOME-A', solarsystem: { name: 'J145510' } } as TMapSolarsystem,
+    { id: 3, alias: null, solarsystem: { name: 'J104859' } } as TMapSolarsystem,
+];
 
 const scenarios: TScenario[] = [
     {
         key: 'typical-c4',
         title: 'Typical C4 jump',
-        description: 'Mixed bag: matching types, wrong classes, sites, a connected hole, and unscanned signatures.',
+        description: 'Mixed bag: matching types, wrong classes, a connected hole, unscanned signatures, and a gas site that must not appear.',
         targetName: 'J145510',
         targetClass: '4',
         suggestedAlias: 'HOME-A',
@@ -95,7 +108,7 @@ const scenarios: TScenario[] = [
             sig({ signatureId: 'JKL-012', category: 'wormhole', code: 'Z142', targetClass: 'n', createdMinutesAgo: 200 }),
             sig({ signatureId: 'MNO-345', category: 'gas', code: undefined, rawTypeName: 'Bountiful Frontier Reservoir' }),
             sig({ signatureId: 'PQR-678' }),
-            sig({ signatureId: 'STU-901', category: 'wormhole', code: 'X877', targetClass: '4', connected: true, createdMinutesAgo: 300 }),
+            sig({ signatureId: 'STU-901', category: 'wormhole', code: 'X877', targetClass: '4', connectedToId: 2, createdMinutesAgo: 300 }),
         ],
     },
     {
@@ -115,7 +128,7 @@ const scenarios: TScenario[] = [
     {
         key: 'all-unlikely',
         title: 'Everything unlikely',
-        description: 'No signature fits the destination: only the demoted section has options.',
+        description: 'No signature fits the destination: only the demoted section has options, and the sites are hidden entirely.',
         targetName: 'J105830',
         targetClass: '5',
         suggestedAlias: 'HOME-B',
@@ -137,7 +150,7 @@ const scenarios: TScenario[] = [
     {
         key: 'crowded',
         title: 'Crowded system',
-        description: 'A C5 with two dozen signatures: scrolling, search, and both sections populated.',
+        description: 'A C6 with two dozen signatures: scrolling, search, and all three sections populated.',
         targetName: 'J104859',
         targetClass: '6',
         suggestedAlias: 'DEEP-1',
@@ -152,7 +165,7 @@ const scenarios: TScenario[] = [
                     code: 'V753',
                     targetClass: '6',
                     createdMinutesAgo: index * 15,
-                    connected: index === 1,
+                    connectedToId: index === 1 ? 3 : undefined,
                 });
             return sig({ signatureId, createdMinutesAgo: index * 10 });
         }),
@@ -240,6 +253,7 @@ function handleSelection(selection: Record<string, unknown>): void {
                 :target-solarsystem-class="activeScenario?.targetClass ?? null"
                 :signatures="activeSignatures"
                 :suggested-alias="activeScenario?.suggestedAlias"
+                :map-solarsystems="MAP_SOLARSYSTEMS"
                 @select-signature="handleSelection"
             />
         </div>

--- a/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
+++ b/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import TrackingSignatureDialog from '@/components/map/TrackingSignatureDialog.vue';
+import { Button } from '@/components/ui/button';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import Appearance from '@/layouts/Appearance.vue';
+import { TMapSolarsystem } from '@/pages/maps';
+import { TLifetimeStatus, TMassStatus, TSignature, TStringedSolarsystemClass } from '@/types/models';
+import { RotateCcw } from 'lucide-vue-next';
+import { computed, ref } from 'vue';
+
+/**
+ * Local-only playground for the "which signature did you jump" prompt: renders
+ * the real TrackingSignatureDialog against canned scenarios so layout changes
+ * can be checked for every case without jumping systems in game.
+ */
+
+type TScenario = {
+    key: string;
+    title: string;
+    description: string;
+    targetName: string;
+    targetClass: TStringedSolarsystemClass;
+    suggestedAlias: string | null;
+    signatures: TSignature[];
+};
+
+let nextId = 1;
+
+function minutesAgo(minutes: number): string {
+    return new Date(Date.now() - minutes * 60_000).toISOString();
+}
+
+function sig(input: {
+    signatureId: string;
+    category?: 'wormhole' | 'gas' | 'data' | 'relic' | 'combat' | 'ore';
+    code?: string;
+    targetClass?: TStringedSolarsystemClass | 'unknown';
+    extra?: string | null;
+    rawTypeName?: string;
+    connected?: boolean;
+    lifetime?: TLifetimeStatus;
+    massStatus?: TMassStatus;
+    createdMinutesAgo?: number;
+}): TSignature {
+    const id = nextId++;
+    const isWormhole = input.category === 'wormhole';
+
+    return {
+        id,
+        signature_id: input.signatureId,
+        signature_type_id: input.code ? id : null,
+        signature_category_id: input.category ? id : null,
+        raw_type_name: input.rawTypeName ?? null,
+        map_connection_id: input.connected ? id : null,
+        signature_type: input.code
+            ? {
+                  id,
+                  name: `${input.code} - ${input.targetClass ?? '?'}`,
+                  signature: input.code,
+                  signature_category_id: id,
+                  category_name: isWormhole ? 'Wormhole' : (input.category ?? null),
+                  target_class: input.targetClass ?? null,
+                  extra: input.extra ?? null,
+                  spawn_areas: null,
+              }
+            : null,
+        signature_category: input.category
+            ? { id, name: input.category, code: input.category, created_at: minutesAgo(0), updated_at: minutesAgo(0) }
+            : null,
+        lifetime: input.lifetime ?? 'healthy',
+        mass_status: input.massStatus ?? null,
+        created_at: minutesAgo(input.createdMinutesAgo ?? 30),
+        updated_at: minutesAgo(input.createdMinutesAgo ?? 30),
+    } as TSignature;
+}
+
+const ORIGIN = {
+    id: 1,
+    alias: 'HOME',
+    solarsystem: { name: 'J152820' },
+} as TMapSolarsystem;
+
+const scenarios: TScenario[] = [
+    {
+        key: 'typical-c4',
+        title: 'Typical C4 jump',
+        description: 'Mixed bag: matching types, wrong classes, sites, a connected hole, and unscanned signatures.',
+        targetName: 'J145510',
+        targetClass: '4',
+        suggestedAlias: 'HOME-A',
+        signatures: [
+            sig({ signatureId: 'ABC-123', category: 'wormhole', code: 'X877', targetClass: '4', createdMinutesAgo: 12 }),
+            sig({ signatureId: 'DEF-456', category: 'wormhole', code: 'K162', targetClass: 'unknown', createdMinutesAgo: 45 }),
+            sig({ signatureId: 'GHI-789', category: 'wormhole', code: 'U210', targetClass: 'l', createdMinutesAgo: 80 }),
+            sig({ signatureId: 'JKL-012', category: 'wormhole', code: 'Z142', targetClass: 'n', createdMinutesAgo: 200 }),
+            sig({ signatureId: 'MNO-345', category: 'gas', code: undefined, rawTypeName: 'Bountiful Frontier Reservoir' }),
+            sig({ signatureId: 'PQR-678' }),
+            sig({ signatureId: 'STU-901', category: 'wormhole', code: 'X877', targetClass: '4', connected: true, createdMinutesAgo: 300 }),
+        ],
+    },
+    {
+        key: 'highsec-exit',
+        title: 'Highsec exit',
+        description: 'Jump into highsec: exact class match on k-space classes.',
+        targetName: 'Jita',
+        targetClass: 'h',
+        suggestedAlias: null,
+        signatures: [
+            sig({ signatureId: 'AAA-111', category: 'wormhole', code: 'B274', targetClass: 'h', createdMinutesAgo: 20 }),
+            sig({ signatureId: 'BBB-222', category: 'wormhole', code: 'U210', targetClass: 'l', createdMinutesAgo: 60 }),
+            sig({ signatureId: 'CCC-333', category: 'wormhole', code: 'D845', targetClass: 'h', lifetime: 'eol', createdMinutesAgo: 900 }),
+            sig({ signatureId: 'DDD-444', category: 'relic', rawTypeName: 'Forgotten Frontier Quarantine Outpost' }),
+        ],
+    },
+    {
+        key: 'all-unlikely',
+        title: 'Everything unlikely',
+        description: 'No signature fits the destination: only the demoted section has options.',
+        targetName: 'J105830',
+        targetClass: '5',
+        suggestedAlias: 'HOME-B',
+        signatures: [
+            sig({ signatureId: 'EEE-555', category: 'wormhole', code: 'B274', targetClass: 'h' }),
+            sig({ signatureId: 'FFF-666', category: 'combat', rawTypeName: 'Fortification Frontier Stronghold' }),
+            sig({ signatureId: 'GGG-777', category: 'data', rawTypeName: 'Unsecured Frontier Database' }),
+        ],
+    },
+    {
+        key: 'unscanned-only',
+        title: 'Unscanned signatures',
+        description: 'Nothing resolved yet: every option is a bare signature id.',
+        targetName: 'J170211',
+        targetClass: '3',
+        suggestedAlias: null,
+        signatures: [sig({ signatureId: 'HHH-888' }), sig({ signatureId: 'III-999' }), sig({ signatureId: 'JJJ-000' })],
+    },
+    {
+        key: 'crowded',
+        title: 'Crowded system',
+        description: 'A C5 with two dozen signatures: scrolling, search, and both sections populated.',
+        targetName: 'J104859',
+        targetClass: '6',
+        suggestedAlias: 'DEEP-1',
+        signatures: Array.from({ length: 24 }, (_, index) => {
+            const signatureId = `${String.fromCharCode(75 + (index % 12))}${String.fromCharCode(65 + (index % 8))}Q-${String(100 + index * 7).slice(0, 3)}`;
+            if (index % 5 === 4) return sig({ signatureId, category: 'gas', rawTypeName: 'Vast Frontier Reservoir' });
+            if (index % 3 === 2) return sig({ signatureId, category: 'wormhole', code: 'H296', targetClass: '5', createdMinutesAgo: index * 30 });
+            if (index % 3 === 1)
+                return sig({
+                    signatureId,
+                    category: 'wormhole',
+                    code: 'V753',
+                    targetClass: '6',
+                    createdMinutesAgo: index * 15,
+                    connected: index === 1,
+                });
+            return sig({ signatureId, createdMinutesAgo: index * 10 });
+        }),
+    },
+    {
+        key: 'eol-critical',
+        title: 'EOL and critical holes',
+        description: 'Signatures carrying lifetime and mass state that prefill the selectors.',
+        targetName: 'J121856',
+        targetClass: '3',
+        suggestedAlias: null,
+        signatures: [
+            sig({ signatureId: 'KKK-111', category: 'wormhole', code: 'C247', targetClass: '3', lifetime: 'eol', massStatus: 'reduced' }),
+            sig({ signatureId: 'LLL-222', category: 'wormhole', code: 'K162', targetClass: 'unknown', lifetime: 'critical', massStatus: 'critical' }),
+        ],
+    },
+];
+
+const activeScenario = ref<TScenario | null>(null);
+const dialogOpen = ref(false);
+const lastSelection = ref<Record<string, unknown> | null>(null);
+
+const activeSignatures = computed(() => activeScenario.value?.signatures ?? []);
+
+function openScenario(scenario: TScenario): void {
+    activeScenario.value = scenario;
+    lastSelection.value = null;
+    dialogOpen.value = true;
+}
+
+function handleSelection(selection: Record<string, unknown>): void {
+    lastSelection.value = selection;
+    dialogOpen.value = false;
+}
+</script>
+
+<template>
+    <TooltipProvider :delay-duration="300">
+        <div class="min-h-screen bg-background p-8 text-foreground">
+            <div class="mx-auto max-w-3xl">
+                <div class="flex items-start justify-between gap-4">
+                    <p class="font-mono text-[10px] tracking-wider text-muted-foreground uppercase">Debug · local only</p>
+                    <Appearance />
+                </div>
+                <h1 class="mt-2 font-display text-2xl font-bold tracking-tight">Tracking signature dialog preview</h1>
+                <p class="mt-2 text-sm text-muted-foreground">
+                    Pick a scenario to open the real jump prompt with canned signatures. Closing or confirming shows the emitted selection below.
+                </p>
+
+                <div class="mt-8 grid gap-3 sm:grid-cols-2">
+                    <button
+                        v-for="scenario in scenarios"
+                        :key="scenario.key"
+                        type="button"
+                        class="flex flex-col gap-1 rounded bg-card p-4 text-left ring-1 ring-border transition-shadow hover:ring-foreground/25"
+                        @click="openScenario(scenario)"
+                    >
+                        <span class="font-display font-bold">{{ scenario.title }}</span>
+                        <span class="text-sm leading-6 text-muted-foreground">{{ scenario.description }}</span>
+                        <span class="mt-2 font-mono text-[10px] tracking-wider text-muted-foreground uppercase">
+                            → {{ scenario.targetName }} · class {{ scenario.targetClass }} · {{ scenario.signatures.length }} signatures
+                        </span>
+                    </button>
+                </div>
+
+                <div v-if="activeScenario" class="mt-8 flex items-center gap-3">
+                    <Button variant="outline" size="sm" class="gap-2" @click="dialogOpen = true">
+                        <RotateCcw class="size-3.5" />
+                        Reopen {{ activeScenario.title }}
+                    </Button>
+                </div>
+
+                <div v-if="lastSelection" class="mt-6 overflow-hidden rounded bg-card ring-1 ring-border">
+                    <div class="border-b border-border/50 bg-muted/30 px-3 py-2 font-mono text-[10px] tracking-wider text-muted-foreground uppercase">
+                        Last emitted selection
+                    </div>
+                    <pre class="overflow-x-auto p-4 text-xs">{{ JSON.stringify(lastSelection, null, 2) }}</pre>
+                </div>
+            </div>
+
+            <TrackingSignatureDialog
+                v-model:open="dialogOpen"
+                :origin-map-solarsystem="ORIGIN"
+                :target-solarsystem-name="activeScenario?.targetName ?? null"
+                :target-solarsystem-class="activeScenario?.targetClass ?? null"
+                :signatures="activeSignatures"
+                :suggested-alias="activeScenario?.suggestedAlias"
+                @select-signature="handleSelection"
+            />
+        </div>
+    </TooltipProvider>
+</template>

--- a/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
+++ b/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import TrackingSignatureDialog from '@/components/map/TrackingSignatureDialog.vue';
+import { MAP_SOLARSYSTEMS, ORIGIN, sig } from '@/components/map/trackingSignatureFixtures';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import Appearance from '@/layouts/Appearance.vue';
-import { TMapConnection, TMapSolarsystem, TWormhole } from '@/pages/maps';
-import { TLifetimeStatus, TMassStatus, TSignature, TStringedSolarsystemClass } from '@/types/models';
+import { TSignature, TStringedSolarsystemClass } from '@/types/models';
 import { RotateCcw } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
 
@@ -25,78 +25,6 @@ type TScenario = {
     signatures: TSignature[];
 };
 
-let nextId = 1;
-
-function minutesAgo(minutes: number): string {
-    return new Date(Date.now() - minutes * 60_000).toISOString();
-}
-
-function sig(input: {
-    signatureId: string;
-    category?: 'wormhole' | 'gas' | 'data' | 'relic' | 'combat' | 'ore';
-    code?: string;
-    targetClass?: TStringedSolarsystemClass | 'unknown';
-    /** Maximum jump mass of the identified wormhole type; locks the ship size select. */
-    jumpMass?: number;
-    extra?: string | null;
-    rawTypeName?: string;
-    /** Marks the signature as already tied to a connection leading to this map solarsystem id. */
-    connectedToId?: number;
-    lifetime?: TLifetimeStatus;
-    massStatus?: TMassStatus;
-    createdMinutesAgo?: number;
-}): TSignature {
-    const id = nextId++;
-    const isWormhole = input.category === 'wormhole';
-
-    return {
-        id,
-        signature_id: input.signatureId,
-        signature_type_id: input.code ? id : null,
-        signature_category_id: input.category ? id : null,
-        raw_type_name: input.rawTypeName ?? null,
-        map_connection_id: input.connectedToId ? id : null,
-        map_connection: input.connectedToId
-            ? ({ id, from_map_solarsystem_id: ORIGIN_ID, to_map_solarsystem_id: input.connectedToId } as TMapConnection)
-            : null,
-        signature_type: input.code
-            ? {
-                  id,
-                  name: `${input.code} - ${input.targetClass ?? '?'}`,
-                  signature: input.code,
-                  signature_category_id: id,
-                  category_name: isWormhole ? 'Wormhole' : (input.category ?? null),
-                  target_class: input.targetClass ?? null,
-                  extra: input.extra ?? null,
-                  spawn_areas: null,
-              }
-            : null,
-        signature_category: input.category
-            ? { id, name: input.category, code: input.category, created_at: minutesAgo(0), updated_at: minutesAgo(0) }
-            : null,
-        wormhole: input.jumpMass ? ({ id, name: input.code ?? 'K162', maximum_jump_mass: input.jumpMass } as TWormhole) : null,
-        lifetime: input.lifetime ?? 'healthy',
-        mass_status: input.massStatus ?? null,
-        created_at: minutesAgo(input.createdMinutesAgo ?? 30),
-        updated_at: minutesAgo(input.createdMinutesAgo ?? 30),
-    } as TSignature;
-}
-
-const ORIGIN_ID = 1;
-
-const ORIGIN = {
-    id: ORIGIN_ID,
-    alias: 'HOME',
-    solarsystem: { name: 'J152820' },
-} as TMapSolarsystem;
-
-/** Map systems the connected fixtures can lead to. */
-const MAP_SOLARSYSTEMS = [
-    ORIGIN,
-    { id: 2, alias: 'HOME-A', solarsystem: { name: 'J145510' } } as TMapSolarsystem,
-    { id: 3, alias: null, solarsystem: { name: 'J104859' } } as TMapSolarsystem,
-];
-
 const scenarios: TScenario[] = [
     {
         key: 'typical-c4',
@@ -106,13 +34,13 @@ const scenarios: TScenario[] = [
         targetClass: '4',
         suggestedAlias: 'HOME-A',
         signatures: [
-            sig({ signatureId: 'ABC-123', category: 'wormhole', code: 'X877', targetClass: '4', jumpMass: 375_000_000, createdMinutesAgo: 12 }),
-            sig({ signatureId: 'DEF-456', category: 'wormhole', code: 'K162', targetClass: 'unknown', createdMinutesAgo: 45 }),
-            sig({ signatureId: 'GHI-789', category: 'wormhole', code: 'U210', targetClass: 'l', createdMinutesAgo: 80 }),
-            sig({ signatureId: 'JKL-012', category: 'wormhole', code: 'Z142', targetClass: 'n', createdMinutesAgo: 200 }),
+            sig({ signatureId: 'ABC-123', category: 'wormhole', code: 'X877', targetClass: '4', jumpMass: 375_000_000 }),
+            sig({ signatureId: 'DEF-456', category: 'wormhole', code: 'K162', targetClass: 'unknown' }),
+            sig({ signatureId: 'GHI-789', category: 'wormhole', code: 'U210', targetClass: 'l' }),
+            sig({ signatureId: 'JKL-012', category: 'wormhole', code: 'Z142', targetClass: 'n' }),
             sig({ signatureId: 'MNO-345', category: 'gas', code: undefined, rawTypeName: 'Bountiful Frontier Reservoir' }),
             sig({ signatureId: 'PQR-678' }),
-            sig({ signatureId: 'STU-901', category: 'wormhole', code: 'X877', targetClass: '4', connectedToId: 2, createdMinutesAgo: 300 }),
+            sig({ signatureId: 'STU-901', category: 'wormhole', code: 'X877', targetClass: '4', connectedToId: 2 }),
         ],
     },
     {
@@ -123,9 +51,9 @@ const scenarios: TScenario[] = [
         targetClass: 'h',
         suggestedAlias: null,
         signatures: [
-            sig({ signatureId: 'AAA-111', category: 'wormhole', code: 'B274', targetClass: 'h', jumpMass: 375_000_000, createdMinutesAgo: 20 }),
-            sig({ signatureId: 'BBB-222', category: 'wormhole', code: 'U210', targetClass: 'l', createdMinutesAgo: 60 }),
-            sig({ signatureId: 'CCC-333', category: 'wormhole', code: 'D845', targetClass: 'h', lifetime: 'eol', createdMinutesAgo: 900 }),
+            sig({ signatureId: 'AAA-111', category: 'wormhole', code: 'B274', targetClass: 'h', jumpMass: 375_000_000 }),
+            sig({ signatureId: 'BBB-222', category: 'wormhole', code: 'U210', targetClass: 'l' }),
+            sig({ signatureId: 'CCC-333', category: 'wormhole', code: 'D845', targetClass: 'h', lifetime: 'eol' }),
             sig({ signatureId: 'DDD-444', category: 'relic', rawTypeName: 'Forgotten Frontier Quarantine Outpost' }),
         ],
     },
@@ -168,7 +96,6 @@ const scenarios: TScenario[] = [
                     code: 'H296',
                     targetClass: '5',
                     jumpMass: 2_000_000_000,
-                    createdMinutesAgo: index * 30,
                 });
             if (index % 3 === 1)
                 return sig({
@@ -176,10 +103,9 @@ const scenarios: TScenario[] = [
                     category: 'wormhole',
                     code: 'V753',
                     targetClass: '6',
-                    createdMinutesAgo: index * 15,
                     connectedToId: index === 1 ? 3 : undefined,
                 });
-            return sig({ signatureId, createdMinutesAgo: index * 10 });
+            return sig({ signatureId });
         }),
     },
     {

--- a/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
+++ b/resources/js/pages/debug/TrackingSignatureDialogPreview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import TrackingSignatureDialog from '@/components/map/TrackingSignatureDialog.vue';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import Appearance from '@/layouts/Appearance.vue';
 import { TMapConnection, TMapSolarsystem } from '@/pages/maps';
@@ -184,6 +185,8 @@ const scenarios: TScenario[] = [
     },
 ];
 
+const preselectFirst = ref(false);
+
 const activeScenario = ref<TScenario | null>(null);
 const dialogOpen = ref(false);
 const lastSelection = ref<Record<string, unknown> | null>(null);
@@ -231,6 +234,11 @@ function handleSelection(selection: Record<string, unknown>): void {
                     </button>
                 </div>
 
+                <label class="mt-6 flex w-fit items-center gap-2 text-sm text-muted-foreground">
+                    <Checkbox :model-value="preselectFirst" @update:model-value="(value) => (preselectFirst = value === true)" />
+                    Preselect the first likely signature
+                </label>
+
                 <div v-if="activeScenario" class="mt-8 flex items-center gap-3">
                     <Button variant="outline" size="sm" class="gap-2" @click="dialogOpen = true">
                         <RotateCcw class="size-3.5" />
@@ -254,6 +262,7 @@ function handleSelection(selection: Record<string, unknown>): void {
                 :signatures="activeSignatures"
                 :suggested-alias="activeScenario?.suggestedAlias"
                 :map-solarsystems="MAP_SOLARSYSTEMS"
+                :preselect-first-signature="preselectFirst"
                 @select-signature="handleSelection"
             />
         </div>

--- a/resources/js/pages/maps/index.ts
+++ b/resources/js/pages/maps/index.ts
@@ -235,7 +235,6 @@ export type TWormhole = {
     name: string;
     total_mass: number;
     maximum_jump_mass: number;
-    ship_size: string;
     maximum_lifetime: number;
     leads_to: string;
     signature_strength: number | null;

--- a/resources/js/pages/maps/settings/ShowMapping.vue
+++ b/resources/js/pages/maps/settings/ShowMapping.vue
@@ -62,6 +62,12 @@ function handlePromptForSignatureChange(value: boolean | 'indeterminate') {
     }
 }
 
+function handlePreselectSignatureChange(value: boolean | 'indeterminate') {
+    if (typeof value === 'boolean') {
+        updateMapUserSettings({ preselect_signature_enabled: value });
+    }
+}
+
 function handleSuggestAliasChange(value: boolean | 'indeterminate') {
     if (typeof value === 'boolean') {
         updateMapUserSettings({ suggest_alias_enabled: value });
@@ -162,6 +168,16 @@ function handleSolarsystemSelect(solarsystem: TStaticSolarsystem) {
                             :model-value="map_user_settings.prompt_for_signature_enabled"
                             @update:model-value="handlePromptForSignatureChange"
                         />
+                    </div>
+
+                    <div class="flex items-center justify-between" v-if="map_user_settings.prompt_for_signature_enabled">
+                        <div class="space-y-0.5">
+                            <Label class="text-sm font-medium">Preselect First Signature</Label>
+                            <div class="text-sm text-muted-foreground">
+                                Pre-select the first likely signature in the jump prompt, so working through holes alphabetically only takes Enter
+                            </div>
+                        </div>
+                        <Checkbox :model-value="map_user_settings.preselect_signature_enabled" @update:model-value="handlePreselectSignatureChange" />
                     </div>
 
                     <div class="flex items-center justify-between">

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -285,6 +285,7 @@ export type TMapUserSetting = {
     killmail_filter: 'all' | 'jspace' | 'kspace';
     introduction_confirmed_at: string | null;
     prompt_for_signature_enabled: boolean;
+    preselect_signature_enabled: boolean;
     suggest_alias_enabled: boolean;
     copy_bookmark_enabled: boolean;
     layout_breakpoints?: Record<string, any> | null;

--- a/routes/debug.php
+++ b/routes/debug.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/*
+ * Debug-only routes. Registered exclusively in local and testing environments;
+ * see the routing configuration in bootstrap/app.php.
+ */
+
+Route::get('debug/tracking-signature-dialog', fn (): Response => Inertia::render('debug/TrackingSignatureDialogPreview', [
+    'map' => ['slug' => 'debug-preview'],
+]))->name('debug.tracking-signature-dialog');

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,8 @@ use App\Http\Controllers\UserCharacterController;
 use App\Http\Controllers\WaypointController;
 use App\Http\Middleware\SetMapShareToken;
 use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use Inertia\Response;
 
 Route::get('/', [LandingController::class, 'index'])->name('landing')->middleware('guest');
 Route::get('documentation/{path?}', [DocumentationController::class, 'index'])->where('path', '.*')->name('documentation');
@@ -54,6 +56,12 @@ Route::get('login', [LoginController::class, 'show'])->name('login');
 Route::get('auth', [AuthController::class, 'show'])->name('auth');
 Route::get('eve', [EveController::class, 'show'])->name('eve.show');
 Route::get('eve/callback', [EveController::class, 'store'])->name('eve.store');
+
+if (! app()->environment('production')) {
+    Route::get('debug/tracking-signature-dialog', fn (): Response => Inertia::render('debug/TrackingSignatureDialogPreview', [
+        'map' => ['slug' => 'debug-preview'],
+    ]))->name('debug.tracking-signature-dialog');
+}
 
 Route::middleware('auth')->group(function () {
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,8 +47,6 @@ use App\Http\Controllers\UserCharacterController;
 use App\Http\Controllers\WaypointController;
 use App\Http\Middleware\SetMapShareToken;
 use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
-use Inertia\Response;
 
 Route::get('/', [LandingController::class, 'index'])->name('landing')->middleware('guest');
 Route::get('documentation/{path?}', [DocumentationController::class, 'index'])->where('path', '.*')->name('documentation');
@@ -56,12 +54,6 @@ Route::get('login', [LoginController::class, 'show'])->name('login');
 Route::get('auth', [AuthController::class, 'show'])->name('auth');
 Route::get('eve', [EveController::class, 'show'])->name('eve.show');
 Route::get('eve/callback', [EveController::class, 'store'])->name('eve.store');
-
-if (! app()->environment('production')) {
-    Route::get('debug/tracking-signature-dialog', fn (): Response => Inertia::render('debug/TrackingSignatureDialogPreview', [
-        'map' => ['slug' => 'debug-preview'],
-    ]))->name('debug.tracking-signature-dialog');
-}
 
 Route::middleware('auth')->group(function () {
 

--- a/tests/Feature/Actions/MapConnectionActionsTest.php
+++ b/tests/Feature/Actions/MapConnectionActionsTest.php
@@ -75,7 +75,6 @@ function makeCapitalWormhole(): Wormhole
         'name' => 'H296',
         'total_mass' => 3_300_000_000,
         'maximum_jump_mass' => 2_000_000_000,
-        'ship_size' => '',
         'maximum_lifetime' => 86_400,
         'leads_to' => 'c5',
     ]);

--- a/tests/Feature/Actions/MapConnectionActionsTest.php
+++ b/tests/Feature/Actions/MapConnectionActionsTest.php
@@ -8,8 +8,10 @@ use App\Actions\MapConnections\DeleteMapConnectionAction;
 use App\Actions\MapConnections\UpdateMapConnectionAction;
 use App\Data\MapConnectionData;
 use App\Enums\MassStatus;
+use App\Enums\ShipSize;
 use App\Models\Map;
 use App\Models\MapConnection;
+use App\Models\Wormhole;
 
 it('creates a connection between two placements', function () {
     $map = Map::factory()->create();
@@ -65,4 +67,69 @@ it('deletes a connection', function () {
     app(DeleteMapConnectionAction::class)->handle($connection);
 
     expect(MapConnection::find($connection->id))->toBeNull();
+});
+
+function makeCapitalWormhole(): Wormhole
+{
+    return Wormhole::create([
+        'name' => 'H296',
+        'total_mass' => 3_300_000_000,
+        'maximum_jump_mass' => 2_000_000_000,
+        'ship_size' => '',
+        'maximum_lifetime' => 86_400,
+        'leads_to' => 'c5',
+    ]);
+}
+
+it('derives the ship size from the wormhole type when creating a connection', function () {
+    $map = Map::factory()->create();
+    $from = placeMapSolarsystem($map, 30004020);
+    $to = placeMapSolarsystem($map, 30004021);
+
+    $connection = app(CreateMapConnectionAction::class)->handle([
+        'from_map_solarsystem_id' => $from->id,
+        'to_map_solarsystem_id' => $to->id,
+        'wormhole_id' => makeCapitalWormhole()->id,
+        'ship_size' => 'medium',
+    ]);
+
+    expect($connection->ship_size)->toBe(ShipSize::ExtraLarge);
+});
+
+it('keeps the ship size locked to a linked signature wormhole type on updates', function () {
+    $map = Map::factory()->create();
+    $from = placeMapSolarsystem($map, 30004022);
+    $to = placeMapSolarsystem($map, 30004023);
+    $connection = MapConnection::factory()->create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $from->id,
+        'to_map_solarsystem_id' => $to->id,
+        'ship_size' => ShipSize::ExtraLarge,
+    ]);
+    $from->signatures()->create([
+        'signature_id' => 'AAA-111',
+        'map_connection_id' => $connection->id,
+        'wormhole_id' => makeCapitalWormhole()->id,
+        'lifetime' => 'healthy',
+    ]);
+
+    app(UpdateMapConnectionAction::class)->handle($connection, MapConnectionData::from(['ship_size' => 'frigate']));
+
+    expect($connection->fresh()->ship_size)->toBe(ShipSize::ExtraLarge);
+});
+
+it('allows manual ship size changes when no wormhole type is identified', function () {
+    $map = Map::factory()->create();
+    $from = placeMapSolarsystem($map, 30004024);
+    $to = placeMapSolarsystem($map, 30004025);
+    $connection = MapConnection::factory()->create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $from->id,
+        'to_map_solarsystem_id' => $to->id,
+        'ship_size' => ShipSize::Large,
+    ]);
+
+    app(UpdateMapConnectionAction::class)->handle($connection, MapConnectionData::from(['ship_size' => 'frigate']));
+
+    expect($connection->fresh()->ship_size)->toBe(ShipSize::Frigate);
 });

--- a/tests/Feature/Actions/MapConnectionActionsTest.php
+++ b/tests/Feature/Actions/MapConnectionActionsTest.php
@@ -11,7 +11,6 @@ use App\Enums\MassStatus;
 use App\Enums\ShipSize;
 use App\Models\Map;
 use App\Models\MapConnection;
-use App\Models\Wormhole;
 
 it('creates a connection between two placements', function () {
     $map = Map::factory()->create();
@@ -69,17 +68,6 @@ it('deletes a connection', function () {
     expect(MapConnection::find($connection->id))->toBeNull();
 });
 
-function makeCapitalWormhole(): Wormhole
-{
-    return Wormhole::create([
-        'name' => 'H296',
-        'total_mass' => 3_300_000_000,
-        'maximum_jump_mass' => 2_000_000_000,
-        'maximum_lifetime' => 86_400,
-        'leads_to' => 'c5',
-    ]);
-}
-
 it('derives the ship size from the wormhole type when creating a connection', function () {
     $map = Map::factory()->create();
     $from = placeMapSolarsystem($map, 30004020);
@@ -88,7 +76,7 @@ it('derives the ship size from the wormhole type when creating a connection', fu
     $connection = app(CreateMapConnectionAction::class)->handle([
         'from_map_solarsystem_id' => $from->id,
         'to_map_solarsystem_id' => $to->id,
-        'wormhole_id' => makeCapitalWormhole()->id,
+        'wormhole_id' => makeWormhole()->id,
         'ship_size' => 'medium',
     ]);
 
@@ -108,7 +96,7 @@ it('keeps the ship size locked to a linked signature wormhole type on updates', 
     $from->signatures()->create([
         'signature_id' => 'AAA-111',
         'map_connection_id' => $connection->id,
-        'wormhole_id' => makeCapitalWormhole()->id,
+        'wormhole_id' => makeWormhole()->id,
         'lifetime' => 'healthy',
     ]);
 

--- a/tests/Feature/Actions/SignatureActionsTest.php
+++ b/tests/Feature/Actions/SignatureActionsTest.php
@@ -14,7 +14,6 @@ use App\Enums\ShipSize;
 use App\Models\Map;
 use App\Models\MapConnection;
 use App\Models\Signature;
-use App\Models\Wormhole;
 
 it('stores a signature on a system', function () {
     $map = Map::factory()->create();
@@ -84,13 +83,7 @@ it('syncs the connection ship size from the signature wormhole type', function (
         'lifetime' => 'healthy',
         'mass_status' => 'fresh',
     ]);
-    $wormhole = Wormhole::create([
-        'name' => 'H296',
-        'total_mass' => 3_300_000_000,
-        'maximum_jump_mass' => 2_000_000_000,
-        'maximum_lifetime' => 86_400,
-        'leads_to' => 'c5',
-    ]);
+    $wormhole = makeWormhole();
     $signature = $origin->signatures()->create([
         'signature_id' => 'ABC-123',
         'map_connection_id' => $connection->id,
@@ -115,13 +108,7 @@ it('syncs the connection ship size when pasting over a typed connected signature
         'lifetime' => 'healthy',
         'mass_status' => 'fresh',
     ]);
-    $wormhole = Wormhole::create([
-        'name' => 'X877',
-        'total_mass' => 2_000_000_000,
-        'maximum_jump_mass' => 375_000_000,
-        'maximum_lifetime' => 57_600,
-        'leads_to' => 'c4',
-    ]);
+    $wormhole = makeWormhole('X877', 375_000_000, 'c4');
     $signature_type = App\Models\SignatureType::query()->where('signature', 'X877')->firstOrFail();
     $origin->signatures()->create([
         'signature_id' => 'AAA-111',
@@ -137,6 +124,30 @@ it('syncs the connection ship size when pasting over a typed connected signature
         'signatures' => [
             ['signature_id' => 'AAA-111'],
         ],
+    ]));
+
+    expect($connection->fresh()->ship_size)->toBe(ShipSize::Large);
+});
+
+it('syncs the connection ship size when storing an already-connected typed signature', function () {
+    $map = Map::factory()->create();
+    $origin = placeMapSolarsystem($map, 30011014);
+    $target = placeMapSolarsystem($map, 30011015, 300, 300);
+    $connection = MapConnection::create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $origin->id,
+        'to_map_solarsystem_id' => $target->id,
+        'ship_size' => 'xlarge',
+        'lifetime' => 'healthy',
+        'mass_status' => 'fresh',
+    ]);
+    makeWormhole('X877', 375_000_000, 'c4');
+    $signature_type = App\Models\SignatureType::query()->where('signature', 'X877')->firstOrFail();
+
+    app(StoreSignatureAction::class)->handle($origin, NewSignatureData::from([
+        'signature_id' => 'NEW-001',
+        'signature_type_id' => $signature_type->id,
+        'map_connection_id' => $connection->id,
     ]));
 
     expect($connection->fresh()->ship_size)->toBe(ShipSize::Large);

--- a/tests/Feature/Actions/SignatureActionsTest.php
+++ b/tests/Feature/Actions/SignatureActionsTest.php
@@ -88,7 +88,6 @@ it('syncs the connection ship size from the signature wormhole type', function (
         'name' => 'H296',
         'total_mass' => 3_300_000_000,
         'maximum_jump_mass' => 2_000_000_000,
-        'ship_size' => '',
         'maximum_lifetime' => 86_400,
         'leads_to' => 'c5',
     ]);
@@ -120,7 +119,6 @@ it('syncs the connection ship size when pasting over a typed connected signature
         'name' => 'X877',
         'total_mass' => 2_000_000_000,
         'maximum_jump_mass' => 375_000_000,
-        'ship_size' => '',
         'maximum_lifetime' => 57_600,
         'leads_to' => 'c4',
     ]);

--- a/tests/Feature/Actions/SignatureActionsTest.php
+++ b/tests/Feature/Actions/SignatureActionsTest.php
@@ -10,8 +10,11 @@ use App\Actions\Signatures\UpdateSignatureAction;
 use App\Data\NewSignatureData;
 use App\Data\SignatureData;
 use App\Data\SignaturesData;
+use App\Enums\ShipSize;
 use App\Models\Map;
+use App\Models\MapConnection;
 use App\Models\Signature;
+use App\Models\Wormhole;
 
 it('stores a signature on a system', function () {
     $map = Map::factory()->create();
@@ -67,4 +70,76 @@ it('pastes new signatures onto a system', function () {
     ]));
 
     expect($system->signatures()->count())->toBe(2);
+});
+
+it('syncs the connection ship size from the signature wormhole type', function () {
+    $map = Map::factory()->create();
+    $origin = placeMapSolarsystem($map, 30011010);
+    $target = placeMapSolarsystem($map, 30011011, 300, 300);
+    $connection = MapConnection::create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $origin->id,
+        'to_map_solarsystem_id' => $target->id,
+        'ship_size' => 'large',
+        'lifetime' => 'healthy',
+        'mass_status' => 'fresh',
+    ]);
+    $wormhole = Wormhole::create([
+        'name' => 'H296',
+        'total_mass' => 3_300_000_000,
+        'maximum_jump_mass' => 2_000_000_000,
+        'ship_size' => '',
+        'maximum_lifetime' => 86_400,
+        'leads_to' => 'c5',
+    ]);
+    $signature = $origin->signatures()->create([
+        'signature_id' => 'ABC-123',
+        'map_connection_id' => $connection->id,
+        'wormhole_id' => $wormhole->id,
+        'lifetime' => 'healthy',
+    ]);
+
+    app(UpdateSignatureAction::class)->handle($signature, SignatureData::from(['signature_id' => 'ABC-123']));
+
+    expect($connection->fresh()->ship_size)->toBe(ShipSize::ExtraLarge);
+});
+
+it('syncs the connection ship size when pasting over a typed connected signature', function () {
+    $map = Map::factory()->create();
+    $origin = placeMapSolarsystem($map, 30011012);
+    $target = placeMapSolarsystem($map, 30011013, 300, 300);
+    $connection = MapConnection::create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $origin->id,
+        'to_map_solarsystem_id' => $target->id,
+        'ship_size' => 'large',
+        'lifetime' => 'healthy',
+        'mass_status' => 'fresh',
+    ]);
+    $wormhole = Wormhole::create([
+        'name' => 'X877',
+        'total_mass' => 2_000_000_000,
+        'maximum_jump_mass' => 375_000_000,
+        'ship_size' => '',
+        'maximum_lifetime' => 57_600,
+        'leads_to' => 'c4',
+    ]);
+    $signature_type = App\Models\SignatureType::query()->where('signature', 'X877')->firstOrFail();
+    $origin->signatures()->create([
+        'signature_id' => 'AAA-111',
+        'map_connection_id' => $connection->id,
+        'signature_type_id' => $signature_type->id,
+        'wormhole_id' => $wormhole->id,
+        'lifetime' => 'healthy',
+    ]);
+    $connection->update(['ship_size' => 'xlarge']);
+
+    app(PasteSignaturesAction::class)->handle(SignaturesData::from([
+        'map_solarsystem_id' => $origin->id,
+        'signatures' => [
+            ['signature_id' => 'AAA-111'],
+        ],
+    ]));
+
+    expect($connection->fresh()->ship_size)->toBe(ShipSize::Large);
 });

--- a/tests/Feature/Actions/TrackingActionTest.php
+++ b/tests/Feature/Actions/TrackingActionTest.php
@@ -171,3 +171,33 @@ it('prefers the explicit ship size over the signature ship size', function () {
 
     expect(MapConnection::where('map_id', $map->id)->value('ship_size'))->toBe(ShipSize::ExtraLarge);
 });
+
+it('locks the connection ship size to the signature wormhole type', function () {
+    $map = Map::factory()->create();
+    $origin = placeMapSolarsystem($map, 30012011);
+    $targetId = makeSolarsystem(30012012);
+
+    $wormhole = App\Models\Wormhole::create([
+        'name' => 'H296',
+        'total_mass' => 3_300_000_000,
+        'maximum_jump_mass' => 2_000_000_000,
+        'ship_size' => '',
+        'maximum_lifetime' => 86_400,
+        'leads_to' => 'c5',
+    ]);
+
+    $signature = Signature::create([
+        'map_solarsystem_id' => $origin->id,
+        'signature_id' => 'GHI-789',
+        'wormhole_id' => $wormhole->id,
+    ]);
+
+    app(StoreTrackingAction::class)->handle(TrackingData::from([
+        'from_map_solarsystem_id' => $origin->id,
+        'to_solarsystem_id' => $targetId,
+        'signature_id' => $signature->id,
+        'ship_size' => 'frigate',
+    ]));
+
+    expect(MapConnection::where('map_id', $map->id)->value('ship_size'))->toBe(ShipSize::ExtraLarge);
+});

--- a/tests/Feature/Actions/TrackingActionTest.php
+++ b/tests/Feature/Actions/TrackingActionTest.php
@@ -177,13 +177,7 @@ it('locks the connection ship size to the signature wormhole type', function () 
     $origin = placeMapSolarsystem($map, 30012011);
     $targetId = makeSolarsystem(30012012);
 
-    $wormhole = App\Models\Wormhole::create([
-        'name' => 'H296',
-        'total_mass' => 3_300_000_000,
-        'maximum_jump_mass' => 2_000_000_000,
-        'maximum_lifetime' => 86_400,
-        'leads_to' => 'c5',
-    ]);
+    $wormhole = makeWormhole();
 
     $signature = Signature::create([
         'map_solarsystem_id' => $origin->id,

--- a/tests/Feature/Actions/TrackingActionTest.php
+++ b/tests/Feature/Actions/TrackingActionTest.php
@@ -9,6 +9,7 @@ use App\Enums\ShipSize;
 use App\Events\MapSolarsystems\MapSolarsystemsUpsertedEvent;
 use App\Models\Map;
 use App\Models\MapConnection;
+use App\Models\Signature;
 use Illuminate\Support\Facades\Event;
 
 it('adds the target system and connects it when tracking a jump', function () {
@@ -128,4 +129,45 @@ it('applies an explicitly chosen ship size to the tracked connection', function 
     ]));
 
     expect(MapConnection::where('map_id', $map->id)->value('ship_size'))->toBe(ShipSize::Frigate);
+});
+
+it('falls back to the signature ship size when none is chosen explicitly', function () {
+    $map = Map::factory()->create();
+    $origin = placeMapSolarsystem($map, 30012007);
+    $targetId = makeSolarsystem(30012008);
+
+    $signature = Signature::create([
+        'map_solarsystem_id' => $origin->id,
+        'signature_id' => 'ABC-123',
+        'ship_size' => 'medium',
+    ]);
+
+    app(StoreTrackingAction::class)->handle(TrackingData::from([
+        'from_map_solarsystem_id' => $origin->id,
+        'to_solarsystem_id' => $targetId,
+        'signature_id' => $signature->id,
+    ]));
+
+    expect(MapConnection::where('map_id', $map->id)->value('ship_size'))->toBe(ShipSize::Medium);
+});
+
+it('prefers the explicit ship size over the signature ship size', function () {
+    $map = Map::factory()->create();
+    $origin = placeMapSolarsystem($map, 30012009);
+    $targetId = makeSolarsystem(30012010);
+
+    $signature = Signature::create([
+        'map_solarsystem_id' => $origin->id,
+        'signature_id' => 'DEF-456',
+        'ship_size' => 'medium',
+    ]);
+
+    app(StoreTrackingAction::class)->handle(TrackingData::from([
+        'from_map_solarsystem_id' => $origin->id,
+        'to_solarsystem_id' => $targetId,
+        'signature_id' => $signature->id,
+        'ship_size' => 'xlarge',
+    ]));
+
+    expect(MapConnection::where('map_id', $map->id)->value('ship_size'))->toBe(ShipSize::ExtraLarge);
 });

--- a/tests/Feature/Actions/TrackingActionTest.php
+++ b/tests/Feature/Actions/TrackingActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\MapSolarsystem\UpdateMapSolarsystemAction;
 use App\Actions\Tracking\StoreTrackingAction;
 use App\Data\TrackingData;
+use App\Enums\ShipSize;
 use App\Events\MapSolarsystems\MapSolarsystemsUpsertedEvent;
 use App\Models\Map;
 use App\Models\MapConnection;
@@ -113,4 +114,18 @@ it('updates the alias and occupier of a tracked system afterwards', function () 
                 && $system['alias'] === 'STAGING'
                 && $system['occupier_alias'] === 'Lazerhawks');
     });
+});
+
+it('applies an explicitly chosen ship size to the tracked connection', function () {
+    $map = Map::factory()->create();
+    $origin = placeMapSolarsystem($map, 30012005);
+    $targetId = makeSolarsystem(30012006);
+
+    app(StoreTrackingAction::class)->handle(TrackingData::from([
+        'from_map_solarsystem_id' => $origin->id,
+        'to_solarsystem_id' => $targetId,
+        'ship_size' => 'frigate',
+    ]));
+
+    expect(MapConnection::where('map_id', $map->id)->value('ship_size'))->toBe(ShipSize::Frigate);
 });

--- a/tests/Feature/Actions/TrackingActionTest.php
+++ b/tests/Feature/Actions/TrackingActionTest.php
@@ -181,7 +181,6 @@ it('locks the connection ship size to the signature wormhole type', function () 
         'name' => 'H296',
         'total_mass' => 3_300_000_000,
         'maximum_jump_mass' => 2_000_000_000,
-        'ship_size' => '',
         'maximum_lifetime' => 86_400,
         'leads_to' => 'c5',
     ]);

--- a/tests/Feature/DebugPreviewTest.php
+++ b/tests/Feature/DebugPreviewTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+it('renders the tracking signature dialog preview outside production', function () {
+    $response = $this->get(route('debug.tracking-signature-dialog'));
+
+    $response->assertSuccessful();
+    $response->assertInertia(fn ($page) => $page
+        ->component('debug/TrackingSignatureDialogPreview')
+        ->where('map.slug', 'debug-preview'));
+});

--- a/tests/Feature/MapUserSettingTest.php
+++ b/tests/Feature/MapUserSettingTest.php
@@ -220,3 +220,22 @@ it('does not share pinned maps the user can no longer access', function () {
 
     $this->get(route('home'))->assertInertia(fn ($page) => $page->has('pinned_maps', 0));
 });
+
+// --- Preselect first signature setting ---
+
+it('persists the preselect signature setting', function () {
+    $map = Map::factory()->create();
+    $user = User::factory()->ownsMap($map)->create();
+
+    actingAs($user);
+
+    $this->put(route('maps.user-settings.update', $map), [
+        'preselect_signature_enabled' => true,
+    ])->assertRedirect();
+
+    expect(MapUserSetting::query()
+        ->where('user_id', $user->id)
+        ->where('map_id', $map->id)
+        ->value('preselect_signature_enabled')
+    )->toBeTruthy();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -77,6 +77,18 @@ function makeSolarsystem(int $id, float $security = 0.5, string $type = 'normal'
  * Place a solarsystem on a map (seeding the underlying solarsystem so the FK resolves),
  * returning the placement.
  */
+/** Create a wormhole type row; defaults to a capital-capable H296. */
+function makeWormhole(string $name = 'H296', float $maximum_jump_mass = 2_000_000_000, string $leads_to = 'c5'): App\Models\Wormhole
+{
+    return App\Models\Wormhole::create([
+        'name' => $name,
+        'total_mass' => 3_300_000_000,
+        'maximum_jump_mass' => $maximum_jump_mass,
+        'maximum_lifetime' => 86_400,
+        'leads_to' => $leads_to,
+    ]);
+}
+
 function placeMapSolarsystem(App\Models\Map $map, int $solarsystemId, int $x = 100, int $y = 100): App\Models\MapSolarsystem
 {
     makeSolarsystem($solarsystemId);


### PR DESCRIPTION
Rebuilds the "which signature did you jump" prompt and makes the wormhole type authoritative for connection ship size.

- Modernized dialog: panel header and footer, connection details (alias, lifetime, mass, ship size) above a flat fixed-height list, three sections (possible, already connected with destination, unlikely), status dots and size letters, keyboard-first flow with search focus and arrow key navigation
- New per-map setting to preselect the first likely signature so alphabetical hole-jumping only takes Enter
- A wormhole type's jump mass now locks the connection ship size everywhere: creation, manual updates, tracking, signature edits, and pasted scans, with the shared tier mapping in ShipSize::fromJumpMass and its frontend mirror
- Drops the dead wormholes ship_size column
- Local-only debug preview page for the dialog, with debug routes moved to their own conditionally registered file