### PR TITLE
fix: sort watchlist systems alphabetically within a class

### DIFF
--- a/resources/js/components/autopilot/NavigationDestinations.vue
+++ b/resources/js/components/autopilot/NavigationDestinations.vue
@@ -5,7 +5,7 @@ import { useMap } from '@/composables/useMap';
 import usePermission from '@/composables/usePermission';
 import { useSelectedMapSolarsystem } from '@/composables/useSelectedMapSolarsystem';
 import { useStaticSolarsystems } from '@/composables/useStaticSolarsystems';
-import { classSortWeight, isWormholeClass } from '@/const/solarsystemClasses';
+import { compareSolarsystemsByClass } from '@/const/solarsystemClasses';
 import type { TResolvedMapRouteSolarsystem } from '@/pages/maps';
 import { useLocalStorage } from '@vueuse/core';
 import { ArrowDown, ArrowUp } from 'lucide-vue-next';
@@ -65,23 +65,9 @@ const sorted = computed(() => {
         let comparison = 0;
 
         switch (sortColumn.value) {
-            case 'system': {
-                const aIsWH = isWormholeClass(a.solarsystem.class);
-                const bIsWH = isWormholeClass(b.solarsystem.class);
-
-                if (aIsWH && bIsWH) {
-                    comparison = classSortWeight(a.solarsystem.class) - classSortWeight(b.solarsystem.class);
-                } else if (!aIsWH && !bIsWH) {
-                    comparison = (b.solarsystem.security || 0) - (a.solarsystem.security || 0);
-                } else {
-                    comparison = aIsWH ? 1 : -1;
-                }
-
-                if (comparison === 0) {
-                    comparison = a.solarsystem.name.localeCompare(b.solarsystem.name);
-                }
+            case 'system':
+                comparison = compareSolarsystemsByClass(a.solarsystem, b.solarsystem);
                 break;
-            }
             case 'jumps': {
                 const aJumps = a.route ? a.route.length - 1 : 999;
                 const bJumps = b.route ? b.route.length - 1 : 999;

--- a/resources/js/const/solarsystemClasses.spec.ts
+++ b/resources/js/const/solarsystemClasses.spec.ts
@@ -1,0 +1,28 @@
+import { compareSolarsystemsByClass } from '@/const/solarsystemClasses';
+import type { TStringedSolarsystemClass } from '@/types/models';
+import { describe, expect, it } from 'vitest';
+
+function system(name: string, klass: TStringedSolarsystemClass): { name: string; class: TStringedSolarsystemClass } {
+    return { name, class: klass };
+}
+
+describe('compareSolarsystemsByClass', () => {
+    it('orders known space before wormhole space', () => {
+        expect(compareSolarsystemsByClass(system('Jita', 'h'), system('J152820', '5'))).toBeLessThan(0);
+        expect(compareSolarsystemsByClass(system('J152820', '5'), system('Tama', 'l'))).toBeGreaterThan(0);
+    });
+
+    it('orders known space high to null', () => {
+        expect(compareSolarsystemsByClass(system('Jita', 'h'), system('Tama', 'l'))).toBeLessThan(0);
+        expect(compareSolarsystemsByClass(system('Tama', 'l'), system('VFK-IV', 'n'))).toBeLessThan(0);
+    });
+
+    it('orders wormhole classes numerically', () => {
+        expect(compareSolarsystemsByClass(system('J100001', '1'), system('J100002', '5'))).toBeLessThan(0);
+    });
+
+    it('sorts alphabetically within the same class', () => {
+        const sorted = [system('Jita', 'h'), system('Amarr', 'h'), system('Dodixie', 'h')].toSorted(compareSolarsystemsByClass);
+        expect(sorted.map((s) => s.name)).toEqual(['Amarr', 'Dodixie', 'Jita']);
+    });
+});

--- a/resources/js/const/solarsystemClasses.ts
+++ b/resources/js/const/solarsystemClasses.ts
@@ -35,3 +35,11 @@ export function isWormholeClass(value: TStringedSolarsystemClass | null | undefi
 export function classSortWeight(value: TStringedSolarsystemClass | null | undefined): number {
     return classMeta(value).sort_weight;
 }
+
+/** Order systems by class (known space first, then wormhole classes), alphabetically within a class. */
+export function compareSolarsystemsByClass(
+    a: { class: TStringedSolarsystemClass; name: string },
+    b: { class: TStringedSolarsystemClass; name: string },
+): number {
+    return classSortWeight(a.class) - classSortWeight(b.class) || a.name.localeCompare(b.name);
+}


### PR DESCRIPTION
Fixes the watchlist's system column ordering known space by raw security value.

- Systems now sort by class (highsec to nullsec, then wormhole classes) with names alphabetical within each class
- The comparator lives in the shared solarsystem class module for reuse