### PR TITLE
fix: correct effect strength for drifter and C13 systems

### DIFF
--- a/app/Console/Commands/GenerateStaticDataCommand.php
+++ b/app/Console/Commands/GenerateStaticDataCommand.php
@@ -59,6 +59,20 @@ final class GenerateStaticDataCommand extends Command
     protected $description = 'Generate static data files for client-side routing';
 
     /**
+     * Index into the six-entry effect strength arrays (C1-C6). Drifter systems
+     * carry C2-strength effects and the C13 small-ship shattered systems
+     * C6-strength ones; their raw classes would index out of bounds.
+     */
+    public static function effectStrengthIndex(int $class): int
+    {
+        return match (true) {
+            $class >= 14 && $class <= 18 => 1,
+            $class === 13 => 5,
+            default => $class - 1,
+        };
+    }
+
+    /**
      * @throws JsonException
      * @throws Throwable
      */
@@ -547,7 +561,7 @@ final class GenerateStaticDataCommand extends Command
 
         ['Buffs' => $buffs, 'Debuffs' => $debuffs] = $effects;
 
-        $strength = $wormholeSystem['class'] - 1;
+        $strength = self::effectStrengthIndex($wormholeSystem['class']);
 
         $buffValues = collect($buffs)
             ->map(static fn (array $strengths, string $name): array => [

--- a/tests/Unit/EffectStrengthIndexTest.php
+++ b/tests/Unit/EffectStrengthIndexTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Console\Commands\GenerateStaticDataCommand;
+
+it('maps wormhole classes onto the six effect strength tiers', function (int $class, int $index) {
+    expect(GenerateStaticDataCommand::effectStrengthIndex($class))->toBe($index);
+})->with([
+    'C1' => [1, 0],
+    'C2' => [2, 1],
+    'C6' => [6, 5],
+    'C13 small-ship shattered uses C6 strength' => [13, 5],
+    'Sentinel uses C2 strength' => [14, 1],
+    'Redoubt uses C2 strength' => [18, 1],
+]);


### PR DESCRIPTION
Fixes wormhole effects rendering with empty strengths in special-class systems.

- The strength index was derived as class minus one, walking off the six-entry strength arrays for classes above C6
- Drifter systems (C14 to C18) now use C2-strength effects and C13 small-ship shattered systems C6-strength ones, per the community documentation