### PR TITLE
Fix 500 when a bulk signature delete removes the system

### DIFF
--- a/app/Support/Broadcasting/MapBroadcaster.php
+++ b/app/Support/Broadcasting/MapBroadcaster.php
@@ -100,6 +100,16 @@ final readonly class MapBroadcaster
      */
     public function signaturesChanged(MapSolarsystem $map_solarsystem): void
     {
+        // Deleting signatures can also roll their connections and remove the
+        // system in the same transaction. If it is gone there are no counts to
+        // broadcast — loadCount would re-query by key, find nothing, and fatal on
+        // getAttributes(). The removal itself is announced by its own event.
+        $map_solarsystem = $map_solarsystem->fresh();
+
+        if (! $map_solarsystem instanceof MapSolarsystem) {
+            return;
+        }
+
         $map_solarsystem->loadCount(['signatures', 'wormholeSignatures', 'uncategorizedSignatures']);
 
         broadcast(new SignaturesChangedEvent(

--- a/tests/Feature/Broadcasting/SignatureBroadcastTest.php
+++ b/tests/Feature/Broadcasting/SignatureBroadcastTest.php
@@ -12,6 +12,9 @@ use App\Data\SignatureData;
 use App\Data\SignaturesData;
 use App\Events\Signatures\SignaturesChangedEvent;
 use App\Models\Map;
+use App\Models\MapConnection;
+use App\Models\MapSolarsystem;
+use App\Models\Signature;
 use Illuminate\Support\Facades\Event;
 
 it('broadcasts the signature counts once when a signature is stored', function () {
@@ -89,6 +92,31 @@ it('broadcasts the signature counts once for a bulk delete', function () {
         return $payload['map_solarsystem_id'] === $system->id
             && $payload['signature_counts']['signatures_count'] === 0;
     });
+});
+
+it('does not crash when a bulk delete also removes the system', function () {
+    $map = Map::factory()->create();
+    $origin = placeMapSolarsystem($map, 30023020);
+    $target = placeMapSolarsystem($map, 30023021);
+
+    $connection = MapConnection::factory()->create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $origin->id,
+        'to_map_solarsystem_id' => $target->id,
+    ]);
+
+    $signature = $origin->signatures()->create([
+        'signature_id' => 'ABC-123',
+        'map_connection_id' => $connection->id,
+    ]);
+
+    // With remove_map_solarsystems, deleting the signature rolls its connection
+    // and removes both now-disconnected endpoints — including the origin. The
+    // count broadcast must not fatal on the row it just deleted.
+    app(DeleteSignaturesAction::class)->handle($origin, [$signature->id], remove_map_solarsystems: true);
+
+    expect(MapSolarsystem::query()->whereKey($origin->id)->exists())->toBeFalse()
+        ->and(Signature::query()->whereKey($signature->id)->exists())->toBeFalse();
 });
 
 it('broadcasts the signature counts once for a paste of multiple signatures', function () {


### PR DESCRIPTION
## Fix: 500 when a bulk signature delete also removes the system

### The bug
Deleting signatures with `remove_map_solarsystems = true` (the "delete missing signatures and their connections" action) rolls each signature's connection via `DeleteMapConnectionAction`, which removes **both** now-disconnected endpoints — so the origin system can remove itself when its last connection goes.

`DeleteSignaturesAction` then calls `MapBroadcaster::signaturesChanged($mapSolarsystem)` on that origin. `signaturesChanged` runs `loadCount(...)`, which re-queries the model by primary key, gets `null` (the row is gone), and fatals:

```
Call to a member function getAttributes() on null
  at Illuminate\Database\Eloquent\Collection::loadAggregate() (Collection.php:127)
  MapBroadcaster::signaturesChanged()   → loadCount(...)
  DeleteSignaturesAction::handle()
```

Result: HTTP 500 for the user doing the delete.

### The fix
Refresh the model in `signaturesChanged` and skip the count broadcast when the system no longer exists — its removal is already announced by the connection/system-removed event.

### Tests
Adds a regression test to `SignatureBroadcastTest`: a bulk delete that also removes the origin system completes without error and removes the rows. Full broadcast suite passes (6 tests).
