### PR TITLE
feat: add an option for a more compact signature list

### DIFF
--- a/app/Features/MapSettingsFeature.php
+++ b/app/Features/MapSettingsFeature.php
@@ -31,6 +31,7 @@ final readonly class MapSettingsFeature implements ProvidesInertiaProperties
         'hidden_cards' => null,
         'show_threat_level' => true,
         'show_statics_first' => true,
+        'compact_signature_list' => false,
         'background_image_mode' => 'grid',
         'layout_override' => null,
     ];

--- a/app/Http/Requests/UpdateMapUserSettingRequest.php
+++ b/app/Http/Requests/UpdateMapUserSettingRequest.php
@@ -60,6 +60,7 @@ final class UpdateMapUserSettingRequest extends FormRequest
             'hidden_cards.*' => ['string', Rule::enum(RemovableCard::class)],
             'show_threat_level' => ['boolean'],
             'show_statics_first' => ['boolean'],
+            'compact_signature_list' => ['boolean'],
             'is_archived' => ['boolean'],
             'is_pinned' => ['boolean'],
             'background_image_mode' => ['nullable', 'string', Rule::enum(MapBackgroundMode::class)],

--- a/app/Http/Resources/MapUserSettingResource.php
+++ b/app/Http/Resources/MapUserSettingResource.php
@@ -43,6 +43,7 @@ final class MapUserSettingResource extends JsonResource
             'hidden_cards' => $this->hidden_cards ?? [],
             'show_threat_level' => $this->show_threat_level,
             'show_statics_first' => $this->show_statics_first,
+            'compact_signature_list' => $this->compact_signature_list,
             'is_archived' => $this->is_archived ?? false,
             'is_pinned' => $this->is_pinned ?? false,
             'background_image_url' => $this->background_image_path

--- a/app/Models/MapUserSetting.php
+++ b/app/Models/MapUserSetting.php
@@ -37,6 +37,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property array|null $hidden_cards
  * @property bool $show_threat_level
  * @property bool $show_statics_first
+ * @property bool $compact_signature_list
  * @property bool $is_archived
  * @property bool $is_pinned
  * @property string|null $background_image_path
@@ -88,6 +89,7 @@ final class MapUserSetting extends Model
             'hidden_cards' => 'array',
             'show_threat_level' => 'boolean',
             'show_statics_first' => 'boolean',
+            'compact_signature_list' => 'boolean',
             'is_archived' => 'boolean',
             'is_pinned' => 'boolean',
             'background_image_mode' => MapBackgroundMode::class,

--- a/database/migrations/2026_07_18_190332_add_compact_signature_list_to_map_user_settings_table.php
+++ b/database/migrations/2026_07_18_190332_add_compact_signature_list_to_map_user_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('map_user_settings', function (Blueprint $table): void {
+            $table->boolean('compact_signature_list')->default(false)->after('show_statics_first');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('map_user_settings', function (Blueprint $table): void {
+            $table->dropColumn('compact_signature_list');
+        });
+    }
+};

--- a/resources/js/components/signatures/MapConnectionInput.vue
+++ b/resources/js/components/signatures/MapConnectionInput.vue
@@ -2,6 +2,7 @@
 import ConnectionOption from '@/components/signatures/ConnectionOption.vue';
 import SolarsystemClass from '@/components/solarsystem/SolarsystemClass.vue';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useMapUserSettings } from '@/composables/useMapUserSettings';
 import type { TProcessedConnection } from '@/map/api';
 import { TSignatureType } from '@/types/models';
 import { computed, ref } from 'vue';
@@ -17,6 +18,8 @@ const { type, unconnected_connections, connected_connections, disabled } = defin
 const model = defineModel<number | null>({
     required: true,
 });
+
+const map_user_settings = useMapUserSettings();
 
 const open = ref(false);
 
@@ -43,7 +46,7 @@ function isNotFilterable(type: TSignatureType | null | undefined): type is null 
 
 <template>
     <Select v-model:model-value="model" v-model:open="open" :disabled="disabled">
-        <SelectTrigger class="h-6 w-full text-xs">
+        <SelectTrigger class="w-full text-xs" :class="map_user_settings.compact_signature_list ? '!h-5 !py-0' : ''">
             <SelectValue as-child>
                 <span>
                     <span v-if="selected" class="inline-flex items-center gap-1">

--- a/resources/js/components/signatures/Signature.vue
+++ b/resources/js/components/signatures/Signature.vue
@@ -202,7 +202,8 @@ function handleTogglePreserveMass() {
 
 <template>
     <div
-        class="flex items-center gap-2 border-b border-border/30 px-3 py-1.5 hover:bg-muted/30 data-deleted:bg-red-500/10 data-new:bg-green-500/10 data-updated:bg-amber-500/15"
+        class="flex items-center gap-2 border-b border-border/30 px-3 hover:bg-muted/30 data-deleted:bg-red-500/10 data-new:bg-green-500/10 data-updated:bg-amber-500/15"
+        :class="map_user_settings.compact_signature_list ? 'py-0.5' : 'py-1.5'"
         :data-deleted="Data(is_deleted)"
         :data-new="Data(is_new)"
         :data-updated="Data(is_updated)"
@@ -217,14 +218,15 @@ function handleTogglePreserveMass() {
                 @blur="saveId"
                 @keydown.enter="saveId"
                 @keydown.escape="cancelEditId"
-                class="h-6 w-full rounded border border-border/50 bg-background/50 px-1.5 font-mono text-xs uppercase focus:border-primary focus:outline-none"
+                class="w-full rounded border border-border/50 bg-background/50 px-1.5 font-mono text-xs uppercase focus:border-primary focus:outline-none"
+                :class="map_user_settings.compact_signature_list ? 'h-5' : 'h-6'"
                 maxlength="7"
                 placeholder="XXX-XXX"
             />
             <button
                 v-else
-                class="font-mono text-xs hover:text-amber-400"
-                :class="can_write ? 'cursor-pointer' : 'cursor-default'"
+                class="flex items-center font-mono text-xs hover:text-amber-400"
+                :class="[can_write ? 'cursor-pointer' : 'cursor-default', map_user_settings.compact_signature_list ? 'h-5' : 'h-6']"
                 @click="startEditId"
             >
                 {{ signature.signature_id || '---' }}
@@ -234,7 +236,7 @@ function handleTogglePreserveMass() {
         <!-- Category -->
         <div class="w-24 shrink-0">
             <Select :model-value="signature.signature_category_id" @update:modelValue="handleCategoryChange" :disabled="!can_write">
-                <SelectTrigger class="h-6 w-full text-xs">
+                <SelectTrigger class="w-full text-xs" :class="map_user_settings.compact_signature_list ? '!h-5 !py-0' : ''">
                     <SelectValue placeholder="Category">
                         <span class="flex items-center gap-1">
                             <component
@@ -301,7 +303,12 @@ function handleTogglePreserveMass() {
         <div class="w-6 shrink-0">
             <DropdownMenu v-if="can_write">
                 <DropdownMenuTrigger as-child>
-                    <Button variant="ghost" size="icon" class="size-6 text-muted-foreground hover:text-foreground">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        class="text-muted-foreground hover:text-foreground"
+                        :class="map_user_settings.compact_signature_list ? 'size-5' : 'size-6'"
+                    >
                         <MoreVertical class="size-3.5" />
                     </Button>
                 </DropdownMenuTrigger>

--- a/resources/js/components/signatures/SignatureTimeDetails.vue
+++ b/resources/js/components/signatures/SignatureTimeDetails.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useMapUserSettings } from '@/composables/useMapUserSettings';
 import { useNowUTC } from '@/composables/useNowUTC';
 import type { TProcessedConnection } from '@/map/api';
 import { TSignature } from '@/types/models';
@@ -14,6 +15,7 @@ const { category, selected_connection, signature } = defineProps<{
 }>();
 
 const now = useNowUTC();
+const map_user_settings = useMapUserSettings();
 
 const created_at = computed(() => {
     if (!selected_connection) return signature.created_at;
@@ -93,7 +95,8 @@ const current_lifetime = computed(() => {
         <TooltipTrigger
             :data-lifetime="current_lifetime"
             :data-mass="selected_connection?.mass_status || signature.mass_status"
-            class="time font-mono text-xs whitespace-nowrap text-muted-foreground tabular-nums"
+            class="time flex items-center justify-end font-mono text-xs whitespace-nowrap text-muted-foreground tabular-nums"
+            :class="map_user_settings.compact_signature_list ? 'h-5' : 'h-6'"
         >
             <span>
                 {{ modified_ago }}

--- a/resources/js/components/signatures/SignatureTypeInput.vue
+++ b/resources/js/components/signatures/SignatureTypeInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Combobox, ComboboxAnchor, ComboboxInput, ComboboxItem, ComboboxTrigger, ComboboxVirtualList } from '@/components/ui/combobox';
+import { useMapUserSettings } from '@/composables/useMapUserSettings';
 import { getTypeById } from '@/const/signatures';
 import { TSignatureType } from '@/types/models';
 import { computed, ref, watch } from 'vue';
@@ -16,6 +17,8 @@ const model = defineModel<number | null>({
 });
 
 const hasRawTypeName = computed(() => !model.value && rawTypeName);
+
+const map_user_settings = useMapUserSettings();
 
 const open = ref(false);
 const search = ref('');
@@ -52,7 +55,7 @@ function optionName(option: TSignatureType): string {
 <template>
     <Combobox v-model:open="open" :ignore-filter="true" :disabled="!can_write || !category">
         <ComboboxAnchor as-child>
-            <ComboboxTrigger class="text-xs" :disabled="!can_write || !category">
+            <ComboboxTrigger class="text-xs" :size="map_user_settings.compact_signature_list ? 'sm' : 'default'" :disabled="!can_write || !category">
                 <span v-if="hasRawTypeName" class="truncate text-foreground">{{ rawTypeName }}</span>
                 <span v-else-if="selected_option" class="truncate">{{ selected_option.name }}</span>
                 <span v-else class="truncate text-muted-foreground">Type</span>

--- a/resources/js/components/signatures/Signatures.vue
+++ b/resources/js/components/signatures/Signatures.vue
@@ -15,6 +15,7 @@ import { usePasteSignatures } from '@/composables/signatures/usePasteSignatures'
 import { useSignatures } from '@/composables/signatures/useSignatures';
 import { useSortableSignatures } from '@/composables/signatures/useSortedSignatures';
 import { useActiveMapCharacter } from '@/composables/useActiveMapCharacter';
+import { useMapUserSettings } from '@/composables/useMapUserSettings';
 import usePermission from '@/composables/usePermission';
 import { createSignature } from '@/map/api';
 import type { TResolvedSelectedMapSolarsystem } from '@/pages/maps';
@@ -31,6 +32,8 @@ const { connections } = useSignatures();
 const { canEdit: can_write } = usePermission();
 
 const character = useActiveMapCharacter();
+
+const map_user_settings = useMapUserSettings();
 
 const {
     signatures,
@@ -166,7 +169,8 @@ function createNewSignature() {
         <MapPanelContent>
             <!-- Header -->
             <div
-                class="flex items-center gap-2 border-b border-border/30 bg-muted/20 px-3 py-1.5 font-mono text-[10px] tracking-wider text-muted-foreground uppercase"
+                class="flex items-center gap-2 border-b border-border/30 bg-muted/20 px-3 font-mono text-[10px] tracking-wider text-muted-foreground uppercase"
+                :class="map_user_settings.compact_signature_list ? 'py-0.5' : 'py-1.5'"
             >
                 <button class="flex w-16 shrink-0 items-center gap-1 hover:text-foreground" @click="handleSort('id')">
                     <span>ID</span>

--- a/resources/js/components/signatures/WormholeTypeInput.vue
+++ b/resources/js/components/signatures/WormholeTypeInput.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import WormholeOption from '@/components/signatures/WormholeOption.vue';
 import { Combobox, ComboboxAnchor, ComboboxInput, ComboboxItem, ComboboxTrigger, ComboboxVirtualList } from '@/components/ui/combobox';
+import { useMapUserSettings } from '@/composables/useMapUserSettings';
 import { comboboxRowText, flattenComboboxSections, type TComboboxRow } from '@/lib/comboboxSections';
 import type { TSignatureType } from '@/types/models';
 import { computed, ref, watch } from 'vue';
@@ -19,6 +20,8 @@ const {
 const model = defineModel<number | null>({
     required: true,
 });
+
+const map_user_settings = useMapUserSettings();
 
 const open = ref(false);
 const search = ref('');
@@ -85,7 +88,7 @@ function filterByCurrentClass(option: TSignatureType) {
 <template>
     <Combobox v-model:open="open" :ignore-filter="true" :disabled="!can_write">
         <ComboboxAnchor as-child>
-            <ComboboxTrigger class="text-xs" :disabled="!can_write">
+            <ComboboxTrigger class="text-xs" :size="map_user_settings.compact_signature_list ? 'sm' : 'default'" :disabled="!can_write">
                 <WormholeOption v-if="selected_signature" :wormhole="selected_signature" />
                 <span v-else class="truncate text-muted-foreground">Type</span>
             </ComboboxTrigger>

--- a/resources/js/components/ui/combobox/ComboboxTrigger.vue
+++ b/resources/js/components/ui/combobox/ComboboxTrigger.vue
@@ -20,7 +20,7 @@ const forwarded = useForwardProps(delegatedProps);
  */
 const sizeClasses: Record<'sm' | 'default', string> = {
     default: 'h-9 px-3 text-sm',
-    sm: 'h-6 px-3 text-xs',
+    sm: 'h-5 px-3 text-xs',
 };
 </script>
 

--- a/resources/js/pages/maps/settings/ShowPreferences.vue
+++ b/resources/js/pages/maps/settings/ShowPreferences.vue
@@ -38,6 +38,12 @@ function handleToggleStaticsFirst(value: boolean | 'indeterminate') {
         updateMapUserSettings({ show_statics_first: value });
     }
 }
+
+function handleToggleCompactSignatureList(value: boolean | 'indeterminate') {
+    if (typeof value === 'boolean') {
+        updateMapUserSettings({ compact_signature_list: value });
+    }
+}
 </script>
 
 <template>
@@ -80,6 +86,14 @@ function handleToggleStaticsFirst(value: boolean | 'indeterminate') {
                             </div>
                         </div>
                         <Checkbox :model-value="map_user_settings.show_statics_first" @update:model-value="handleToggleStaticsFirst" />
+                    </div>
+
+                    <div class="flex items-center justify-between">
+                        <div class="space-y-0.5">
+                            <Label class="text-sm font-medium">Compact Signature List</Label>
+                            <div class="text-sm text-muted-foreground">Show signatures in a denser list with less spacing between rows</div>
+                        </div>
+                        <Checkbox :model-value="map_user_settings.compact_signature_list" @update:model-value="handleToggleCompactSignatureList" />
                     </div>
                 </CardContent>
             </Card>

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -292,6 +292,7 @@ export type TMapUserSetting = {
     hidden_cards: string[] | null;
     show_threat_level: boolean;
     show_statics_first: boolean;
+    compact_signature_list: boolean;
     is_archived: boolean;
     is_pinned: boolean;
     background_image_url: string | null;

--- a/tests/Feature/MapUserSettingTest.php
+++ b/tests/Feature/MapUserSettingTest.php
@@ -239,3 +239,22 @@ it('persists the preselect signature setting', function () {
         ->value('preselect_signature_enabled')
     )->toBeTruthy();
 });
+
+// --- Compact signature list setting ---
+
+it('persists the compact signature list setting', function () {
+    $map = Map::factory()->create();
+    $user = User::factory()->ownsMap($map)->create();
+
+    actingAs($user);
+
+    $this->put(route('maps.user-settings.update', $map), [
+        'compact_signature_list' => true,
+    ])->assertRedirect();
+
+    expect(MapUserSetting::query()
+        ->where('user_id', $user->id)
+        ->where('map_id', $map->id)
+        ->value('compact_signature_list')
+    )->toBeTruthy();
+});


### PR DESCRIPTION
**Context**

Signature scan rows are tall enough to force scrolling in most wormhole systems where there are regularly 10+ signatures.

This PR adds a per-map "Compact Signature List" toggle under map Preferences.
* When enabled, row padding and all interactive controls (ID, Category, Type, Connection, Age, actions) shrink to a uniform compact height.
* When disabled, the panel keeps its default taller layout (current style).

**Details**

* When enabled, the Signatures panel renders denser rows: tighter vertical padding (py-1.5 → py-0.5), shorter inline controls (category/connection Select triggers h-6 → h-5), and a smaller wormhole/signature type ComboboxTrigger (size="sm", h-9 → h-5).
* A vertical alignment fix was also required so every cell in a row lines up in both compact and default modes.
* The database contains a new compact_signature_list boolean column on map_user_settings, defaulting to false (opt-in, existing behavior unchanged).
* Includes the backend setting (migration, model cast, request, resource).

New visual with "Compact Signature List" option on:
<img width="765" height="187" alt="image" src="https://github.com/user-attachments/assets/3b1d96b2-b3b5-4ae9-88b0-b8e8445065ef" />

For reference, the default view (which has not changed):
<img width="765" height="270" alt="image" src="https://github.com/user-attachments/assets/5075186b-b784-4cdf-a6b2-0f22f39e357c" />