### PR TITLE
feat: optional starting points for proximity alerts and routes

### DIFF
--- a/app/Actions/Discord/CalculateDiscordRouteAction.php
+++ b/app/Actions/Discord/CalculateDiscordRouteAction.php
@@ -9,13 +9,14 @@ use App\Models\Map;
 use App\Models\MapIgnoredSolarsystem;
 use App\Models\Solarsystem;
 use App\Services\Routing\MapProximityPathfinder;
+use App\Services\Routing\ProximityResult;
 use Illuminate\Support\Facades\Gate;
 
 final readonly class CalculateDiscordRouteAction
 {
     public function __construct(private MapProximityPathfinder $pathfinder) {}
 
-    public function handle(DiscordAccount $account, int $mapId, int $targetSolarsystemId): string
+    public function handle(DiscordAccount $account, int $mapId, int $targetSolarsystemId, ?int $fromSolarsystemId = null): string
     {
         $map = Map::query()->find($mapId);
         $target = Solarsystem::query()->find($targetSolarsystemId);
@@ -23,12 +24,18 @@ final readonly class CalculateDiscordRouteAction
             return 'That map or target system is unavailable.';
         }
 
-        $origins = $map->mapSolarsystems()->pluck('solarsystem_id')->all();
-        $edges = $map->mapConnections()->with(['fromMapSolarsystem:id,solarsystem_id', 'toMapSolarsystem:id,solarsystem_id'])->get()
-            ->map(fn ($connection): array => [$connection->fromMapSolarsystem->solarsystem_id, $connection->toMapSolarsystem->solarsystem_id])->all();
+        $from = $fromSolarsystemId === null ? null : Solarsystem::query()->find($fromSolarsystemId);
+        if ($fromSolarsystemId !== null && ! $from instanceof Solarsystem) {
+            return 'That starting point system is unavailable.';
+        }
+
+        $origins = $from instanceof Solarsystem
+            ? [$from->id]
+            : $map->mapSolarsystems()->pluck('solarsystem_id')->all();
+        $edges = $map->wormholeEdges();
         $ignored = MapIgnoredSolarsystem::query()->where('map_id', $map->id)->pluck('solarsystem_id')->all();
         $result = $this->pathfinder->nearest($origins, $target->id, $edges, $ignored, 100);
-        if (! $result instanceof \App\Services\Routing\ProximityResult) {
+        if (! $result instanceof ProximityResult) {
             return 'No route was found within 100 jumps.';
         }
 

--- a/app/Actions/Discord/CreateDiscordAlertAction.php
+++ b/app/Actions/Discord/CreateDiscordAlertAction.php
@@ -34,6 +34,7 @@ final readonly class CreateDiscordAlertAction
         ?string $guildId,
         ?string $channelId,
         ?string $roleId,
+        ?int $originSolarsystemId = null,
     ): string {
         $map = Map::query()->find($mapId);
         if ($map === null || ! in_array($delivery, [MapAlertDeliveryType::DiscordDm, MapAlertDeliveryType::DiscordChannel], true) || ! $mentionMode instanceof MapAlertMentionMode) {
@@ -44,6 +45,15 @@ final readonly class CreateDiscordAlertAction
         $target = $needsTarget && $solarsystemId !== null ? Solarsystem::query()->find($solarsystemId) : null;
         if ($needsTarget && $target === null) {
             return 'That target system is unavailable.';
+        }
+
+        if ($originSolarsystemId !== null && $type !== MapAlertType::Proximity) {
+            return 'Starting points are only supported for proximity alerts.';
+        }
+
+        $origin = $originSolarsystemId === null ? null : Solarsystem::query()->find($originSolarsystemId);
+        if ($originSolarsystemId !== null && ! $origin instanceof Solarsystem) {
+            return 'That starting point system is unavailable.';
         }
 
         $needsJumps = $type !== MapAlertType::JumpRange;
@@ -75,7 +85,7 @@ final readonly class CreateDiscordAlertAction
             return 'Select a role only when the mention option is A role.';
         }
 
-        DB::transaction(function () use ($account, $map, $type, $target, $jumps, $shipType, $jdcLevel, $includeHighsec, $delivery, $mentionMode, $guildId, $channelId, $roleId, $isChannel): void {
+        DB::transaction(function () use ($account, $map, $type, $target, $origin, $jumps, $shipType, $jdcLevel, $includeHighsec, $delivery, $mentionMode, $guildId, $channelId, $roleId, $isChannel): void {
             $alert = MapAlert::query()->create([
                 'map_id' => $map->id,
                 'created_by_user_id' => $account->user_id,
@@ -88,6 +98,7 @@ final readonly class CreateDiscordAlertAction
                 'discord_role_id' => $isChannel ? $roleId : null,
                 'type' => $type,
                 'target_solarsystem_id' => $target?->id,
+                'origin_solarsystem_id' => $origin?->id,
                 'max_jumps' => $type === MapAlertType::JumpRange ? null : $jumps,
                 'ship_type' => $type === MapAlertType::JumpRange ? $shipType : null,
                 'jdc_level' => $type === MapAlertType::JumpRange ? $jdcLevel : null,
@@ -98,7 +109,9 @@ final readonly class CreateDiscordAlertAction
         });
 
         return match ($type) {
-            MapAlertType::Proximity => sprintf('Alert created for **%s** within %d jumps of **%s**.', $target->name, $jumps, $map->name),
+            MapAlertType::Proximity => $origin instanceof Solarsystem
+                ? sprintf('Alert created for **%s** within %d jumps of **%s** through the **%s** chain.', $target->name, $jumps, $origin->name, $map->name)
+                : sprintf('Alert created for **%s** within %d jumps of **%s**.', $target->name, $jumps, $map->name),
             MapAlertType::JumpRange => sprintf('Alert created for exits within %.1f ly of **%s** on **%s**.', $shipType->maxRangeLy($jdcLevel), $target->name, $map->name),
             MapAlertType::Killmail => sprintf('Alert created for kills within %d jumps of the **%s** chain.', $jumps, $map->name),
         };

--- a/app/Actions/Discord/DiscordAlertFormatter.php
+++ b/app/Actions/Discord/DiscordAlertFormatter.php
@@ -7,6 +7,7 @@ namespace App\Actions\Discord;
 use App\Enums\MapAlertDeliveryType;
 use App\Enums\MapAlertType;
 use App\Models\MapAlert;
+use App\Models\Solarsystem;
 
 final readonly class DiscordAlertFormatter
 {
@@ -27,7 +28,9 @@ final readonly class DiscordAlertFormatter
         return match ($alert->type) {
             MapAlertType::Killmail => sprintf('killmails within %d jumps', $alert->max_jumps ?? 0),
             MapAlertType::JumpRange => sprintf('capital range of %s', $alert->targetSolarsystem->name),
-            MapAlertType::Proximity => sprintf('%s within %d jumps', $alert->targetSolarsystem->name, $alert->max_jumps ?? 0),
+            MapAlertType::Proximity => $alert->originSolarsystem instanceof Solarsystem
+                ? sprintf('%s within %d jumps of %s', $alert->targetSolarsystem->name, $alert->max_jumps ?? 0, $alert->originSolarsystem->name)
+                : sprintf('%s within %d jumps', $alert->targetSolarsystem->name, $alert->max_jumps ?? 0),
         };
     }
 }

--- a/app/Actions/Discord/ListDiscordMapAlertsAction.php
+++ b/app/Actions/Discord/ListDiscordMapAlertsAction.php
@@ -23,7 +23,7 @@ final readonly class ListDiscordMapAlertsAction
         $isManager = Gate::forUser($account->user)->allows('manageAccess', $map);
         $alerts = $map->mapAlerts()
             ->when(! $isManager, fn ($query) => $query->shared())
-            ->with(['creator:id,name', 'map:id,name', 'targetSolarsystem:id,name'])
+            ->with(['creator:id,name', 'map:id,name', 'targetSolarsystem:id,name', 'originSolarsystem:id,name'])
             ->latest()
             ->get();
 

--- a/app/Actions/Discord/ListMyDiscordAlertsAction.php
+++ b/app/Actions/Discord/ListMyDiscordAlertsAction.php
@@ -13,7 +13,7 @@ final readonly class ListMyDiscordAlertsAction
 
     public function handle(DiscordAccount $account): string
     {
-        $alerts = $account->user->createdMapAlerts()->bot()->with(['map:id,name', 'targetSolarsystem:id,name'])->latest()->get();
+        $alerts = $account->user->createdMapAlerts()->bot()->with(['map:id,name', 'targetSolarsystem:id,name', 'originSolarsystem:id,name'])->latest()->get();
 
         return $alerts->isEmpty()
             ? 'You have no proximity alerts.'

--- a/app/Actions/MapConnections/CreateMapConnectionAction.php
+++ b/app/Actions/MapConnections/CreateMapConnectionAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\MapConnections;
 
 use App\Enums\ShipSize;
+use App\Jobs\MapAlerts\EvaluateMapAlertsJob;
 use App\Models\MapConnection;
 use App\Models\MapSolarsystem;
 use App\Models\Wormhole;
@@ -42,6 +43,13 @@ final readonly class CreateMapConnectionAction
          * already carries jumps observed before the connection existed.
          */
         $this->claimPendingConnectionJumpsAction->handle($map_connection);
+
+        /* A new wormhole edge can complete a route for alerts with a fixed starting
+         * point even though no system was placed, so both endpoints re-evaluate.
+         * Deliveries already sent for an endpoint are deduplicated by the ledger.
+         */
+        EvaluateMapAlertsJob::dispatch($map_connection->from_map_solarsystem_id)->afterCommit();
+        EvaluateMapAlertsJob::dispatch($map_connection->to_map_solarsystem_id)->afterCommit();
 
         $this->mapBroadcaster->connectionsUpserted($map_id, MapConnection::query()
             ->whereKey($map_connection->id)

--- a/app/Http/Controllers/MapDiscordController.php
+++ b/app/Http/Controllers/MapDiscordController.php
@@ -36,10 +36,10 @@ final class MapDiscordController extends Controller
             'map' => $map->toResource(MapInfoResource::class),
             'webhooks' => fn () => $map->mapWebhooks()->withCount('alerts')->latest()->get()->toResourceCollection(MapWebhookResource::class),
             'roles' => fn () => $map->mapWebhookRoles()->withCount('alerts')->latest()->get()->toResourceCollection(MapWebhookRoleResource::class),
-            'alerts' => fn () => $map->mapAlerts()->webhook()->with('webhook')->latest()->get()->toResourceCollection(MapAlertResource::class),
+            'alerts' => fn () => $map->mapAlerts()->webhook()->with(['webhook', 'originSolarsystem'])->latest()->get()->toResourceCollection(MapAlertResource::class),
             'botAlerts' => fn () => $map->mapAlerts()
                 ->bot()
-                ->with(['creator.characters', 'targetSolarsystem'])
+                ->with(['creator.characters', 'targetSolarsystem', 'originSolarsystem'])
                 ->latest()
                 ->get()
                 ->toResourceCollection(MapAlertResource::class),

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -31,7 +31,7 @@ final class SettingsController extends Controller
         $discordAccount = $this->user->discordAccount()->first();
         $discordAlerts = $this->user->createdMapAlerts()
             ->bot()
-            ->with(['map:id,name', 'targetSolarsystem:id,name'])
+            ->with(['map:id,name', 'targetSolarsystem:id,name', 'originSolarsystem:id,name'])
             ->latest()
             ->get();
 

--- a/app/Http/Requests/Concerns/HasMapAlertRules.php
+++ b/app/Http/Requests/Concerns/HasMapAlertRules.php
@@ -37,6 +37,7 @@ trait HasMapAlertRules
             'mention_mode' => ['sometimes', Rule::in([MapAlertMentionMode::None->value, MapAlertMentionMode::Everyone->value])],
             'type' => ['required', Rule::enum(MapAlertType::class)],
             'target_solarsystem_id' => ['nullable', 'integer', 'exists:solarsystems,id', 'required_if:type,'.MapAlertType::Proximity->value.','.MapAlertType::JumpRange->value],
+            'origin_solarsystem_id' => ['nullable', 'integer', 'exists:solarsystems,id', 'prohibited_unless:type,'.MapAlertType::Proximity->value],
             'ship_type' => ['nullable', Rule::enum(JumpShipType::class), 'required_if:type,'.MapAlertType::JumpRange->value],
             'jdc_level' => ['nullable', 'integer', 'between:1,5', 'required_if:type,'.MapAlertType::JumpRange->value],
             'include_highsec' => ['boolean'],

--- a/app/Http/Resources/MapAlertResource.php
+++ b/app/Http/Resources/MapAlertResource.php
@@ -46,6 +46,11 @@ final class MapAlertResource extends JsonResource
                 'id' => $this->targetSolarsystem->id,
                 'name' => $this->targetSolarsystem->name,
             ] : null),
+            'origin_solarsystem_id' => $this->origin_solarsystem_id,
+            'origin_solarsystem' => $this->whenLoaded('originSolarsystem', fn (): ?array => $this->originSolarsystem ? [
+                'id' => $this->originSolarsystem->id,
+                'name' => $this->originSolarsystem->name,
+            ] : null),
             'ship_type' => $this->ship_type?->value,
             'jdc_level' => $this->jdc_level,
             'include_highsec' => $this->include_highsec,

--- a/app/Jobs/MapAlerts/EvaluateMapAlertsJob.php
+++ b/app/Jobs/MapAlerts/EvaluateMapAlertsJob.php
@@ -70,6 +70,9 @@ final class EvaluateMapAlertsJob implements ShouldBeUnique, ShouldQueue
     /** @var array<int, MapAlertDelivery> */
     private array $reservations = [];
 
+    /** @var array<int, array{0: int, 1: int}>|null */
+    private ?array $chainEdges = null;
+
     public function __construct(public readonly int $map_solarsystem_id) {}
 
     public function uniqueId(): string
@@ -158,8 +161,22 @@ final class EvaluateMapAlertsJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
-        $result = $this->pathfinder->nearest([$placement->solarsystem_id], $alert->target_solarsystem_id, [], $ignored, $alert->max_jumps);
+        $hasOrigin = $alert->origin_solarsystem_id !== null;
+        $result = $this->pathfinder->nearest(
+            [$hasOrigin ? $alert->origin_solarsystem_id : $placement->solarsystem_id],
+            $alert->target_solarsystem_id,
+            $hasOrigin ? $this->chainEdges($placement) : [],
+            $ignored,
+            $alert->max_jumps,
+        );
         if (! $result instanceof ProximityResult) {
+            return;
+        }
+
+        // A fixed starting point re-measures the same pair on every placement; only the
+        // placement that actually participates in the route may fire, so an in-range
+        // pair does not re-alert for every unrelated system added later.
+        if ($hasOrigin && ! in_array($placement->solarsystem_id, $result->route, true)) {
             return;
         }
 
@@ -283,6 +300,17 @@ final class EvaluateMapAlertsJob implements ShouldBeUnique, ShouldQueue
         $nonce = mb_substr(hash('sha256', $alert->id.':'.$placement->id), 0, 25);
         $failure = $this->botDeliverer->deliver($alert, $embed, $nonce, $reservation);
         $this->firstFailure ??= $failure;
+    }
+
+    /**
+     * The chain's wormhole edges, loaded once per run and only when an alert with a
+     * fixed starting point needs them.
+     *
+     * @return array<int, array{0: int, 1: int}>
+     */
+    private function chainEdges(MapSolarsystem $placement): array
+    {
+        return $this->chainEdges ??= $placement->map->wormholeEdges();
     }
 
     /**

--- a/app/Models/Map.php
+++ b/app/Models/Map.php
@@ -65,6 +65,24 @@ final class Map extends Model
     }
 
     /**
+     * The chain's wormhole connections as solarsystem id pairs, ready to extend the
+     * stargate graph for routing.
+     *
+     * @return array<int, array{0: int, 1: int}>
+     */
+    public function wormholeEdges(): array
+    {
+        return $this->mapConnections()
+            ->with(['fromMapSolarsystem:id,solarsystem_id', 'toMapSolarsystem:id,solarsystem_id'])
+            ->get()
+            ->map(fn (MapConnection $connection): array => [
+                $connection->fromMapSolarsystem->solarsystem_id,
+                $connection->toMapSolarsystem->solarsystem_id,
+            ])
+            ->all();
+    }
+
+    /**
      * The connections between solar systems in this map.
      *
      * @return HasMany<MapSolarsystem, $this>

--- a/app/Models/MapAlert.php
+++ b/app/Models/MapAlert.php
@@ -41,6 +41,7 @@ use Illuminate\Support\Collection;
  * @property string|null $discord_role_id
  * @property MapAlertType $type
  * @property int|null $target_solarsystem_id
+ * @property int|null $origin_solarsystem_id
  * @property JumpShipType|null $ship_type
  * @property int|null $jdc_level
  * @property bool $include_highsec
@@ -63,6 +64,7 @@ use Illuminate\Support\Collection;
  * @property-read MapWebhook|null $webhook
  * @property-read MapWebhookRole|null $role
  * @property-read Solarsystem|null $targetSolarsystem
+ * @property-read Solarsystem|null $originSolarsystem
  * @property-read Collection<int, MapAlertDelivery> $deliveries
  * @property-read Collection<int, MapAlertEvent> $events
  */
@@ -161,6 +163,17 @@ final class MapAlert extends Model
     public function targetSolarsystem(): BelongsTo
     {
         return $this->belongsTo(Solarsystem::class, 'target_solarsystem_id');
+    }
+
+    /**
+     * The optional fixed starting point proximity is measured from; without one the
+     * alert measures from any point of the chain.
+     *
+     * @return BelongsTo<Solarsystem, $this>
+     */
+    public function originSolarsystem(): BelongsTo
+    {
+        return $this->belongsTo(Solarsystem::class, 'origin_solarsystem_id');
     }
 
     /** @return HasMany<MapAlertDelivery, $this> */

--- a/app/Services/Discord/Commands/AlertCommand.php
+++ b/app/Services/Discord/Commands/AlertCommand.php
@@ -69,6 +69,7 @@ final readonly class AlertCommand implements CommandDefinition
         $systemId = $this->option($variant, 'system');
         $jumps = $this->option($variant, 'jumps');
         $jdcLevel = $this->option($variant, 'jdc');
+        $from = $this->option($variant, 'from');
 
         return $this->createAlert->handle(
             $account,
@@ -84,6 +85,7 @@ final readonly class AlertCommand implements CommandDefinition
             $interaction->guild_id === null ? null : (string) $interaction->guild_id,
             $interaction->channel_id === null ? null : (string) $interaction->channel_id,
             $roleId === null ? null : (string) $roleId,
+            $from === null ? null : (int) $from,
         );
     }
 

--- a/app/Services/Discord/Commands/BuildsCommandOptions.php
+++ b/app/Services/Discord/Commands/BuildsCommandOptions.php
@@ -26,18 +26,30 @@ trait BuildsCommandOptions
         return Option::string('alert')->description('Alert')->required()->autocomplete();
     }
 
+    private function fromOption(): Option
+    {
+        return Option::string('from')->description('Starting point system (defaults to the chain)')->autocomplete();
+    }
+
+    private function mentionOption(): Option
+    {
+        return Option::string('mention')
+            ->description('Who to ping')
+            ->required()
+            ->choice('Nobody', 'none')
+            ->choice('Me', 'creator')
+            ->choice('A role', 'role')
+            ->choice('Everyone', 'everyone');
+    }
+
+    private function roleOption(): Option
+    {
+        return Option::role('role')->description('Role to ping');
+    }
+
     /** @return Option[] */
     private function mentionOptions(): array
     {
-        return [
-            Option::string('mention')
-                ->description('Who to ping')
-                ->required()
-                ->choice('Nobody', 'none')
-                ->choice('Me', 'creator')
-                ->choice('A role', 'role')
-                ->choice('Everyone', 'everyone'),
-            Option::role('role')->description('Role to ping'),
-        ];
+        return [$this->mentionOption(), $this->roleOption()];
     }
 }

--- a/app/Services/Discord/Commands/ProximityAlertCommand.php
+++ b/app/Services/Discord/Commands/ProximityAlertCommand.php
@@ -16,6 +16,12 @@ final readonly class ProximityAlertCommand implements AlertVariantDefinition
             $this->jumpsOption(),
         );
 
-        return $withMentions ? $subCommand->options(...$this->mentionOptions()) : $subCommand;
+        if ($withMentions) {
+            $subCommand->options($this->mentionOption());
+        }
+
+        $subCommand->options($this->fromOption());
+
+        return $withMentions ? $subCommand->options($this->roleOption()) : $subCommand;
     }
 }

--- a/app/Services/Discord/Commands/RouteCommand.php
+++ b/app/Services/Discord/Commands/RouteCommand.php
@@ -20,6 +20,7 @@ final readonly class RouteCommand implements CommandDefinition
         return SlashCommand::make('route', 'Find the shortest route from a map')->options(
             $this->mapOption(),
             $this->systemOption(),
+            $this->fromOption(),
         );
     }
 
@@ -30,10 +31,13 @@ final readonly class RouteCommand implements CommandDefinition
 
     public function respond(ApplicationCommand $interaction, ?DiscordAccount $account): string
     {
+        $from = $this->option($interaction->data, 'from');
+
         return $this->calculateRoute->handle(
             $account,
             (int) $this->option($interaction->data, 'map'),
             (int) $this->option($interaction->data, 'system'),
+            $from === null ? null : (int) $from,
         );
     }
 }

--- a/app/Services/Discord/DiscordInteractionHandler.php
+++ b/app/Services/Discord/DiscordInteractionHandler.php
@@ -120,7 +120,7 @@ final readonly class DiscordInteractionHandler
 
         return match ($focused->name) {
             'map' => $this->autocomplete->maps($account, (string) $focused->value),
-            'system' => $this->autocomplete->solarsystems((string) $focused->value),
+            'system', 'from' => $this->autocomplete->solarsystems((string) $focused->value),
             'alert' => $this->autocompleteAlerts->handle($account, (string) $focused->value),
             default => [],
         };

--- a/app/Services/Discord/PersonalProximityAlertEmbed.php
+++ b/app/Services/Discord/PersonalProximityAlertEmbed.php
@@ -16,23 +16,34 @@ final class PersonalProximityAlertEmbed
     /** @return array<string, mixed> */
     public function build(MapAlert $alert, MapSolarsystem $placement, ProximityResult $result): array
     {
-        $systems = $this->resolveSystems([$alert->target_solarsystem_id, $placement->solarsystem_id, ...$result->route]);
+        $systems = $this->resolveSystems([$alert->target_solarsystem_id, $alert->origin_solarsystem_id, $placement->solarsystem_id, ...$result->route]);
 
         $target = $systems[$alert->target_solarsystem_id] ?? ['name' => (string) $alert->target_solarsystem_id, 'security' => 0.0];
-        $originName = $systems[$placement->solarsystem_id]['name'] ?? (string) $placement->solarsystem_id;
+        $placementName = $systems[$placement->solarsystem_id]['name'] ?? (string) $placement->solarsystem_id;
         $routeNames = array_map(fn (int $id): string => $systems[$id]['name'] ?? (string) $id, $result->route);
+
+        $fields = [
+            ['name' => 'Target', 'value' => $target['name'], 'inline' => true],
+            ['name' => 'Map', 'value' => $alert->map->name, 'inline' => true],
+            ['name' => 'Gate jumps', 'value' => (string) $result->jumps, 'inline' => true],
+        ];
+
+        if ($alert->origin_solarsystem_id !== null) {
+            $fields[] = [
+                'name' => 'From',
+                'value' => $systems[$alert->origin_solarsystem_id]['name'] ?? (string) $alert->origin_solarsystem_id,
+                'inline' => true,
+            ];
+        }
+
+        $fields[] = ['name' => 'Route', 'value' => implode(' → ', $routeNames)];
 
         return [
             'title' => sprintf('%s is now within %d %s', $target['name'], $result->jumps, $result->jumps === 1 ? 'jump' : 'jumps'),
             'url' => route('maps.show', $alert->map),
-            'description' => sprintf('**%s** was added to **%s**.', $originName, $alert->map->name),
+            'description' => sprintf('**%s** was added to **%s**.', $placementName, $alert->map->name),
             'color' => $this->colorForSecurity($target['security']),
-            'fields' => [
-                ['name' => 'Target', 'value' => $target['name'], 'inline' => true],
-                ['name' => 'Map', 'value' => $alert->map->name, 'inline' => true],
-                ['name' => 'Gate jumps', 'value' => (string) $result->jumps, 'inline' => true],
-                ['name' => 'Route', 'value' => implode(' → ', $routeNames)],
-            ],
+            'fields' => $fields,
         ];
     }
 }

--- a/app/Services/Discord/ProximityAlertEmbed.php
+++ b/app/Services/Discord/ProximityAlertEmbed.php
@@ -34,7 +34,9 @@ final readonly class ProximityAlertEmbed
         return [
             'title' => sprintf('Found new %d %s %s connection', $result->jumps, $result->jumps === 1 ? 'jump' : 'jumps', $target['name']),
             'url' => route('maps.show', $alert->map),
-            'description' => sprintf('**%s** was just added to your map, putting **%s** within range.', $originName, $target['name']),
+            'description' => $alert->origin_solarsystem_id === null
+                ? sprintf('**%s** was just added to your map, putting **%s** within range.', $originName, $target['name'])
+                : sprintf('The chain now puts **%s** within range of **%s**.', $target['name'], $originName),
             'color' => $this->colorForSecurity((float) $target['security']),
             'fields' => [
                 ['name' => 'Target', 'value' => sprintf('%s (%.1f)', $target['name'], $target['security']), 'inline' => true],

--- a/database/migrations/2026_07_22_120000_add_origin_solarsystem_to_map_alerts.php
+++ b/database/migrations/2026_07_22_120000_add_origin_solarsystem_to_map_alerts.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('map_alerts', function (Blueprint $table): void {
+            $table->foreignId('origin_solarsystem_id')->nullable()->after('target_solarsystem_id')->constrained('solarsystems')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('map_alerts', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('origin_solarsystem_id');
+        });
+    }
+};

--- a/resources/js/lib/mapAlerts.ts
+++ b/resources/js/lib/mapAlerts.ts
@@ -1,11 +1,14 @@
 import { maxRangeLy } from '@/const/jumpShipTypes';
 import type { TMapAlert } from '@/types/models';
 
-type TAlertTriggerFields = Pick<TMapAlert, 'type' | 'max_jumps' | 'ship_type' | 'jdc_level' | 'target_solarsystem' | 'target_solarsystem_id'>;
+type TAlertTriggerFields = Pick<
+    TMapAlert,
+    'type' | 'max_jumps' | 'ship_type' | 'jdc_level' | 'target_solarsystem' | 'target_solarsystem_id' | 'origin_solarsystem' | 'origin_solarsystem_id'
+>;
 
 /**
  * Human-readable description of what fires an alert, shared by every alert list.
- * Pass a resolver when the alert payload does not include its target solarsystem.
+ * Pass a resolver when the alert payload does not include its solarsystems.
  */
 export function alertTriggerLabel(alert: TAlertTriggerFields, resolveSystemName?: (id: number | null) => string): string {
     const systemName = alert.target_solarsystem?.name ?? resolveSystemName?.(alert.target_solarsystem_id) ?? 'Unknown system';
@@ -17,5 +20,9 @@ export function alertTriggerLabel(alert: TAlertTriggerFields, resolveSystemName?
     if (alert.type === 'jump_range') {
         return `Exits within ${maxRangeLy(alert.ship_type ?? 'dreadnought', alert.jdc_level ?? 5).toFixed(1)} ly of ${systemName}`;
     }
-    return `${systemName} within ${alert.max_jumps} gate jump${jumpsPlural}`;
+
+    const originName = alert.origin_solarsystem?.name ?? (alert.origin_solarsystem_id ? resolveSystemName?.(alert.origin_solarsystem_id) : null);
+    const origin = originName ? ` of ${originName} through the chain` : '';
+
+    return `${systemName} within ${alert.max_jumps} gate jump${jumpsPlural}${origin}`;
 }

--- a/resources/js/pages/maps/settings/Discord.vue
+++ b/resources/js/pages/maps/settings/Discord.vue
@@ -173,6 +173,7 @@ type TAlertForm = {
     mention_mode: 'none' | 'everyone';
     type: TMapAlertType;
     target_solarsystem_id: number;
+    origin_solarsystem_id: number;
     ship_type: TJumpShipType;
     jdc_level: number;
     include_highsec: boolean;
@@ -190,6 +191,7 @@ function emptyAlertForm(type: TMapAlertType = 'proximity'): TAlertForm {
         mention_mode: 'none',
         type,
         target_solarsystem_id: 0,
+        origin_solarsystem_id: 0,
         ship_type: 'dreadnought',
         jdc_level: 5,
         include_highsec: false,
@@ -231,11 +233,13 @@ const alertForm = useForm<TAlertForm>(emptyAlertForm());
 const alertDialogOpen = ref(false);
 const alertDialogTab = ref<TAlertDialogTab>('trigger');
 const search = ref('');
+const originSearch = ref('');
 const editingAlert = computed(() => alertForm.id !== null);
 const alertErrors = computed(() => Object.values(alertForm.errors));
 const isKillmail = computed(() => alertForm.type === 'killmail');
 const isJumpRange = computed(() => alertForm.type === 'jump_range');
 const selectedTarget = computed(() => findSolarsystem(alertForm.target_solarsystem_id));
+const selectedOrigin = computed(() => findSolarsystem(alertForm.origin_solarsystem_id));
 const formJumpRangeLy = computed(() => maxRangeLy(alertForm.ship_type, alertForm.jdc_level));
 
 const filteredSolarsystems = computed(() => {
@@ -249,6 +253,22 @@ const filteredSolarsystems = computed(() => {
         (solarsystem) => solarsystem.name,
     );
 });
+
+const filteredOriginSolarsystems = computed(() => {
+    const query = originSearch.value.trim().toLowerCase();
+    if (!query) return [] as TStaticSolarsystem[];
+    return takeRanked(
+        solarsystems.value,
+        query,
+        MAX_SEARCH_RESULTS,
+        (solarsystem) => [solarsystem.name],
+        (solarsystem) => solarsystem.name,
+    );
+});
+
+const origin_search_sections = computed<TComboboxSection<TStaticSolarsystem>[]>(() => [
+    { key: 'results', heading: 'Search Results', items: filteredOriginSolarsystems.value },
+]);
 
 const search_sections = computed<TComboboxSection<TStaticSolarsystem>[]>(() => [
     { key: 'results', heading: 'Search Results', items: filteredSolarsystems.value },
@@ -268,10 +288,17 @@ watch(search, (value) => {
     }
 });
 
+watch(originSearch, (value) => {
+    if (selectedOrigin.value && value.trim() !== selectedOrigin.value.name) {
+        alertForm.origin_solarsystem_id = 0;
+    }
+});
+
 function openCreateAlert() {
     alertForm.clearErrors();
     Object.assign(alertForm, emptyAlertForm());
     search.value = '';
+    originSearch.value = '';
     alertDialogTab.value = 'trigger';
     alertDialogOpen.value = true;
 }
@@ -284,6 +311,7 @@ function openEditAlert(alert: TMapAlert) {
         map_webhook_role_id: alert.map_webhook_role_id,
         mention_mode: alert.mention_mode === 'everyone' ? 'everyone' : 'none',
         target_solarsystem_id: alert.target_solarsystem_id ?? 0,
+        origin_solarsystem_id: alert.origin_solarsystem_id ?? 0,
         ship_type: alert.ship_type ?? 'dreadnought',
         jdc_level: alert.jdc_level ?? 5,
         include_highsec: alert.include_highsec,
@@ -293,6 +321,7 @@ function openEditAlert(alert: TMapAlert) {
         is_active: alert.is_active,
     });
     search.value = findSolarsystem(alert.target_solarsystem_id)?.name ?? '';
+    originSearch.value = findSolarsystem(alert.origin_solarsystem_id)?.name ?? '';
     alertDialogTab.value = 'trigger';
     alertDialogOpen.value = true;
 }
@@ -300,6 +329,11 @@ function openEditAlert(alert: TMapAlert) {
 function handleTargetSelect(solarsystem: TStaticSolarsystem) {
     alertForm.target_solarsystem_id = solarsystem.id;
     search.value = solarsystem.name;
+}
+
+function handleOriginSelect(solarsystem: TStaticSolarsystem) {
+    alertForm.origin_solarsystem_id = solarsystem.id;
+    originSearch.value = solarsystem.name;
 }
 
 function submitAlert() {
@@ -311,6 +345,7 @@ function submitAlert() {
         mention_mode: alertForm.mention_mode,
         type: alertForm.type,
         target_solarsystem_id: isKillmail.value ? null : alertForm.target_solarsystem_id,
+        origin_solarsystem_id: alertForm.type === 'proximity' && alertForm.origin_solarsystem_id > 0 ? alertForm.origin_solarsystem_id : null,
         ship_type: isJumpRange.value ? alertForm.ship_type : null,
         jdc_level: isJumpRange.value ? alertForm.jdc_level : null,
         include_highsec: isJumpRange.value ? alertForm.include_highsec : false,
@@ -861,6 +896,23 @@ function confirmPendingDelete() {
                                 <Input id="alert-jumps" type="number" min="1" max="20" v-model.number="alertForm.max_jumps" />
                                 <p class="text-xs text-muted-foreground">Stargate jumps from the added system to the target (1–20).</p>
                             </div>
+                        </div>
+
+                        <div v-if="!isKillmail && !isJumpRange" class="space-y-1.5">
+                            <Label for="alert-origin-system">Starting point (optional)</Label>
+                            <div v-if="selectedOrigin" class="flex items-center gap-2 text-sm">
+                                <SolarsystemClass :solarsystem_class="selectedOrigin.class" :name="selectedOrigin.name" />
+                                <span class="font-medium">{{ selectedOrigin.name }}</span>
+                            </div>
+                            <Combobox class="rounded-lg border bg-neutral-900" :ignore-filter="true">
+                                <ComboboxAnchor>
+                                    <ComboboxInput id="alert-origin-system" v-model="originSearch" placeholder="Anywhere on the chain" />
+                                </ComboboxAnchor>
+                                <VirtualizedSolarsystemList align="start" :sections="origin_search_sections" @select="handleOriginSelect" />
+                            </Combobox>
+                            <p class="text-xs text-muted-foreground">
+                                Measure from this system through the chain instead of from each newly added system.
+                            </p>
                         </div>
 
                         <template v-if="isJumpRange">

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -354,6 +354,8 @@ export type TMapAlert = {
     type: TMapAlertType;
     target_solarsystem_id: number | null;
     target_solarsystem?: { id: number; name: string } | null;
+    origin_solarsystem_id: number | null;
+    origin_solarsystem?: { id: number; name: string } | null;
     ship_type: TJumpShipType | null;
     jdc_level: number | null;
     include_highsec: boolean;

--- a/tests/Feature/Actions/DiscordCommandActionsTest.php
+++ b/tests/Feature/Actions/DiscordCommandActionsTest.php
@@ -24,6 +24,7 @@ use App\Models\DiscordAccount;
 use App\Models\Map;
 use App\Models\MapAccess;
 use App\Models\MapAlert;
+use App\Models\MapConnection;
 use App\Models\MapWebhook;
 use App\Models\Solarsystem;
 use App\Models\User;
@@ -389,4 +390,51 @@ it('creates a killmail alert without a target system', function () {
         ->and($alert->target_solarsystem_id)->toBeNull()
         ->and($alert->max_jumps)->toBe(6)
         ->and($alert->mention_mode)->toBe(MapAlertMentionMode::Everyone);
+});
+
+it('creates a proximity alert with a fixed starting point', function () {
+    $map = Map::factory()->create(['name' => 'Origin Chain']);
+    $account = discordAccountWithMapAccess($map);
+    $target = discordAlertTarget(30009618, 'Jita Prime');
+    $origin = discordAlertTarget(30009619, 'Turnur Prime');
+
+    $response = app(CreateDiscordAlertAction::class)->handle(
+        $account, MapAlertType::Proximity, MapAlertDeliveryType::DiscordDm, $map->id, $target->id,
+        4, null, null, false, MapAlertMentionMode::None, null, null, null, $origin->id,
+    );
+
+    $alert = MapAlert::query()->sole();
+    expect($response)->toBe('Alert created for **Jita Prime** within 4 jumps of **Turnur Prime** through the **Origin Chain** chain.')
+        ->and($alert->origin_solarsystem_id)->toBe($origin->id);
+});
+
+it('rejects a starting point on non proximity alerts', function () {
+    $map = Map::factory()->create();
+    $account = discordAccountWithMapAccess($map, Permission::Manager);
+    $origin = discordAlertTarget(30009620);
+
+    expect(app(CreateDiscordAlertAction::class)->handle(
+        $account, MapAlertType::Killmail, MapAlertDeliveryType::DiscordDm, $map->id, null,
+        6, null, null, false, MapAlertMentionMode::None, null, null, null, $origin->id,
+    ))->toBe('Starting points are only supported for proximity alerts.')
+        ->and(MapAlert::query()->count())->toBe(0);
+});
+
+it('calculates routes from an optional starting point through the chain', function () {
+    $map = Map::factory()->create();
+    $account = discordAccountWithMapAccess($map);
+    $origin = placeMapSolarsystem($map, 30009621);
+    Solarsystem::query()->whereKey($origin->solarsystem_id)->update(['name' => 'Start']);
+    $target = discordAlertTarget(30009622, 'Goal');
+    $targetPlacement = placeMapSolarsystem($map, $target->id, 200, 200);
+    MapConnection::factory()->create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $origin->id,
+        'to_map_solarsystem_id' => $targetPlacement->id,
+    ]);
+    $action = app(CalculateDiscordRouteAction::class);
+
+    expect($action->handle($account, $map->id, $target->id, $origin->solarsystem_id))->toBe('**1 jumps**: Start -> Goal')
+        ->and($action->handle($account, $map->id, $target->id, $target->id))->toBe('**0 jumps**: Goal')
+        ->and($action->handle($account, $map->id, $target->id, 999999))->toBe('That starting point system is unavailable.');
 });

--- a/tests/Feature/Actions/WebhookEvaluationDispatchTest.php
+++ b/tests/Feature/Actions/WebhookEvaluationDispatchTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Actions\MapConnections\CreateMapConnectionAction;
 use App\Actions\MapSolarsystem\StoreMapSolarsystemAction;
 use App\Jobs\MapAlerts\EvaluateMapAlertsJob;
 use App\Models\Map;
@@ -24,5 +25,25 @@ it('queues an evaluation for the added system when a system joins the map', func
     Queue::assertPushed(
         EvaluateMapAlertsJob::class,
         fn (EvaluateMapAlertsJob $job): bool => $job->map_solarsystem_id === $map->mapSolarsystems()->sole()->id,
+    );
+});
+
+it('queues evaluations for both endpoints when a connection is created', function () {
+    $map = Map::factory()->create();
+    $from = placeMapSolarsystem($map, 30009202);
+    $to = placeMapSolarsystem($map, 30009203, 200, 200);
+
+    app(CreateMapConnectionAction::class)->handle([
+        'from_map_solarsystem_id' => $from->id,
+        'to_map_solarsystem_id' => $to->id,
+    ]);
+
+    Queue::assertPushed(
+        EvaluateMapAlertsJob::class,
+        fn (EvaluateMapAlertsJob $job): bool => $job->map_solarsystem_id === $from->id,
+    );
+    Queue::assertPushed(
+        EvaluateMapAlertsJob::class,
+        fn (EvaluateMapAlertsJob $job): bool => $job->map_solarsystem_id === $to->id,
     );
 });

--- a/tests/Feature/DiscordAlertTest.php
+++ b/tests/Feature/DiscordAlertTest.php
@@ -42,9 +42,11 @@ it('registers the Discord command surface', function () {
             && $channel['type'] === 2
             && collect($dm['options'])->pluck('name')->all() === ['proximity', 'jump-range', 'killmail']
             && collect($channel['options'])->pluck('name')->all() === ['proximity', 'jump-range', 'killmail']
-            && collect(collect($dm['options'])->firstWhere('name', 'proximity')['options'])->pluck('name')->all() === ['map', 'system', 'jumps']
+            && collect(collect($dm['options'])->firstWhere('name', 'proximity')['options'])->pluck('name')->all() === ['map', 'system', 'jumps', 'from']
+            && collect($channelProximity['options'])->pluck('name')->all() === ['map', 'system', 'jumps', 'mention', 'from', 'role']
             && collect($dmJumpRange['options'])->pluck('name')->all() === ['map', 'system', 'ship', 'jdc', 'highsec']
             && collect($dmKillmail['options'])->pluck('name')->all() === ['map', 'jumps']
+            && collect(collect($commands)->firstWhere('name', 'route')['options'])->pluck('name')->all() === ['map', 'system', 'from']
             && collect($alerts['options'])->pluck('name')->all() === ['list', 'map', 'enable', 'disable', 'remove']
             && collect($mention['choices'])->pluck('value')->all() === ['none', 'creator', 'role', 'everyone']
             && $mention['required'] === true

--- a/tests/Feature/Jobs/EvaluateMapWebhooksJobTest.php
+++ b/tests/Feature/Jobs/EvaluateMapWebhooksJobTest.php
@@ -6,6 +6,7 @@ use App\Enums\MapAlertMentionMode;
 use App\Jobs\MapAlerts\EvaluateMapAlertsJob;
 use App\Models\Map;
 use App\Models\MapAlert;
+use App\Models\MapConnection;
 use App\Models\MapSolarsystem;
 use App\Models\MapWebhook;
 use App\Models\MapWebhookRole;
@@ -195,4 +196,46 @@ it('does not deliver a webhook alert twice for the same placement', function () 
 
     Http::assertSentCount(1);
     expect($alert->deliveries()->count())->toBe(1);
+});
+
+it('fires an origin based proximity alert when the chain creates the route', function () {
+    $originSid = makeSolarsystem(30009025);
+    $targetSid = makeSolarsystem(30009026);
+    $map = Map::factory()->create();
+    $originPlacement = MapSolarsystem::factory()->for($map)->create(['solarsystem_id' => $originSid]);
+    $alert = proximityAlert($map, [
+        'target_solarsystem_id' => $targetSid,
+        'origin_solarsystem_id' => $originSid,
+        'max_jumps' => 3,
+    ]);
+
+    $targetPlacement = MapSolarsystem::factory()->for($map)->create(['solarsystem_id' => $targetSid]);
+    MapConnection::factory()->create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $originPlacement->id,
+        'to_map_solarsystem_id' => $targetPlacement->id,
+    ]);
+
+    app()->call([new EvaluateMapAlertsJob($targetPlacement->id), 'handle']);
+
+    Http::assertSentCount(1);
+    Http::assertSent(fn ($request): bool => str_contains((string) $request['embeds'][0]['description'], 'within range of'));
+    expect($alert->refresh()->last_fired_at)->not->toBeNull();
+});
+
+it('does not fire an origin based proximity alert for an unrelated placement', function () {
+    $originSid = makeSolarsystem(30009027);
+    $unrelatedSid = makeSolarsystem(30009028);
+    $map = Map::factory()->create();
+    MapSolarsystem::factory()->for($map)->create(['solarsystem_id' => $originSid]);
+    proximityAlert($map, [
+        'target_solarsystem_id' => $originSid,
+        'origin_solarsystem_id' => $originSid,
+        'max_jumps' => 3,
+    ]);
+
+    $unrelated = MapSolarsystem::factory()->for($map)->create(['solarsystem_id' => $unrelatedSid]);
+    app()->call([new EvaluateMapAlertsJob($unrelated->id), 'handle']);
+
+    Http::assertNothingSent();
 });

--- a/tests/Feature/MapAlertTest.php
+++ b/tests/Feature/MapAlertTest.php
@@ -304,3 +304,29 @@ it('rejects bot-only mention modes for webhook alerts', function () {
         'mention_mode' => 'creator',
     ]))->assertInvalid(['mention_mode']);
 });
+
+it('stores an optional starting point on proximity alerts', function () {
+    $map = Map::factory()->create();
+    $webhook = MapWebhook::factory()->for($map)->create();
+    actingAs(mapAlertManager($map, Permission::Manager));
+    $originId = makeSolarsystem(30009301);
+
+    $this->post(route('map-alerts.store'), validAlertPayload($map, $webhook, [
+        'origin_solarsystem_id' => $originId,
+    ]))->assertRedirect();
+
+    expect(MapAlert::query()->where('map_id', $map->id)->sole()->origin_solarsystem_id)->toBe($originId);
+});
+
+it('rejects a starting point for killmail alerts', function () {
+    $map = Map::factory()->create();
+    $webhook = MapWebhook::factory()->for($map)->create();
+    actingAs(mapAlertManager($map, Permission::Manager));
+
+    $this->post(route('map-alerts.store'), validAlertPayload($map, $webhook, [
+        'type' => 'killmail',
+        'target_solarsystem_id' => null,
+        'origin_solarsystem_id' => makeSolarsystem(30009302),
+        'filters' => [],
+    ]))->assertInvalid(['origin_solarsystem_id']);
+});


### PR DESCRIPTION
Lets proximity alerts and the route command measure from a fixed starting point instead of the chain.

- Proximity alerts accept an optional starting point system on the web form and the /alert command; routes then run from that system through the chain's wormholes, and the alert only fires when the newly added system is part of the route
- Without a starting point, alerts keep measuring from any point of the chain as before
- /route accepts an optional from system with autocomplete
- Embeds, bot listings, and web labels show the starting point when one is set