### PR TITLE
feat: toggle the compact signature list from the signatures panel

### DIFF
--- a/resources/js/components/signatures/Signatures.vue
+++ b/resources/js/components/signatures/Signatures.vue
@@ -16,11 +16,12 @@ import { useSignatures } from '@/composables/signatures/useSignatures';
 import { useSortableSignatures } from '@/composables/signatures/useSortedSignatures';
 import { useActiveMapCharacter } from '@/composables/useActiveMapCharacter';
 import { useMapUserSettings } from '@/composables/useMapUserSettings';
+import { useShowMap } from '@/composables/useShowMap';
 import usePermission from '@/composables/usePermission';
-import { createSignature } from '@/map/api';
+import { createSignature, updateMapUserSettings } from '@/map/api';
 import type { TResolvedSelectedMapSolarsystem } from '@/pages/maps';
 import { useLocalStorage } from '@vueuse/core';
-import { ArrowDown, ArrowUp, CircleHelp, Cloud, Database, Fan, Gem, Landmark, Shield, Swords } from 'lucide-vue-next';
+import { ArrowDown, ArrowUp, CircleHelp, Cloud, Database, Fan, Gem, Landmark, Rows2, Rows3, Shield, Swords } from 'lucide-vue-next';
 import { type Component, computed } from 'vue';
 
 const props = defineProps<{
@@ -34,6 +35,14 @@ const { canEdit: can_write } = usePermission();
 const character = useActiveMapCharacter();
 
 const map_user_settings = useMapUserSettings();
+
+const page = useShowMap();
+
+function toggleCompactSignatureList() {
+    updateMapUserSettings(page.props.map.slug, {
+        compact_signature_list: !map_user_settings.value.compact_signature_list,
+    });
+}
 
 const {
     signatures,
@@ -120,6 +129,17 @@ function createNewSignature() {
             <span v-if="filteredSignatures.length" class="ml-1 text-amber-400">{{ filteredSignatures.length }}</span>
             <span v-if="hiddenSignaturesCount > 0" class="ml-1 text-muted-foreground/70">{{ hiddenSignaturesCount }} hidden</span>
             <template #actions>
+                <Tooltip>
+                    <TooltipTrigger as-child>
+                        <MapPanelHeaderActionButton size="icon" @click="toggleCompactSignatureList">
+                            <Rows2 v-if="map_user_settings.compact_signature_list" class="size-3.5" />
+                            <Rows3 v-else class="size-3.5" />
+                        </MapPanelHeaderActionButton>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        {{ map_user_settings.compact_signature_list ? 'Switch to comfortable signature list' : 'Switch to compact signature list' }}
+                    </TooltipContent>
+                </Tooltip>
                 <ToggleGroup v-model="activeCategoryFilters" type="multiple" size="sm" variant="outline">
                     <Tooltip v-for="option in categoryFilterOptions" :key="option.value">
                         <TooltipTrigger as-child>


### PR DESCRIPTION
Adds a header action to the signatures panel that toggles the compact signature list preference in place.

- Icon button with a tooltip next to the category filters, available to all viewers
- Persists through the existing map user settings endpoint, staying in sync with the preference page checkbox