### PR TITLE
fix(alerts): keep the picked target system when the search list closes

### DIFF
--- a/resources/js/components/solarsystem/SolarsystemPicker.spec.ts
+++ b/resources/js/components/solarsystem/SolarsystemPicker.spec.ts
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+import SolarsystemPicker from '@/components/solarsystem/SolarsystemPicker.vue';
+import { flushVirtualizer, stubElementMeasurements } from '@/components/ui/combobox/comboboxTestUtils';
+import type { TStaticSolarsystem } from '@/types/static-data';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+function solarsystem(id: number, name: string): TStaticSolarsystem {
+    return {
+        id,
+        name,
+        region_id: 1,
+        constellation_id: 1,
+        class: 'h',
+        security: 0.9,
+        type: 'eve',
+        region: { id: 1, name: 'The Forge' },
+        sovereignty: null,
+        statics: null,
+        effect: null,
+        has_jove_observatory: false,
+        has_stations: true,
+        services: [],
+        connection_type: null,
+    } as unknown as TStaticSolarsystem;
+}
+
+const solarsystems = [solarsystem(30000142, 'Jita'), solarsystem(30000144, 'Perimeter'), solarsystem(30002187, 'Amarr')];
+
+const { staticDataRef } = await vi.hoisted(async () => {
+    const { shallowRef } = await import('vue');
+    return { staticDataRef: shallowRef<{ solarsystems: TStaticSolarsystem[] } | null>(null) };
+});
+
+vi.mock('@/composables/useStaticData', () => ({
+    useStaticData: () => ({
+        staticData: staticDataRef,
+        loadStaticData: async () => {},
+    }),
+}));
+
+let wrapper: VueWrapper;
+
+function mountPicker(modelValue = 0): VueWrapper {
+    wrapper = mount(SolarsystemPicker, { props: { modelValue }, attachTo: document.body });
+    return wrapper;
+}
+
+function selectedId(wrapper: VueWrapper): number | undefined {
+    return (wrapper.emitted('update:modelValue')?.at(-1) as number[] | undefined)?.at(0);
+}
+
+function input(wrapper: VueWrapper): HTMLInputElement {
+    return wrapper.find('input').element as HTMLInputElement;
+}
+
+async function type(wrapper: VueWrapper, value: string): Promise<void> {
+    const field = wrapper.find('input');
+    (field.element as HTMLInputElement).value = value;
+    await field.trigger('input');
+    await flushVirtualizer();
+}
+
+async function clickRow(name: string): Promise<void> {
+    const row = [...document.body.querySelectorAll('[role="option"]')].find((option) => option.textContent?.includes(name));
+    expect(row).toBeTruthy();
+    row!.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+    row!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushVirtualizer();
+}
+
+/** Closing the list resets the search term asynchronously, one tick after the close. */
+async function closeList(wrapper: VueWrapper): Promise<void> {
+    await wrapper.find('input').trigger('keydown', { key: 'Escape' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await wrapper.vm.$nextTick();
+}
+
+beforeEach(() => {
+    staticDataRef.value = { solarsystems };
+    stubElementMeasurements();
+    // The rows' sovereignty badge lazily fetches /api/sovereignties.
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })),
+    );
+});
+
+afterEach(() => {
+    wrapper?.unmount();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+});
+
+describe('SolarsystemPicker', () => {
+    it('selects a searched system', async () => {
+        const wrapper = mountPicker();
+        await type(wrapper, 'jit');
+        await clickRow('Jita');
+
+        expect(selectedId(wrapper)).toBe(30000142);
+        expect(input(wrapper).value).toBe('Jita');
+    });
+
+    it('keeps the selection and the query when the list closes', async () => {
+        const wrapper = mountPicker();
+        await type(wrapper, 'jit');
+        await clickRow('Jita');
+        await wrapper.setProps({ modelValue: 30000142 });
+
+        await closeList(wrapper);
+
+        expect(selectedId(wrapper)).toBe(30000142);
+        expect(input(wrapper).value).toBe('Jita');
+        expect(wrapper.text()).toContain('Jita');
+    });
+
+    it('drops the selection when the query is edited after picking', async () => {
+        const wrapper = mountPicker();
+        await type(wrapper, 'jit');
+        await clickRow('Jita');
+        await wrapper.setProps({ modelValue: 30000142 });
+
+        await type(wrapper, 'Amar');
+
+        expect(selectedId(wrapper)).toBe(0);
+        expect(input(wrapper).value).toBe('Amar');
+    });
+
+    it('shows the query for a selection made from the outside', async () => {
+        const wrapper = mountPicker();
+
+        await wrapper.setProps({ modelValue: 30002187 });
+
+        expect(input(wrapper).value).toBe('Amarr');
+    });
+
+    it('fills the query for a preselected system once the static data arrives', async () => {
+        staticDataRef.value = null;
+        const wrapper = mountPicker(30000144);
+        expect(input(wrapper).value).toBe('');
+
+        staticDataRef.value = { solarsystems };
+        await wrapper.vm.$nextTick();
+
+        expect(input(wrapper).value).toBe('Perimeter');
+    });
+
+    it('clears the query when the selection is reset from the outside', async () => {
+        const wrapper = mountPicker(30002187);
+        expect(input(wrapper).value).toBe('Amarr');
+
+        await wrapper.setProps({ modelValue: 0 });
+
+        expect(input(wrapper).value).toBe('');
+    });
+});

--- a/resources/js/components/solarsystem/SolarsystemPicker.vue
+++ b/resources/js/components/solarsystem/SolarsystemPicker.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import SolarsystemClass from '@/components/solarsystem/SolarsystemClass.vue';
+import VirtualizedSolarsystemList from '@/components/solarsystem/VirtualizedSolarsystemList.vue';
+import { Combobox, ComboboxAnchor, ComboboxInput } from '@/components/ui/combobox';
+import { useStaticData } from '@/composables/useStaticData';
+import { type TComboboxSection } from '@/lib/comboboxSections';
+import { MAX_SEARCH_RESULTS, takeRanked } from '@/lib/searchRank';
+import type { TStaticSolarsystem } from '@/types/static-data';
+import { computed, ref, watch } from 'vue';
+
+/**
+ * Search picker that keeps the picked system in the input instead of clearing it,
+ * for forms where the selection has to survive until the form is submitted.
+ */
+const { inputId, placeholder = 'Search for a system…' } = defineProps<{
+    inputId?: string;
+    placeholder?: string;
+}>();
+
+/** 0 means nothing is selected. */
+const solarsystemId = defineModel<number>({ required: true });
+
+const { staticData, loadStaticData } = useStaticData();
+
+void loadStaticData();
+
+const solarsystems = computed(() => staticData.value?.solarsystems ?? []);
+const selected = computed(() => solarsystems.value.find((solarsystem) => solarsystem.id === solarsystemId.value));
+
+const search = ref(selected.value?.name ?? '');
+
+const results = computed(() => {
+    const query = search.value.trim().toLowerCase();
+    if (!query) return [] as TStaticSolarsystem[];
+    return takeRanked(
+        solarsystems.value,
+        query,
+        MAX_SEARCH_RESULTS,
+        (solarsystem) => [solarsystem.name],
+        (solarsystem) => solarsystem.name,
+    );
+});
+
+const sections = computed<TComboboxSection<TStaticSolarsystem>[]>(() => [{ key: 'results', heading: 'Search Results', items: results.value }]);
+
+/**
+ * Guards the two watchers below against each other: only changes coming from
+ * outside the component should overwrite the query, not the ones we make here.
+ * The watchers flush synchronously so the flag is still set when they run.
+ */
+let syncingFromSearch = false;
+
+function withoutQuerySync(update: () => void): void {
+    syncingFromSearch = true;
+    update();
+    syncingFromSearch = false;
+}
+
+// Editing the query after a pick drops the selection.
+watch(
+    search,
+    (value) => {
+        if (selected.value && value.trim() !== selected.value.name) {
+            withoutQuerySync(() => (solarsystemId.value = 0));
+        }
+    },
+    { flush: 'sync' },
+);
+
+// Follow selections set from the outside, e.g. when a form is loaded for editing.
+// Keyed off the resolved system so a preselected id still fills the query once
+// the static data has loaded.
+watch(
+    selected,
+    (solarsystem) => {
+        if (syncingFromSearch) return;
+        search.value = solarsystem?.name ?? '';
+    },
+    { flush: 'sync' },
+);
+
+function handleSelect(solarsystem: TStaticSolarsystem): void {
+    withoutQuerySync(() => (solarsystemId.value = solarsystem.id));
+    search.value = solarsystem.name;
+}
+</script>
+
+<template>
+    <div class="space-y-1.5">
+        <div v-if="selected" class="flex items-center gap-2 text-sm">
+            <SolarsystemClass :solarsystem_class="selected.class" :name="selected.name" />
+            <span class="font-medium">{{ selected.name }}</span>
+        </div>
+        <!-- Without reset-search-term-on-blur, closing the list clears the query and with it the selection. -->
+        <Combobox class="rounded-lg border bg-neutral-900" :ignore-filter="true" :reset-search-term-on-blur="false">
+            <ComboboxAnchor>
+                <ComboboxInput :id="inputId" v-model="search" :placeholder="placeholder" />
+            </ComboboxAnchor>
+            <VirtualizedSolarsystemList align="start" :sections="sections" @select="handleSelect" />
+        </Combobox>
+    </div>
+</template>

--- a/resources/js/pages/maps/settings/Discord.vue
+++ b/resources/js/pages/maps/settings/Discord.vue
@@ -7,13 +7,11 @@ import MapWebhookRoleController from '@/actions/App/Http/Controllers/MapWebhookR
 import PlusIcon from '@/components/icons/PlusIcon.vue';
 import DiscordIcon from '@/components/icons/DiscordIcon.vue';
 import KillmailFilterEditor from '@/components/maps/webhooks/KillmailFilterEditor.vue';
-import SolarsystemClass from '@/components/solarsystem/SolarsystemClass.vue';
-import VirtualizedSolarsystemList from '@/components/solarsystem/VirtualizedSolarsystemList.vue';
+import SolarsystemPicker from '@/components/solarsystem/SolarsystemPicker.vue';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Combobox, ComboboxAnchor, ComboboxInput } from '@/components/ui/combobox';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -29,9 +27,7 @@ import usePermission from '@/composables/usePermission';
 import { useStaticData } from '@/composables/useStaticData';
 import { jumpShipLabel, jumpShipTypes, maxRangeLy } from '@/const/jumpShipTypes';
 import SettingsLayout from '@/layouts/SettingsLayout.vue';
-import { type TComboboxSection } from '@/lib/comboboxSections';
 import { alertTriggerLabel } from '@/lib/mapAlerts';
-import { MAX_SEARCH_RESULTS, takeRanked } from '@/lib/searchRank';
 import { TMapSummary } from '@/pages/maps';
 import {
     TJumpShipType,
@@ -46,7 +42,7 @@ import {
 import { TStaticSolarsystem } from '@/types/static-data';
 import { router, useForm } from '@inertiajs/vue3';
 import { AtSign, Bell, Bot, ExternalLink, Pencil, Rocket, Route, ShieldCheck, Swords, Trash2, Webhook } from 'lucide-vue-next';
-import { computed, ref, watch, type Component } from 'vue';
+import { computed, ref, type Component } from 'vue';
 
 const { map, tab, botAlerts, alertEvents, discordInviteUrl } = defineProps<{
     map: TMapSummary;
@@ -232,47 +228,11 @@ type TAlertDialogTab = 'trigger' | 'conditions' | 'delivery';
 const alertForm = useForm<TAlertForm>(emptyAlertForm());
 const alertDialogOpen = ref(false);
 const alertDialogTab = ref<TAlertDialogTab>('trigger');
-const search = ref('');
-const originSearch = ref('');
 const editingAlert = computed(() => alertForm.id !== null);
 const alertErrors = computed(() => Object.values(alertForm.errors));
 const isKillmail = computed(() => alertForm.type === 'killmail');
 const isJumpRange = computed(() => alertForm.type === 'jump_range');
-const selectedTarget = computed(() => findSolarsystem(alertForm.target_solarsystem_id));
-const selectedOrigin = computed(() => findSolarsystem(alertForm.origin_solarsystem_id));
 const formJumpRangeLy = computed(() => maxRangeLy(alertForm.ship_type, alertForm.jdc_level));
-
-const filteredSolarsystems = computed(() => {
-    const query = search.value.trim().toLowerCase();
-    if (!query) return [] as TStaticSolarsystem[];
-    return takeRanked(
-        solarsystems.value,
-        query,
-        MAX_SEARCH_RESULTS,
-        (solarsystem) => [solarsystem.name],
-        (solarsystem) => solarsystem.name,
-    );
-});
-
-const filteredOriginSolarsystems = computed(() => {
-    const query = originSearch.value.trim().toLowerCase();
-    if (!query) return [] as TStaticSolarsystem[];
-    return takeRanked(
-        solarsystems.value,
-        query,
-        MAX_SEARCH_RESULTS,
-        (solarsystem) => [solarsystem.name],
-        (solarsystem) => solarsystem.name,
-    );
-});
-
-const origin_search_sections = computed<TComboboxSection<TStaticSolarsystem>[]>(() => [
-    { key: 'results', heading: 'Search Results', items: filteredOriginSolarsystems.value },
-]);
-
-const search_sections = computed<TComboboxSection<TStaticSolarsystem>[]>(() => [
-    { key: 'results', heading: 'Search Results', items: filteredSolarsystems.value },
-]);
 
 const canSubmitAlert = computed(
     () =>
@@ -282,23 +242,9 @@ const canSubmitAlert = computed(
         (!isKillmail.value || alertForm.filters.every((filter) => filter.ids.length > 0)),
 );
 
-watch(search, (value) => {
-    if (selectedTarget.value && value.trim() !== selectedTarget.value.name) {
-        alertForm.target_solarsystem_id = 0;
-    }
-});
-
-watch(originSearch, (value) => {
-    if (selectedOrigin.value && value.trim() !== selectedOrigin.value.name) {
-        alertForm.origin_solarsystem_id = 0;
-    }
-});
-
 function openCreateAlert() {
     alertForm.clearErrors();
     Object.assign(alertForm, emptyAlertForm());
-    search.value = '';
-    originSearch.value = '';
     alertDialogTab.value = 'trigger';
     alertDialogOpen.value = true;
 }
@@ -320,20 +266,8 @@ function openEditAlert(alert: TMapAlert) {
         filters: alert.filters.map((filter) => ({ ...filter, ids: [...filter.ids] })),
         is_active: alert.is_active,
     });
-    search.value = findSolarsystem(alert.target_solarsystem_id)?.name ?? '';
-    originSearch.value = findSolarsystem(alert.origin_solarsystem_id)?.name ?? '';
     alertDialogTab.value = 'trigger';
     alertDialogOpen.value = true;
-}
-
-function handleTargetSelect(solarsystem: TStaticSolarsystem) {
-    alertForm.target_solarsystem_id = solarsystem.id;
-    search.value = solarsystem.name;
-}
-
-function handleOriginSelect(solarsystem: TStaticSolarsystem) {
-    alertForm.origin_solarsystem_id = solarsystem.id;
-    originSearch.value = solarsystem.name;
 }
 
 function submitAlert() {
@@ -877,16 +811,7 @@ function confirmPendingDelete() {
                         <div v-if="!isKillmail" class="grid gap-4 sm:grid-cols-2">
                             <div class="space-y-1.5">
                                 <Label for="alert-target-system">Target system</Label>
-                                <div v-if="selectedTarget" class="flex items-center gap-2 text-sm">
-                                    <SolarsystemClass :solarsystem_class="selectedTarget.class" :name="selectedTarget.name" />
-                                    <span class="font-medium">{{ selectedTarget.name }}</span>
-                                </div>
-                                <Combobox class="rounded-lg border bg-neutral-900" :ignore-filter="true">
-                                    <ComboboxAnchor>
-                                        <ComboboxInput id="alert-target-system" v-model="search" placeholder="Search for a system…" />
-                                    </ComboboxAnchor>
-                                    <VirtualizedSolarsystemList align="start" :sections="search_sections" @select="handleTargetSelect" />
-                                </Combobox>
+                                <SolarsystemPicker input-id="alert-target-system" v-model="alertForm.target_solarsystem_id" />
                                 <p v-if="isJumpRange" class="text-xs text-muted-foreground">
                                     Jump range is measured between this system and new exits on the map.
                                 </p>
@@ -900,16 +825,11 @@ function confirmPendingDelete() {
 
                         <div v-if="!isKillmail && !isJumpRange" class="space-y-1.5">
                             <Label for="alert-origin-system">Starting point (optional)</Label>
-                            <div v-if="selectedOrigin" class="flex items-center gap-2 text-sm">
-                                <SolarsystemClass :solarsystem_class="selectedOrigin.class" :name="selectedOrigin.name" />
-                                <span class="font-medium">{{ selectedOrigin.name }}</span>
-                            </div>
-                            <Combobox class="rounded-lg border bg-neutral-900" :ignore-filter="true">
-                                <ComboboxAnchor>
-                                    <ComboboxInput id="alert-origin-system" v-model="originSearch" placeholder="Anywhere on the chain" />
-                                </ComboboxAnchor>
-                                <VirtualizedSolarsystemList align="start" :sections="origin_search_sections" @select="handleOriginSelect" />
-                            </Combobox>
+                            <SolarsystemPicker
+                                input-id="alert-origin-system"
+                                v-model="alertForm.origin_solarsystem_id"
+                                placeholder="Anywhere on the chain"
+                            />
                             <p class="text-xs text-muted-foreground">
                                 Measure from this system through the chain instead of from each newly added system.
                             </p>


### PR DESCRIPTION
Fixes the alert form clearing the target system when the search list is closed by clicking away.

- reka-ui resets an unbound combobox's search term on close, which emptied the query and tripped the "user edited the query" branch that drops the selection
- Extracts the input + list + selection into a reusable `SolarsystemPicker`, used for both the target system and the starting point
- The picker keeps the query in sync with selections set from outside the component (edit dialog, form reset, late static data)