### PR TITLE
Fix error 500 related to inexistant $user->email accessed by Pail

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use Carbon\CarbonImmutable;
 use Database\Factories\UserFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -21,6 +22,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property int $id
  * @property string $name
  * @property int|null $preferred_character_id
+ * @property-read string|null $email
  * @property Character|null $active_character
  * @property-read Character|null $preferredCharacter
  * @property-read Collection<int,Character> $characters
@@ -139,6 +141,19 @@ final class User extends Authenticatable
     public function mapUserSettings(): HasMany
     {
         return $this->hasMany(MapUserSetting::class, 'user_id');
+    }
+
+    /**
+     * Users authenticate via EVE Online SSO and have no email address.
+     *
+     * Provided so tooling that reads `email` (e.g. Nightwatch, Pail) does not
+     * trip `Model::preventAccessingMissingAttributes()` under strict mode.
+     *
+     * @return Attribute<null, never>
+     */
+    protected function email(): Attribute
+    {
+        return Attribute::get(fn (): ?string => null);
     }
 
     /**

--- a/tests/Feature/Models/UserEmailAttributeTest.php
+++ b/tests/Feature/Models/UserEmailAttributeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+it('exposes a null email without tripping strict missing-attribute protection', function () {
+    $user = User::factory()->create();
+
+    // Retrieved (not recently created) so strict mode would throw on a truly
+    // missing attribute - this is the state tooling reads the user in.
+    $retrieved = User::query()->findOrFail($user->id);
+
+    expect($retrieved->email)->toBeNull();
+});
+
+it('lets authenticated-user tooling read email during a request', function () {
+    $user = User::factory()->create();
+
+    Auth::login(User::query()->findOrFail($user->id));
+
+    expect(Auth::user())->toBeInstanceOf(User::class)
+        ->and(Auth::user()->email)->toBeNull();
+});


### PR DESCRIPTION
# Problem summary

On some occasions, logging during or after a SSO callback generate an exception under strict mode which materialize as an HTTP 500 blank page for users.

This bug was only reproduced in a local development environment, shadowing an underlying exception, but is still annoying to debug and deal with.

# Root cause

1. Characters authenticate through EVE Online SSO, which does not return any email address. Thus, the model in `App\Models\User` has no `email` either.
2. The application calls `Model::shouldBeStrict()` in `AppServiceProvider`, which enables `preventAccessingMissingAttributes()`. Under that setting, reading an attribute that isn't there throws `MissingAttributeException` instead of returning `null`.
3. Two loggers actually call `$user->email`. If a log is issued with a user, the call throws an exception.

## 1. Horizon - project code, production dependency

`app/Providers/HorizonServiceProvider.php:32` defines the `viewHorizon` gate as `in_array(optional($user)->email, [])`. `laravel/horizon` is in `require`, so this ships to production, and the gate runs for any authenticated user hitting a Horizon route.

This is Laravel's default published stub, left with an empty allowlist and is probably worth a proper fix.

## 2. Pail - vendor code, dev dependency

`vendor/laravel/pail/src/Handler.php:105` does a bare `Auth::user()->email` while building log context, and `PailServiceProvider` registers its `MessageLogged` listener in every environment except unit tests and Vapor — not only while `php artisan pail` is running.

This produced several bugs during EVE SSO callback with this calls tack:
```
EveController->store()                    app/Http/Controllers/EveController.php:31
  EsiAuthService->getUser()               app/Services/EsiAuthService.php:54
    UpdateAffiliations::dispatchSync()
      UpdateAffiliations->updateCorporation()   app/Jobs/UpdateAffiliations.php:102
         Log::info('Updated corporation with ID 98253255')
             PailServiceProvider.php:51 -> Handler->log()
               Handler.php:59           -> Handler->context()
                 Handler.php:105        -> Auth::user()->email
                   MissingAttributeException -> HTTP 500
```

As far as I understand, `laravel/pail` is only used in the local dev environment (it is a `require-dev` dependency). So it does not cause any issue in production (this is also probably why it did not surface earlier).

## Nightwatch - not an issue

Nightwatch is another logger, but it reads `$user->email ?? ''`, and `??` routes through `Model::offsetExists()`, which disables the strict check inside a `try`/`finally` (`Model.php:2713-2725`), so it cannot throw.

# Fix applied

Unfortunately, I did not find an **easy** way to customize of configure Pail to not read the email.
- Thus, this PR instead add an `email()` accessor on `App\Models\User` returning `null`, so these reads resolve instead of throwing.
- `@property-read string|null $email` is added to the model docblock so static analysis and IDEs agree with runtime.
- A test case was also added.

The accessor is deliberately read-only (`Attribute::get`, typed `Attribute<null, never>`): `email` is not a real attribute and must not become settable.

# Potential alternatives:

- **Fix `HorizonServiceProvider.php:32` directly** — narrower, and the allowlist is empty so the gate returns `false` regardless of what `email` evaluates to. Handles the production case only, leaving Pail throwing in local development.
- **Override Pail's handler** — mechanically possible (`Handler` isn't `final`, `context()` is `protected`, and it is bound as a container singleton), but it means copying ~40 lines of vendor internals into the app and re-syncing them on every Pail release, to patch a dev-only tool. Pail exposes no configuration for this: it ships no config file and has no user-details resolver hook, unlike Nightwatch's `userDetailsResolverResolver`.