### PR TITLE
Add "Unknown" option to wormhole type selector

### DIFF
--- a/app/Actions/Signatures/UpdateSignatureAction.php
+++ b/app/Actions/Signatures/UpdateSignatureAction.php
@@ -27,9 +27,9 @@ final readonly class UpdateSignatureAction
         return DB::transaction(function () use ($signature, $data): Signature {
             $updateData = $data->toArray();
 
-            // Update wormhole_id if signature_type_id changed
-            if (! $data->signature_type_id instanceof Optional && $data->signature_type_id) {
-                $signatureType = SignatureType::query()->find($data->signature_type_id);
+            // Update wormhole_id if signature_type_id changed, resetting it when cleared
+            if (! $data->signature_type_id instanceof Optional) {
+                $signatureType = $data->signature_type_id ? SignatureType::query()->find($data->signature_type_id) : null;
                 $updateData['wormhole_id'] = $signatureType?->wormhole?->id;
             }
 

--- a/resources/js/components/signatures/WormholeTypeInput.vue
+++ b/resources/js/components/signatures/WormholeTypeInput.vue
@@ -60,6 +60,8 @@ function filterByCurrentClass(option: TSignatureType) {
         </SelectTrigger>
         <SelectContent class="max-h-72">
             <template v-if="open">
+                <SelectItem :value="null" class="text-xs text-muted-foreground">Unknown</SelectItem>
+                <SelectSeparator />
                 <template v-if="statics.length">
                     <SelectGroup>
                         <SelectLabel class="text-xs text-muted-foreground">Statics</SelectLabel>

--- a/tests/Browser/Concerns/InteractsWithMap.php
+++ b/tests/Browser/Concerns/InteractsWithMap.php
@@ -57,9 +57,11 @@ trait InteractsWithMap
      * Perform a custom pointer drag from $source to $target.
      *
      * The map uses custom pointer events (not native HTML drag-and-drop). The browser driver's
-     * drag performs the real press + move (rendering any live preview) but swallows the release
-     * the interaction listens for, so the matching pointerup over the target is delivered to
-     * finalise it. Pass $reveal to hover a parent first when the source only appears on hover.
+     * drag performs the real press + move (rendering any live preview) but can swallow the
+     * release the interaction listens for, so the matching pointerup over the target is
+     * delivered to finalise it. The gesture arbiter ignores a release whose pointerId differs
+     * from the press it recorded, so the fallback replays the pointerId of the real press.
+     * Pass $reveal to hover a parent first when the source only appears on hover.
      *
      * @param  string|null  $reveal  CSS selector to hover before dragging (e.g. to reveal a hover-only handle)
      */
@@ -69,22 +71,47 @@ trait InteractsWithMap
             $page->hover($reveal);
         }
 
-        return $page
-            ->drag($source, $target)
-            ->script(sprintf(
-                <<<'JS'
-                const target = document.querySelector(%s);
-                if (target) {
-                    const rect = target.getBoundingClientRect();
-                    target.dispatchEvent(new PointerEvent('pointerup', {
-                        bubbles: true,
-                        clientX: rect.left + rect.width / 2,
-                        clientY: rect.top + rect.height / 2,
-                    }));
-                }
-                JS,
-                json_encode($target),
-            ));
+        $page->script(<<<'JS'
+            window.__lastPointerId = null;
+            window.addEventListener('pointerdown', (event) => { window.__lastPointerId = event.pointerId; }, true);
+        JS);
+
+        $page->drag($source, $target);
+
+        $page->script(sprintf(
+            <<<'JS'
+            const target = document.querySelector(%s);
+            if (target) {
+                const rect = target.getBoundingClientRect();
+                target.dispatchEvent(new PointerEvent('pointerup', {
+                    bubbles: true,
+                    pointerId: window.__lastPointerId ?? 1,
+                    pointerType: 'mouse',
+                    clientX: rect.left + rect.width / 2,
+                    clientY: rect.top + rect.height / 2,
+                }));
+            }
+            JS,
+            json_encode($target),
+        ));
+
+        return $page;
+    }
+
+    /**
+     * Wait for an asynchronous request to land in the database.
+     *
+     * The application is served in-process, on the same event loop that drives the browser
+     * client, so a blocking sleep here starves the server and the pending request is never
+     * handled at all. Yielding through the page's own wait() keeps the loop turning.
+     */
+    protected function waitForDatabase(mixed $page, callable $condition, float $seconds = 5): void
+    {
+        $deadline = microtime(true) + $seconds;
+
+        while (! $condition() && microtime(true) < $deadline) {
+            $page->wait(0.1);
+        }
     }
 
     /**

--- a/tests/Browser/MapInteractionsTest.php
+++ b/tests/Browser/MapInteractionsTest.php
@@ -75,13 +75,10 @@ it('draws a connection between two systems from the connection handle', function
 
     expect(MapConnection::where('map_id', $map->id)->count())->toBe(0);
 
-    $this->connectSystems(visit(route('maps.show', $map)), JITA, AMARR);
+    $page = $this->connectSystems(visit(route('maps.show', $map)), JITA, AMARR);
 
     // The connection is persisted via an async POST; wait briefly for it to land.
-    $deadline = microtime(true) + 5;
-    while (MapConnection::where('map_id', $map->id)->count() === 0 && microtime(true) < $deadline) {
-        usleep(100_000);
-    }
+    $this->waitForDatabase($page, fn (): bool => MapConnection::where('map_id', $map->id)->count() > 0);
 
     expect(MapConnection::where('map_id', $map->id)->count())->toBe(1);
 });
@@ -122,10 +119,7 @@ it('round-trips alias and occupier through the alias editor', function () {
         ->click('Save');
 
     // The update is persisted via an async PUT; wait briefly for it to land.
-    $deadline = microtime(true) + 5;
-    while ($system->fresh()->alias === null && microtime(true) < $deadline) {
-        usleep(100_000);
-    }
+    $this->waitForDatabase($page, fn (): bool => $system->fresh()->alias !== null);
 
     $system = $system->fresh()->loadMissing('details');
     expect($system->alias)->toBe('HOME')

--- a/tests/Feature/Actions/SignatureActionsTest.php
+++ b/tests/Feature/Actions/SignatureActionsTest.php
@@ -10,8 +10,11 @@ use App\Actions\Signatures\UpdateSignatureAction;
 use App\Data\NewSignatureData;
 use App\Data\SignatureData;
 use App\Data\SignaturesData;
+use App\Enums\WormholeSignature;
 use App\Models\Map;
 use App\Models\Signature;
+use App\Models\SignatureType;
+use App\Models\Wormhole;
 
 it('stores a signature on a system', function () {
     $map = Map::factory()->create();
@@ -31,6 +34,30 @@ it('updates a signature', function () {
     app(UpdateSignatureAction::class)->handle($signature, SignatureData::from(['signature_id' => 'XYZ-999']));
 
     expect($signature->fresh()->signature_id)->toBe('XYZ-999');
+});
+
+it('resets the wormhole_id when the signature type is cleared to unknown', function () {
+    $map = Map::factory()->create();
+    $system = placeMapSolarsystem($map, 30011016);
+    $wormhole = Wormhole::create([
+        'name' => WormholeSignature::X877->value,
+        'total_mass' => 3_300_000_000,
+        'maximum_jump_mass' => 375_000_000,
+        'maximum_lifetime' => 86_400,
+        'leads_to' => 'c4',
+    ]);
+    $signature_type = SignatureType::query()->where('signature', WormholeSignature::X877)->firstOrFail();
+    $signature = $system->signatures()->create([
+        'signature_id' => 'ABC-123',
+        'signature_type_id' => $signature_type->id,
+        'wormhole_id' => $wormhole->id,
+    ]);
+
+    app(UpdateSignatureAction::class)->handle($signature, SignatureData::from(['signature_type_id' => null]));
+
+    expect($signature->fresh())
+        ->signature_type_id->toBeNull()
+        ->wormhole_id->toBeNull();
 });
 
 it('deletes a signature', function () {


### PR DESCRIPTION
Adds a pinned "Unknown" sentinel entry to the wormhole type combobox so a signature can be marked as a wormhole without committing to a specific type code. This is especially useful if you updated the wrong signature - before, there was no way to "reset" a type without deleting the whole line.
- Selecting the "unknown" entry doesn't add a new `SignatureType` row - it just resets `signature_type_id` back to null.
- Also updated `UpdateSignatureAction` so clearing `signature_type_id` also resets `wormhole_id` instead of leaving the stale wormhole association in place.