### PR TITLE
fix(signatures): add Factional Warfare Site category and recognize it when pasting

### DIFF
--- a/app/Enums/SignatureCategory.php
+++ b/app/Enums/SignatureCategory.php
@@ -13,6 +13,7 @@ enum SignatureCategory: string
     case Gas = 'gas';
     case Ore = 'ore';
     case Homefront = 'homefront';
+    case FactionWarfare = 'faction-warfare';
 
     public function name(): string
     {
@@ -24,6 +25,7 @@ enum SignatureCategory: string
             self::Gas => 'Gas Site',
             self::Ore => 'Ore Site',
             self::Homefront => 'Homefront Operations',
+            self::FactionWarfare => 'Factional Warfare Site',
         };
     }
 }

--- a/database/migrations/2026_08_08_111403_add_faction_warfare_signature_category.php
+++ b/database/migrations/2026_08_08_111403_add_faction_warfare_signature_category.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SignatureCategory as SignatureCategoryEnum;
+use App\Models\SignatureCategory;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * The id is pinned to 8 so it matches resources/js/data/signatures.json,
+     * which the frontend uses to resolve category ids when parsing pastes.
+     */
+    public function up(): void
+    {
+        $category = SignatureCategoryEnum::FactionWarfare;
+
+        SignatureCategory::firstOrCreate([
+            'code' => $category->value,
+        ], [
+            'id' => 8,
+            'name' => $category->name(),
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        SignatureCategory::where('code', SignatureCategoryEnum::FactionWarfare->value)->delete();
+    }
+};

--- a/resources/js/components/landing/fixtures.ts
+++ b/resources/js/components/landing/fixtures.ts
@@ -453,6 +453,7 @@ const SIGNATURE_CATEGORIES: Record<string, { id: number; code: string }> = {
     'Gas Site': { id: 5, code: 'gas' },
     'Ore Site': { id: 6, code: 'ore' },
     'Homefront Operations': { id: 7, code: 'homefront' },
+    'Factional Warfare Site': { id: 8, code: 'faction-warfare' },
 };
 
 interface SignatureInput {

--- a/resources/js/components/signatures/Signature.vue
+++ b/resources/js/components/signatures/Signature.vue
@@ -27,7 +27,7 @@ import { TSignature } from '@/types/models';
 import { UTCDate } from '@date-fns/utc';
 import type { FormDataConvertible } from '@inertiajs/core';
 import { syncRefs } from '@vueuse/core';
-import { Check, Cloud, Database, Fan, Gem, Heart, Landmark, MoreVertical, Shield, Swords } from 'lucide-vue-next';
+import { Check, Cloud, Database, Fan, Flag, Gem, Heart, Landmark, MoreVertical, Shield, Swords } from 'lucide-vue-next';
 import { AcceptableValue } from 'reka-ui';
 import { type Component, computed, nextTick, ref, toRef } from 'vue';
 
@@ -100,6 +100,7 @@ const categoryAbbrev: Record<string, string> = {
     'Gas Site': 'Gas',
     'Combat Site': 'Combat',
     'Homefront Operations': 'HF',
+    'Factional Warfare Site': 'FW',
 };
 
 const categoryIcon: Record<string, Component> = {
@@ -110,6 +111,7 @@ const categoryIcon: Record<string, Component> = {
     'Gas Site': Cloud,
     'Combat Site': Swords,
     'Homefront Operations': Shield,
+    'Factional Warfare Site': Flag,
 };
 
 const categoryColor: Record<string, string> = {
@@ -120,6 +122,7 @@ const categoryColor: Record<string, string> = {
     'Gas Site': 'text-orange-400',
     'Ore Site': 'text-yellow-400',
     'Homefront Operations': 'text-rose-400',
+    'Factional Warfare Site': 'text-fuchsia-400',
 };
 
 function getCategoryAbbrev(name?: string | null): string {

--- a/resources/js/components/signatures/Signatures.vue
+++ b/resources/js/components/signatures/Signatures.vue
@@ -21,7 +21,7 @@ import usePermission from '@/composables/usePermission';
 import { createSignature, updateMapUserSettings } from '@/map/api';
 import type { TResolvedSelectedMapSolarsystem } from '@/pages/maps';
 import { useLocalStorage } from '@vueuse/core';
-import { ArrowDown, ArrowUp, CircleHelp, Cloud, Database, Fan, Gem, Landmark, Rows2, Rows3, Shield, Swords } from 'lucide-vue-next';
+import { ArrowDown, ArrowUp, CircleHelp, Cloud, Database, Fan, Flag, Gem, Landmark, Rows2, Rows3, Shield, Swords } from 'lucide-vue-next';
 import { type Component, computed } from 'vue';
 
 const props = defineProps<{
@@ -65,18 +65,25 @@ const categoryFilterOptions: Array<{ value: string; icon: Component; color: stri
     { value: 'Gas Site', icon: Cloud, color: 'text-orange-400', label: 'Gas Site' },
     { value: 'Combat Site', icon: Swords, color: 'text-green-400', label: 'Combat Site' },
     { value: 'Homefront Operations', icon: Shield, color: 'text-rose-400', label: 'Homefront Operations' },
+    { value: 'Factional Warfare Site', icon: Flag, color: 'text-fuchsia-400', label: 'Factional Warfare Site' },
     { value: UNCATEGORIZED_FILTER, icon: CircleHelp, color: 'text-muted-foreground', label: 'Uncategorized' },
 ];
 
-const activeCategoryFilters = useLocalStorage<string[]>(
-    'signatures-category-filters',
-    categoryFilterOptions.map((option) => option.value),
-);
+// Persist the hidden categories instead of the visible ones so categories added
+// in later releases default to visible for users with saved filters.
+const hiddenCategoryFilters = useLocalStorage<string[]>('signatures-category-hidden-filters', []);
+
+const activeCategoryFilters = computed<string[]>({
+    get: () => categoryFilterOptions.map((option) => option.value).filter((value) => !hiddenCategoryFilters.value.includes(value)),
+    set: (values) => {
+        hiddenCategoryFilters.value = categoryFilterOptions.map((option) => option.value).filter((value) => !values.includes(value));
+    },
+});
 
 const filteredSignatures = computed(() =>
     signatures.value.filter((signature) => {
         const key = signature.signature_category?.name ?? UNCATEGORIZED_FILTER;
-        return activeCategoryFilters.value.includes(key);
+        return !hiddenCategoryFilters.value.includes(key);
     }),
 );
 

--- a/resources/js/components/signatures/SignaturesView.vue
+++ b/resources/js/components/signatures/SignaturesView.vue
@@ -4,7 +4,7 @@ import WormholeOption from '@/components/signatures/WormholeOption.vue';
 import SolarsystemClass from '@/components/solarsystem/SolarsystemClass.vue';
 import type { TProcessedConnection } from '@/map/api';
 import { TSignature } from '@/types/models';
-import { Cloud, Database, Fan, Gem, Landmark, Shield, Swords } from 'lucide-vue-next';
+import { Cloud, Database, Fan, Flag, Gem, Landmark, Shield, Swords } from 'lucide-vue-next';
 import { type Component, computed } from 'vue';
 
 const { signatures, connections = [] } = defineProps<{
@@ -20,6 +20,7 @@ const categoryAbbrev: Record<string, string> = {
     'Gas Site': 'Gas',
     'Combat Site': 'Combat',
     'Homefront Operations': 'HF',
+    'Factional Warfare Site': 'FW',
 };
 
 const categoryIcon: Record<string, Component> = {
@@ -30,6 +31,7 @@ const categoryIcon: Record<string, Component> = {
     'Gas Site': Cloud,
     'Combat Site': Swords,
     'Homefront Operations': Shield,
+    'Factional Warfare Site': Flag,
 };
 
 const categoryColor: Record<string, string> = {
@@ -40,6 +42,7 @@ const categoryColor: Record<string, string> = {
     'Gas Site': 'text-orange-400',
     'Ore Site': 'text-yellow-400',
     'Homefront Operations': 'text-rose-400',
+    'Factional Warfare Site': 'text-fuchsia-400',
 };
 
 function categoryName(signature: TSignature): string {

--- a/resources/js/data/signatures.json
+++ b/resources/js/data/signatures.json
@@ -35,6 +35,11 @@
             "id": 7,
             "name": "Homefront Operations",
             "code": "homefront"
+        },
+        {
+            "id": 8,
+            "name": "Factional Warfare Site",
+            "code": "faction-warfare"
         }
     ],
     "types": [

--- a/resources/js/lib/SignatureParser.spec.ts
+++ b/resources/js/lib/SignatureParser.spec.ts
@@ -1,0 +1,85 @@
+import { signatureCategories, signatureTypes } from '@/const/signatures';
+import { signatureParser } from '@/lib/SignatureParser';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vue-sonner', () => ({ toast: { error: vi.fn() } }));
+
+const factionWarfare = signatureCategories.find((cat) => cat.name === 'Factional Warfare Site')!;
+const gas = signatureCategories.find((cat) => cat.name === 'Gas Site')!;
+const ore = signatureCategories.find((cat) => cat.name === 'Ore Site')!;
+
+describe('parseSignatures', () => {
+    it('parses a signature with a known category and type', () => {
+        const type = signatureTypes.find((t) => t.signature_category_id === gas.id)!;
+        const line = `ABC-123\tCosmic Signature\tGas Site\t${type.name}\t100,0%\t5,03 AU`;
+
+        const [parsed] = signatureParser.parseSignatures(line);
+
+        expect(parsed).toMatchObject({
+            signature_id: 'ABC-123',
+            signature_category_id: gas.id,
+            signature_type_id: type.id,
+            raw_type_name: null,
+        });
+    });
+
+    it('parses faction warfare sites with the raw type name', () => {
+        const line = 'BUH-704\tCosmic Anomaly\tFactional Warfare Site - Combat Site\tMinmatar Large NVY-1\t100,0%\t13,83 AU';
+
+        const [parsed] = signatureParser.parseSignatures(line);
+
+        expect(parsed).toMatchObject({
+            signature_id: 'BUH-704',
+            signature_category_id: factionWarfare.id,
+            signature_type_id: null,
+            raw_type_name: 'Minmatar Large NVY-1',
+        });
+    });
+
+    it('parses a real scan window paste with faction warfare, ore, and unscanned rows', () => {
+        const paste = [
+            'BBL-893\tCosmic Anomaly\tFactional Warfare Site - Combat Site\tAmarr Scout BSC-1\t100,0%\t6,84 AU',
+            'CBA-620\tCosmic Anomaly\tOre Site\tGlacial Mass Belt\t100,0%\t7,02 AU',
+            'DXA-556\tCosmic Signature\t\t\t0,0%\t6,51 AU',
+            'MSA-264\tCosmic Anomaly\tFactional Warfare Site - Combat Site\tAmarr Moderate NVY-3\t100,0%\t60,60 AU',
+        ].join('\n');
+
+        const parsed = signatureParser.parseSignatures(paste);
+
+        expect(parsed).toHaveLength(4);
+        expect(parsed[0]).toMatchObject({
+            signature_id: 'BBL-893',
+            signature_category_id: factionWarfare.id,
+            raw_type_name: 'Amarr Scout BSC-1',
+        });
+        expect(parsed[1]).toMatchObject({
+            signature_id: 'CBA-620',
+            signature_category_id: ore.id,
+            raw_type_name: 'Glacial Mass Belt',
+        });
+        expect(parsed[2]).toMatchObject({
+            signature_id: 'DXA-556',
+            signature_category_id: null,
+            signature_type_id: null,
+            raw_type_name: null,
+        });
+        expect(parsed[3]).toMatchObject({
+            signature_id: 'MSA-264',
+            signature_category_id: factionWarfare.id,
+            raw_type_name: 'Amarr Moderate NVY-3',
+        });
+    });
+
+    it('leaves unknown categories uncategorised', () => {
+        const line = 'XYZ-999\tCosmic Signature\tSomething Unheard Of\tMystery Site\t12,5%\t1,00 AU';
+
+        const [parsed] = signatureParser.parseSignatures(line);
+
+        expect(parsed).toMatchObject({
+            signature_id: 'XYZ-999',
+            signature_category_id: null,
+            signature_type_id: null,
+            raw_type_name: null,
+        });
+    });
+});

--- a/resources/js/lib/SignatureParser.ts
+++ b/resources/js/lib/SignatureParser.ts
@@ -54,7 +54,20 @@ class SignatureParser {
     }
 
     getCategory(categoryName: string): TSignatureCategory | null {
-        return signatureCategories.find((cat) => cat.name === categoryName) || null;
+        const name = categoryName?.trim();
+        const exact = signatureCategories.find((cat) => cat.name === name);
+        if (exact) {
+            return exact;
+        }
+
+        // Faction Warfare sites paste as e.g. "Factional Warfare Site - Combat Site",
+        // so fall back to matching a known category in any " - " separated segment.
+        return (
+            name
+                ?.split(' - ')
+                .map((segment) => signatureCategories.find((cat) => cat.name === segment.trim()))
+                .find(Boolean) || null
+        );
     }
 
     getType(category: TSignatureCategory | null, typeName: string): TSignatureType | null {


### PR DESCRIPTION
Adds a dedicated "Factional Warfare Site" signature category and teaches the paste parser to resolve it, so FW anomalies no longer come through unrecognized.

- New category (id 8, code faction-warfare) in signatures.json, the enum, and a homefront-style migration with the id pinned to match the JSON.
- The parser falls back to matching category names in " - " separated segments, so "Factional Warfare Site - Combat Site" resolves. Site names like "Amarr Scout BSC-1" are kept as the raw type name.
- FW entries in the abbrev/icon/color maps and the category filter.
- The category filter now persists hidden categories instead of visible ones, so categories added in future releases default to visible for users with saved filters.

Fixes #42