### PR TITLE
feat(signatures): add unknown option to the type and connection selectors

### DIFF
--- a/app/Actions/Signatures/UpdateSignatureAction.php
+++ b/app/Actions/Signatures/UpdateSignatureAction.php
@@ -31,9 +31,9 @@ final readonly class UpdateSignatureAction
         return DB::transaction(function () use ($signature, $data): Signature {
             $updateData = $data->toArray();
 
-            // Update wormhole_id if signature_type_id changed
-            if (! $data->signature_type_id instanceof Optional && $data->signature_type_id) {
-                $signatureType = SignatureType::query()->find($data->signature_type_id);
+            // Update wormhole_id if signature_type_id changed, resetting it when cleared
+            if (! $data->signature_type_id instanceof Optional) {
+                $signatureType = $data->signature_type_id ? SignatureType::query()->find($data->signature_type_id) : null;
                 $updateData['wormhole_id'] = $signatureType?->wormhole?->id;
             }
 

--- a/resources/js/components/signatures/MapConnectionInput.vue
+++ b/resources/js/components/signatures/MapConnectionInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ConnectionOption from '@/components/signatures/ConnectionOption.vue';
+import UnknownTypeOption from '@/components/signatures/UnknownTypeOption.vue';
 import SolarsystemClass from '@/components/solarsystem/SolarsystemClass.vue';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useMapUserSettings } from '@/composables/useMapUserSettings';
@@ -63,7 +64,9 @@ function isNotFilterable(type: TSignatureType | null | undefined): type is null 
         </SelectTrigger>
         <SelectContent class="max-h-72">
             <template v-if="open">
-                <SelectItem :value="null" text-value="Unknown" class="text-xs"> Unknown </SelectItem>
+                <SelectItem :value="null" text-value="Unknown" class="text-xs">
+                    <UnknownTypeOption />
+                </SelectItem>
                 <SelectGroup v-if="filtered_unconnected_connections.length > 0">
                     <SelectSeparator />
                     <SelectLabel class="text-xs text-muted-foreground">Connections</SelectLabel>

--- a/resources/js/components/signatures/SignatureTypeInput.spec.ts
+++ b/resources/js/components/signatures/SignatureTypeInput.spec.ts
@@ -72,12 +72,31 @@ describe('SignatureTypeInput', () => {
         const wrapper = mountInput();
         await openPopup(wrapper);
 
-        const option = document.body.querySelector('[role="option"]') as HTMLElement;
+        // The first option is the pinned "Unknown" reset row, so pick the next one.
+        const option = document.body.querySelectorAll('[role="option"]')[1] as HTMLElement;
         option.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
         option.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         await flushVirtualizer();
 
-        expect(wrapper.emitted('update:modelValue')).toBeTruthy();
+        const emitted = wrapper.emitted('update:modelValue');
+        expect(emitted).toBeTruthy();
+        expect(types.map((type) => type.id)).toContain(emitted![0][0]);
+    });
+
+    it('resets the model through the pinned unknown row', async () => {
+        const wrapper = mountInput({ modelValue: 5 });
+        await openPopup(wrapper);
+
+        const option = document.body.querySelector('[role="option"]') as HTMLElement;
+        expect(option.textContent).toContain('Unknown');
+
+        option.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+        option.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flushVirtualizer();
+
+        const emitted = wrapper.emitted('update:modelValue');
+        expect(emitted).toBeTruthy();
+        expect(emitted![0][0]).toBeNull();
     });
 
     it('is disabled without a category', async () => {

--- a/resources/js/components/signatures/SignatureTypeInput.vue
+++ b/resources/js/components/signatures/SignatureTypeInput.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import UnknownTypeOption from '@/components/signatures/UnknownTypeOption.vue';
 import { Combobox, ComboboxAnchor, ComboboxInput, ComboboxItem, ComboboxTrigger, ComboboxVirtualList } from '@/components/ui/combobox';
 import { useMapUserSettings } from '@/composables/useMapUserSettings';
 import { getTypeById } from '@/const/signatures';
+import { comboboxRowText, flattenComboboxSections, type TComboboxRow } from '@/lib/comboboxSections';
 import { TSignatureType } from '@/types/models';
 import { computed, ref, watch } from 'vue';
 
@@ -29,12 +31,15 @@ watch(open, (isOpen) => {
     }
 });
 
-const filtered_options = computed<TSignatureType[]>(() => {
+// A pinned null row lets a signature be reset to an unknown type.
+const rows = computed<TComboboxRow<TSignatureType | null>[]>(() => {
     const needle = search.value.trim().toLowerCase();
-    if (needle === '') {
-        return options;
-    }
-    return options.filter((option) => option.name.toLowerCase().includes(needle));
+    const matched = needle === '' ? options : options.filter((option) => option.name.toLowerCase().includes(needle));
+
+    return flattenComboboxSections<TSignatureType | null>([
+        { key: 'unknown', heading: '', items: needle === '' || 'unknown'.includes(needle) ? [null] : [] },
+        { key: 'types', heading: '', items: matched },
+    ]);
 });
 
 const selected_option = computed(() => {
@@ -42,13 +47,16 @@ const selected_option = computed(() => {
     return options.find((option) => option.id === model.value) ?? getTypeById(model.value) ?? null;
 });
 
-function handleSelect(option: TSignatureType) {
-    model.value = option.id;
+function handleSelect(row: TComboboxRow<TSignatureType | null>) {
+    if (row.kind !== 'option') {
+        return;
+    }
+    model.value = row.value?.id ?? null;
     open.value = false;
 }
 
-function optionName(option: TSignatureType): string {
-    return option.name;
+function rowText(row: TComboboxRow<TSignatureType | null>): string {
+    return comboboxRowText(row, (option) => option?.name ?? 'Unknown');
 }
 </script>
 
@@ -61,13 +69,14 @@ function optionName(option: TSignatureType): string {
                 <span v-else class="truncate text-muted-foreground">Type</span>
             </ComboboxTrigger>
         </ComboboxAnchor>
-        <ComboboxVirtualList :options="filtered_options" :text-content="optionName" empty-text="Unknown" class="min-w-44">
+        <ComboboxVirtualList :options="rows" :text-content="rowText" empty-text="No types found" class="min-w-44">
             <template #header>
                 <ComboboxInput v-model="search" placeholder="Search types" class="h-8 border-b text-xs" auto-focus />
             </template>
             <template #default="{ option }">
-                <ComboboxItem :value="option" class="text-xs" @select.prevent="() => handleSelect(option)">
-                    <span class="truncate">{{ option.name }}</span>
+                <ComboboxItem v-if="option.kind === 'option'" :value="option" class="text-xs" @select.prevent="() => handleSelect(option)">
+                    <UnknownTypeOption v-if="option.value === null" />
+                    <span v-else class="truncate">{{ option.value.name }}</span>
                 </ComboboxItem>
             </template>
         </ComboboxVirtualList>

--- a/resources/js/components/signatures/UnknownTypeOption.vue
+++ b/resources/js/components/signatures/UnknownTypeOption.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { CircleHelp } from 'lucide-vue-next';
+</script>
+
+<template>
+    <span class="flex items-center gap-1.5 text-muted-foreground">
+        <CircleHelp class="size-3" />
+        Unknown
+    </span>
+</template>

--- a/resources/js/components/signatures/WormholeTypeInput.spec.ts
+++ b/resources/js/components/signatures/WormholeTypeInput.spec.ts
@@ -76,7 +76,8 @@ describe('WormholeTypeInput', () => {
         const wrapper = mountInput();
         await openPopup(wrapper);
 
-        const option = document.body.querySelector('[role="option"]') as HTMLElement;
+        // The first option is the pinned "Unknown" reset row, so pick the next one.
+        const option = document.body.querySelectorAll('[role="option"]')[1] as HTMLElement;
         option.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
         option.dispatchEvent(new MouseEvent('click', { bubbles: true }));
         await flushVirtualizer();
@@ -84,6 +85,22 @@ describe('WormholeTypeInput', () => {
         const emitted = wrapper.emitted('update:modelValue');
         expect(emitted).toBeTruthy();
         expect(types.map((type) => type.id)).toContain(emitted![0][0]);
+    });
+
+    it('resets the model through the pinned unknown row', async () => {
+        const wrapper = mountInput({ modelValue: 3 });
+        await openPopup(wrapper);
+
+        const option = document.body.querySelector('[role="option"]') as HTMLElement;
+        expect(option.textContent).toContain('Unknown');
+
+        option.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+        option.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await flushVirtualizer();
+
+        const emitted = wrapper.emitted('update:modelValue');
+        expect(emitted).toBeTruthy();
+        expect(emitted![0][0]).toBeNull();
     });
 
     it('shows the selected type on the trigger', async () => {

--- a/resources/js/components/signatures/WormholeTypeInput.vue
+++ b/resources/js/components/signatures/WormholeTypeInput.vue
@@ -49,12 +49,14 @@ const wormholes = computed<TSignatureType[]>(() => {
         .filter(filterByCurrentClass);
 });
 
-const rows = computed<TComboboxRow<TSignatureType>[]>(() => {
+// A pinned null row lets a wormhole signature be reset to an unknown type.
+const rows = computed<TComboboxRow<TSignatureType | null>[]>(() => {
     const needle = search.value.trim().toLowerCase();
     const matches = (option: TSignatureType) =>
         needle === '' || option.name.toLowerCase().includes(needle) || (option.extra ?? '').toLowerCase().includes(needle);
 
-    return flattenComboboxSections([
+    return flattenComboboxSections<TSignatureType | null>([
+        { key: 'unknown', heading: '', items: needle === '' || 'unknown'.includes(needle) ? [null] : [] },
         { key: 'statics', heading: 'Statics', items: statics.value.filter(matches) },
         { key: 'k162', heading: 'K162', items: k162_options.value.filter(matches) },
         { key: 'wormholes', heading: 'Wormholes', items: wormholes.value.filter(matches) },
@@ -65,16 +67,16 @@ const selected_signature = computed(() => {
     return wormhole_options.find((option: TSignatureType) => option.id === model.value) || null;
 });
 
-function handleSelect(row: TComboboxRow<TSignatureType>) {
+function handleSelect(row: TComboboxRow<TSignatureType | null>) {
     if (row.kind !== 'option') {
         return;
     }
-    model.value = row.value.id;
+    model.value = row.value?.id ?? null;
     open.value = false;
 }
 
-function rowText(row: TComboboxRow<TSignatureType>): string {
-    return comboboxRowText(row, (option) => option.name);
+function rowText(row: TComboboxRow<TSignatureType | null>): string {
+    return comboboxRowText(row, (option) => option?.name ?? 'Unknown');
 }
 
 function filterByCurrentClass(option: TSignatureType) {
@@ -101,7 +103,8 @@ function filterByCurrentClass(option: TSignatureType) {
                 <div class="w-full">
                     <div v-if="option.kind === 'heading'" class="px-2 py-1.5 text-xs text-muted-foreground">{{ option.label }}</div>
                     <ComboboxItem v-else :value="option" class="text-xs" @select.prevent="() => handleSelect(option)">
-                        <WormholeOption :wormhole="option.value" />
+                        <span v-if="option.value === null" class="text-muted-foreground">Unknown</span>
+                        <WormholeOption v-else :wormhole="option.value" />
                     </ComboboxItem>
                 </div>
             </template>

--- a/resources/js/components/signatures/WormholeTypeInput.vue
+++ b/resources/js/components/signatures/WormholeTypeInput.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import UnknownTypeOption from '@/components/signatures/UnknownTypeOption.vue';
 import WormholeOption from '@/components/signatures/WormholeOption.vue';
 import { Combobox, ComboboxAnchor, ComboboxInput, ComboboxItem, ComboboxTrigger, ComboboxVirtualList } from '@/components/ui/combobox';
 import { useMapUserSettings } from '@/composables/useMapUserSettings';
@@ -103,7 +104,7 @@ function filterByCurrentClass(option: TSignatureType) {
                 <div class="w-full">
                     <div v-if="option.kind === 'heading'" class="px-2 py-1.5 text-xs text-muted-foreground">{{ option.label }}</div>
                     <ComboboxItem v-else :value="option" class="text-xs" @select.prevent="() => handleSelect(option)">
-                        <span v-if="option.value === null" class="text-muted-foreground">Unknown</span>
+                        <UnknownTypeOption v-if="option.value === null" />
                         <WormholeOption v-else :wormhole="option.value" />
                     </ComboboxItem>
                 </div>

--- a/tests/Browser/Concerns/InteractsWithMap.php
+++ b/tests/Browser/Concerns/InteractsWithMap.php
@@ -57,9 +57,11 @@ trait InteractsWithMap
      * Perform a custom pointer drag from $source to $target.
      *
      * The map uses custom pointer events (not native HTML drag-and-drop). The browser driver's
-     * drag performs the real press + move (rendering any live preview) but swallows the release
-     * the interaction listens for, so the matching pointerup over the target is delivered to
-     * finalise it. Pass $reveal to hover a parent first when the source only appears on hover.
+     * drag performs the real press + move (rendering any live preview) but can swallow the
+     * release the interaction listens for, so the matching pointerup over the target is
+     * delivered to finalise it. The gesture arbiter ignores a release whose pointerId differs
+     * from the press it recorded, so the fallback replays the pointerId of the real press.
+     * Pass $reveal to hover a parent first when the source only appears on hover.
      *
      * @param  string|null  $reveal  CSS selector to hover before dragging (e.g. to reveal a hover-only handle)
      */
@@ -69,22 +71,47 @@ trait InteractsWithMap
             $page->hover($reveal);
         }
 
-        return $page
-            ->drag($source, $target)
-            ->script(sprintf(
-                <<<'JS'
-                const target = document.querySelector(%s);
-                if (target) {
-                    const rect = target.getBoundingClientRect();
-                    target.dispatchEvent(new PointerEvent('pointerup', {
-                        bubbles: true,
-                        clientX: rect.left + rect.width / 2,
-                        clientY: rect.top + rect.height / 2,
-                    }));
-                }
-                JS,
-                json_encode($target),
-            ));
+        $page->script(<<<'JS'
+            window.__lastPointerId = null;
+            window.addEventListener('pointerdown', (event) => { window.__lastPointerId = event.pointerId; }, true);
+        JS);
+
+        $page->drag($source, $target);
+
+        $page->script(sprintf(
+            <<<'JS'
+            const target = document.querySelector(%s);
+            if (target) {
+                const rect = target.getBoundingClientRect();
+                target.dispatchEvent(new PointerEvent('pointerup', {
+                    bubbles: true,
+                    pointerId: window.__lastPointerId ?? 1,
+                    pointerType: 'mouse',
+                    clientX: rect.left + rect.width / 2,
+                    clientY: rect.top + rect.height / 2,
+                }));
+            }
+            JS,
+            json_encode($target),
+        ));
+
+        return $page;
+    }
+
+    /**
+     * Wait for an asynchronous request to land in the database.
+     *
+     * The application is served in-process, on the same event loop that drives the browser
+     * client, so a blocking sleep here starves the server and the pending request is never
+     * handled at all. Yielding through the page's own wait() keeps the loop turning.
+     */
+    protected function waitForDatabase(mixed $page, callable $condition, float $seconds = 5): void
+    {
+        $deadline = microtime(true) + $seconds;
+
+        while (! $condition() && microtime(true) < $deadline) {
+            $page->wait(0.1);
+        }
     }
 
     /**

--- a/tests/Browser/MapInteractionsTest.php
+++ b/tests/Browser/MapInteractionsTest.php
@@ -96,10 +96,7 @@ it('draws a connection between two systems from the connection handle', function
 
         $this->connectSystems($page, JITA, AMARR);
 
-        $deadline = microtime(true) + 10;
-        while ($connectionCount() === 0 && microtime(true) < $deadline) {
-            usleep(100_000);
-        }
+        $this->waitForDatabase($page, fn (): bool => $connectionCount() > 0, 10);
 
         if ($connectionCount() > 0) {
             break;
@@ -145,10 +142,7 @@ it('round-trips alias and occupier through the alias editor', function () {
         ->click('Save');
 
     // The update is persisted via an async PUT; wait briefly for it to land.
-    $deadline = microtime(true) + 5;
-    while ($system->fresh()->alias === null && microtime(true) < $deadline) {
-        usleep(100_000);
-    }
+    $this->waitForDatabase($page, fn (): bool => $system->fresh()->alias !== null);
 
     $system = $system->fresh()->loadMissing('details');
     expect($system->alias)->toBe('HOME')

--- a/tests/Feature/Actions/SignatureActionsTest.php
+++ b/tests/Feature/Actions/SignatureActionsTest.php
@@ -11,9 +11,12 @@ use App\Data\NewSignatureData;
 use App\Data\SignatureData;
 use App\Data\SignaturesData;
 use App\Enums\ShipSize;
+use App\Enums\WormholeSignature;
 use App\Models\Map;
 use App\Models\MapConnection;
 use App\Models\Signature;
+use App\Models\SignatureType;
+use App\Models\Wormhole;
 
 it('stores a signature on a system', function () {
     $map = Map::factory()->create();
@@ -33,6 +36,30 @@ it('updates a signature', function () {
     app(UpdateSignatureAction::class)->handle($signature, SignatureData::from(['signature_id' => 'XYZ-999']));
 
     expect($signature->fresh()->signature_id)->toBe('XYZ-999');
+});
+
+it('resets the wormhole_id when the signature type is cleared to unknown', function () {
+    $map = Map::factory()->create();
+    $system = placeMapSolarsystem($map, 30011016);
+    $wormhole = Wormhole::create([
+        'name' => WormholeSignature::X877->value,
+        'total_mass' => 3_300_000_000,
+        'maximum_jump_mass' => 375_000_000,
+        'maximum_lifetime' => 86_400,
+        'leads_to' => 'c4',
+    ]);
+    $signature_type = SignatureType::query()->where('signature', WormholeSignature::X877)->firstOrFail();
+    $signature = $system->signatures()->create([
+        'signature_id' => 'ABC-123',
+        'signature_type_id' => $signature_type->id,
+        'wormhole_id' => $wormhole->id,
+    ]);
+
+    app(UpdateSignatureAction::class)->handle($signature, SignatureData::from(['signature_type_id' => null]));
+
+    expect($signature->fresh())
+        ->signature_type_id->toBeNull()
+        ->wormhole_id->toBeNull();
 });
 
 it('deletes a signature', function () {


### PR DESCRIPTION
Rebased and extended version of #39 by @Hiryus, whose commits carry over with their authorship.

- Adds a pinned "Unknown" entry to the wormhole type selector that resets signature_type_id, and clears the stale wormhole_id on the backend.
- Ported onto the virtualized combobox that replaced the old select on main.
- Unifies the unknown option across the wormhole type, signature type, and connection selectors, with a question mark icon so it reads as an option rather than a heading. The signature type selector previously had no way to clear a type at all.
- Browser test helpers from #39: pointerDrag replays the real pointerId, and waitForDatabase stops async-write waits from starving the in-process server.