### PR TITLE
feat(map): colorblind-friendly effect and status indicators

### DIFF
--- a/resources/js/components/map/SolarsystemEffect.vue
+++ b/resources/js/components/map/SolarsystemEffect.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import SolarsystemEffectBadge from '@/components/solarsystem/SolarsystemEffectBadge.vue';
 import { CardTitle } from '@/components/ui/card';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { TEffect } from '@/pages/maps';
+import { ArrowDown, ArrowUp } from 'lucide-vue-next';
 
 const { effect } = defineProps<{
     effect: TEffect;
@@ -13,24 +15,22 @@ const { effect } = defineProps<{
         <Popover>
             <PopoverTrigger class="pointer-events-auto" @drag.prevent>
                 <div class="grid size-[14px] cursor-pointer place-items-center">
-                    <span v-if="effect.name === 'Pulsar'" class="block size-2 rounded-full bg-pulsar" />
-                    <span v-else-if="effect.name === 'Magnetar'" class="block size-2 rounded-full bg-magnetar" />
-                    <span v-else-if="effect.name === 'Black Hole'" class="block size-2 rounded-full bg-black-hole" />
-                    <span v-else-if="effect.name === 'Red Giant'" class="block size-2 rounded-full bg-red-giant" />
-                    <span v-else-if="effect.name === 'Cataclysmic Variable'" class="block size-2 rounded-full bg-catalysmic-variable" />
-                    <span v-else-if="effect.name === 'Wolf-Rayet Star'" class="block size-2 rounded-full bg-wolf-rayet-star" />
+                    <SolarsystemEffectBadge :name="effect.name" />
                 </div>
             </PopoverTrigger>
             <PopoverContent>
-                <CardTitle>{{ effect.name }}</CardTitle>
+                <CardTitle class="flex items-center gap-2"><SolarsystemEffectBadge :name="effect.name" /> {{ effect.name }}</CardTitle>
                 <ul class="mt-4 grid grid-cols-[auto_1fr] divide-y text-xs">
                     <li class="col-span-full grid grid-cols-subgrid items-center gap-2 py-1" v-for="buff in effect.effects" :key="buff.name">
                         <span class="text-muted-foreground">{{ buff.name }}</span>
                         <span
                             :data-type="buff.type"
-                            class="text-right text-foreground data-[type=Buff]:text-green-500 data-[type=Debuff]:text-red-500"
-                            >{{ buff.strength }}</span
+                            class="inline-flex items-center justify-end gap-1 text-right text-foreground data-[type=Buff]:text-green-500 data-[type=Debuff]:text-red-500"
                         >
+                            <ArrowUp v-if="buff.type === 'Buff'" class="size-3" aria-label="Buff" />
+                            <ArrowDown v-else class="size-3" aria-label="Debuff" />
+                            {{ buff.strength }}
+                        </span>
                     </li>
                 </ul>
             </PopoverContent>

--- a/resources/js/components/map/SolarsystemStatusIcon.spec.ts
+++ b/resources/js/components/map/SolarsystemStatusIcon.spec.ts
@@ -1,0 +1,25 @@
+// @vitest-environment happy-dom
+import SolarsystemStatusIcon from '@/components/map/SolarsystemStatusIcon.vue';
+import type { TMapSolarsystemStatus } from '@/types/models';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+const statuses: TMapSolarsystemStatus[] = ['active', 'unscanned', 'unknown', 'friendly', 'hostile', 'empty'];
+
+describe('SolarsystemStatusIcon', () => {
+    it('renders a distinct glyph for every status', () => {
+        const svgs = statuses.map((status) => {
+            const wrapper = mount(SolarsystemStatusIcon, { props: { status } });
+            expect(wrapper.attributes('aria-label')).toBe(status);
+            return wrapper.html();
+        });
+
+        expect(new Set(svgs).size).toBe(statuses.length);
+    });
+
+    it('colors the glyph with the matching status token', () => {
+        const wrapper = mount(SolarsystemStatusIcon, { props: { status: 'hostile' } });
+
+        expect(wrapper.classes()).toContain('text-hostile');
+    });
+});

--- a/resources/js/components/map/SolarsystemStatusIcon.vue
+++ b/resources/js/components/map/SolarsystemStatusIcon.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { TMapSolarsystemStatus } from '@/types/models';
+import { Activity, CircleDashed, CircleHelp, Radar, ShieldCheck, Skull, type LucideProps } from 'lucide-vue-next';
+import { computed, type FunctionalComponent } from 'vue';
+
+/**
+ * Glyph for a system status. The shape carries the distinction for colorblind
+ * users; the status color stays as the fast visual channel.
+ */
+const { status } = defineProps<{
+    status: TMapSolarsystemStatus;
+}>();
+
+const meta: Record<TMapSolarsystemStatus, { icon: FunctionalComponent<LucideProps>; classes: string }> = {
+    friendly: { icon: ShieldCheck, classes: 'text-friendly' },
+    hostile: { icon: Skull, classes: 'text-hostile' },
+    active: { icon: Activity, classes: 'text-active' },
+    unscanned: { icon: Radar, classes: 'text-unscanned' },
+    empty: { icon: CircleDashed, classes: 'text-empty' },
+    unknown: { icon: CircleHelp, classes: 'text-muted-foreground' },
+};
+
+const entry = computed(() => meta[status]);
+</script>
+
+<template>
+    <component :is="entry.icon" v-if="entry" class="size-[14px]" :class="entry.classes" :aria-label="status" />
+</template>
+
+<style scoped></style>

--- a/resources/js/components/solarsystem/SolarsystemEffect.vue
+++ b/resources/js/components/solarsystem/SolarsystemEffect.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import SolarsystemEffectBadge from '@/components/solarsystem/SolarsystemEffectBadge.vue';
 import { TWormholeEffectName } from '@/types/models';
 
 const { effect } = defineProps<{
@@ -7,12 +8,7 @@ const { effect } = defineProps<{
 </script>
 
 <template>
-    <span v-if="effect === 'Pulsar'" class="inline-block size-1 animate-pulse rounded-full bg-blue-500" />
-    <span v-if="effect === 'Magnetar'" class="inline-block size-1 animate-pulse rounded-full bg-pink-500" />
-    <span v-if="effect === 'Wolf-Rayet Star'" class="inline-block size-1 animate-pulse rounded-full bg-amber-500" />
-    <span v-if="effect === 'Black Hole'" class="inline-block size-1 animate-pulse rounded-full bg-red-500" />
-    <span v-if="effect === 'Red Giant'" class="inline-block size-1 animate-pulse rounded-full bg-red-500" />
-    <span v-if="effect === 'Cataclysmic Variable'" class="inline-block size-1 animate-pulse rounded-full bg-orange-500" />
+    <SolarsystemEffectBadge :name="effect" size="sm" :title="effect" />
 </template>
 
 <style scoped></style>

--- a/resources/js/components/solarsystem/SolarsystemEffectBadge.spec.ts
+++ b/resources/js/components/solarsystem/SolarsystemEffectBadge.spec.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+import SolarsystemEffectBadge from '@/components/solarsystem/SolarsystemEffectBadge.vue';
+import type { TWormholeEffectName } from '@/types/models';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+const effects: TWormholeEffectName[] = ['Pulsar', 'Cataclysmic Variable', 'Magnetar', 'Red Giant', 'Wolf-Rayet Star', 'Black Hole'];
+
+describe('SolarsystemEffectBadge', () => {
+    it('renders a unique letter for every effect', () => {
+        const letters = effects.map((name) => mount(SolarsystemEffectBadge, { props: { name } }).text());
+
+        expect(letters).toEqual(['P', 'C', 'M', 'R', 'W', 'B']);
+        expect(new Set(letters).size).toBe(effects.length);
+    });
+
+    it('labels the badge with the effect name for assistive tech', () => {
+        const wrapper = mount(SolarsystemEffectBadge, { props: { name: 'Wolf-Rayet Star' } });
+
+        expect(wrapper.attributes('aria-label')).toBe('Wolf-Rayet Star');
+    });
+
+    it('keeps the effect color and switches size via the size prop', () => {
+        const md = mount(SolarsystemEffectBadge, { props: { name: 'Pulsar' } });
+        expect(md.classes()).toContain('bg-pulsar');
+        expect(md.attributes('data-size')).toBe('md');
+
+        const sm = mount(SolarsystemEffectBadge, { props: { name: 'Pulsar', size: 'sm' } });
+        expect(sm.attributes('data-size')).toBe('sm');
+    });
+});

--- a/resources/js/components/solarsystem/SolarsystemEffectBadge.vue
+++ b/resources/js/components/solarsystem/SolarsystemEffectBadge.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { TWormholeEffectName } from '@/types/models';
+import { computed } from 'vue';
+
+/**
+ * Letter badge for a wormhole effect. The letter carries the distinction for
+ * colorblind users; the effect color stays as the fast visual channel.
+ */
+const { name, size = 'md' } = defineProps<{
+    name: TWormholeEffectName;
+    size?: 'sm' | 'md';
+}>();
+
+const meta: Record<TWormholeEffectName, { letter: string; classes: string }> = {
+    Pulsar: { letter: 'P', classes: 'bg-pulsar text-white' },
+    Magnetar: { letter: 'M', classes: 'bg-magnetar text-white' },
+    'Wolf-Rayet Star': { letter: 'W', classes: 'bg-wolf-rayet-star text-white' },
+    'Black Hole': { letter: 'B', classes: 'bg-black-hole text-white' },
+    'Red Giant': { letter: 'R', classes: 'bg-red-giant text-white' },
+    'Cataclysmic Variable': { letter: 'C', classes: 'bg-catalysmic-variable text-neutral-950' },
+};
+
+const badge = computed(() => meta[name]);
+</script>
+
+<template>
+    <span
+        v-if="badge"
+        :data-size="size"
+        :aria-label="name"
+        class="grid size-[14px] place-items-center rounded-full text-[9px] leading-none font-semibold data-[size=sm]:size-3 data-[size=sm]:text-[8px]"
+        :class="badge.classes"
+        >{{ badge.letter }}</span
+    >
+</template>
+
+<style scoped></style>

--- a/resources/js/map/components/nodes/NodeCard.vue
+++ b/resources/js/map/components/nodes/NodeCard.vue
@@ -4,6 +4,7 @@ import SatelliteDish from '@/components/icons/SatelliteDish.vue';
 import HasExtraConnections from '@/components/map/HasExtraConnections.vue';
 import SolarsystemEffect from '@/components/map/SolarsystemEffect.vue';
 import SolarsystemSovereignty from '@/components/map/SolarsystemSovereignty.vue';
+import SolarsystemStatusIcon from '@/components/map/SolarsystemStatusIcon.vue';
 import SolarsystemClass from '@/components/solarsystem/SolarsystemClass.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -142,6 +143,12 @@ function handleSubmit() {
                 </PopoverContent>
             </Popover>
             <div class="col-start-3 row-start-1 flex items-center gap-1">
+                <Tooltip v-if="system.status && system.status !== 'unknown'" :delay-duration="500">
+                    <TooltipTrigger>
+                        <SolarsystemStatusIcon :status="system.status" />
+                    </TooltipTrigger>
+                    <TooltipContent>{{ system.status.charAt(0).toUpperCase() + system.status.slice(1) }}</TooltipContent>
+                </Tooltip>
                 <Tooltip v-if="isHome" :delay-duration="500">
                     <TooltipTrigger>
                         <HomeIcon class="size-[14px] text-amber-400" />

--- a/resources/js/map/components/overlays/MapSolarsystemContextMenu.vue
+++ b/resources/js/map/components/overlays/MapSolarsystemContextMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { CharacterImage } from '@/components/images';
+import SolarsystemStatusIcon from '@/components/map/SolarsystemStatusIcon.vue';
 import SolarsystemExternalLinks from '@/components/solarsystem/SolarsystemExternalLinks.vue';
 import {
     ContextMenuContent,
@@ -90,10 +91,7 @@ const options: TMapSolarsystemStatus[] = ['unknown', 'friendly', 'hostile', 'act
                 <ContextMenuRadioGroup :model-value="map_solarsystem.status ?? undefined" @update:model-value="handleStatusChange">
                     <ContextMenuRadioItem v-for="option in options" :key="option" :value="option">
                         {{ option.charAt(0).toUpperCase() + option.slice(1) }}
-                        <span
-                            :data-status="option"
-                            class="ml-auto inline-block size-2 rounded-full data-[status=active]:bg-active data-[status=empty]:bg-empty data-[status=friendly]:bg-friendly data-[status=hostile]:bg-hostile data-[status=unknown]:bg-unknown data-[status=unscanned]:bg-unscanned"
-                        />
+                        <SolarsystemStatusIcon :status="option" class="ml-auto" />
                     </ContextMenuRadioItem>
                 </ContextMenuRadioGroup>
             </ContextMenuSubContent>


### PR DESCRIPTION
Adds shape-based indicators for the two map signals that relied on color alone.

- wormhole effects render as small letter badges (P, M, W, B, R, C) in their existing colors, on map nodes and in system lists
- the effect popover marks buffs and debuffs with up/down arrows
- system status gets a glyph next to the node's other icons (shield, skull, activity, radar, dashed circle) and the same glyph appears in the status picker
- unifies the list effect colors with the map's theme tokens

Closes #35