### PR TITLE
fix(bookmark): apply alias suggestion eligibility to guessed bookmark aliases

### DIFF
--- a/resources/js/components/signatures/Signature.vue
+++ b/resources/js/components/signatures/Signature.vue
@@ -213,7 +213,7 @@ const { map_solarsystems } = useMapSolarsystems();
 const bookmark_name = computed(() =>
     buildSignatureBookmark({
         signature,
-        currentSystem: { alias: selected_map_solarsystem.alias },
+        currentSystem: { alias: selected_map_solarsystem.alias, class: selected_map_solarsystem.solarsystem.class },
         connectionTarget: selected_connection.value?.target ?? null,
         aliases: map_solarsystems.value.map((s) => s.alias).filter((alias): alias is string => Boolean(alias)),
         formats: page.props.map,

--- a/resources/js/composables/signatures/useTracking.ts
+++ b/resources/js/composables/signatures/useTracking.ts
@@ -145,8 +145,10 @@ export function useTracking() {
     // Copy the connection bookmark for the system we just jumped into, using the
     // same scheme as the connection context menu: the current system labelled
     // with the signature we used in the origin. Delegates to the shared
-    // signature-bookmark builder, so an empty chosen alias now falls back to
-    // the guessed one instead of leaving the alias token blank.
+    // signature-bookmark builder: an empty chosen alias falls back to the
+    // guessed one only when the jump is eligible for a suggestion (wormhole
+    // target, or an origin that is part of the chain), otherwise the alias
+    // token stays blank.
     function copyConnectionBookmark(signatureId: number | null, alias: string | null) {
         if (!map_user_settings.value.copy_bookmark_enabled) return;
         const target = target_solarsystem.value;
@@ -162,7 +164,7 @@ export function useTracking() {
                 wormhole: signature?.wormhole,
                 signature_type: signature?.signature_type,
             },
-            currentSystem: { alias: origin_map_solarsystem.value?.alias },
+            currentSystem: { alias: origin_map_solarsystem.value?.alias, class: origin_map_solarsystem.value?.solarsystem?.class },
             connectionTarget: { alias, occupier_alias: existing_map_solarsystem.value?.occupier_alias, solarsystem: target },
             aliases: known_aliases.value,
             formats: page.props.map,

--- a/resources/js/lib/bookmark.spec.ts
+++ b/resources/js/lib/bookmark.spec.ts
@@ -202,13 +202,91 @@ describe('buildSignatureBookmark (class token)', () => {
     ])('renders k-space class "%s" as "%s"', (targetClass, label) => {
         const name = buildSignatureBookmark({
             signature: baseSignature({ signature_type: { target_class: targetClass } }),
-            currentSystem: { alias: null },
+            currentSystem: { alias: null, class: '5' },
             connectionTarget: null,
             aliases: [],
             formats: { ...NUMERIC_FORMATS, bookmark_format_kspace: '{alias} {sig} {class}' },
         });
 
         expect(name).toBe(`1 ABC ${label}`);
+    });
+});
+
+describe('buildSignatureBookmark (alias eligibility)', () => {
+    it('leaves the alias blank for a connected k-space target reached from an unaliased k-space system', () => {
+        const name = buildSignatureBookmark({
+            signature: baseSignature(),
+            currentSystem: { alias: null, class: 'l' },
+            connectionTarget: {
+                alias: null,
+                occupier_alias: null,
+                solarsystem: { class: 'h', name: 'Jita', region: { name: 'The Forge' } },
+            },
+            aliases: [],
+            formats: { ...NUMERIC_FORMATS, bookmark_format_kspace: '{alias} {sig} {name}' },
+        });
+
+        expect(name).toBe('ABC Jita');
+    });
+
+    it('still guesses for a k-space target reached from an unaliased wormhole system', () => {
+        const name = buildSignatureBookmark({
+            signature: baseSignature(),
+            currentSystem: { alias: null, class: '3' },
+            connectionTarget: {
+                alias: null,
+                occupier_alias: null,
+                solarsystem: { class: 'h', name: 'Jita', region: { name: 'The Forge' } },
+            },
+            aliases: [],
+            formats: { ...NUMERIC_FORMATS, bookmark_format_kspace: '{alias} {sig} {name}' },
+        });
+
+        expect(name).toBe('1 ABC Jita');
+    });
+
+    it('still guesses for a k-space target reached from an aliased k-space system', () => {
+        const name = buildSignatureBookmark({
+            signature: baseSignature(),
+            currentSystem: { alias: '2', class: 'l' },
+            connectionTarget: {
+                alias: null,
+                occupier_alias: null,
+                solarsystem: { class: 'h', name: 'Jita', region: { name: 'The Forge' } },
+            },
+            aliases: ['2'],
+            formats: { ...NUMERIC_FORMATS, bookmark_format_kspace: '{alias} {sig} {name}' },
+        });
+
+        expect(name).toBe('21 ABC Jita');
+    });
+
+    it('still guesses for a wormhole target reached from an unaliased k-space system', () => {
+        const name = buildSignatureBookmark({
+            signature: baseSignature(),
+            currentSystem: { alias: null, class: 'l' },
+            connectionTarget: {
+                alias: null,
+                occupier_alias: null,
+                solarsystem: { class: '3', name: 'J123456' },
+            },
+            aliases: [],
+            formats: NUMERIC_FORMATS,
+        });
+
+        expect(name).toBe('1 ABC C3');
+    });
+
+    it('leaves the alias blank for an unconnected k-space signature in an unaliased k-space system', () => {
+        const name = buildSignatureBookmark({
+            signature: baseSignature({ signature_type: { target_class: 'h' } }),
+            currentSystem: { alias: null, class: 'l' },
+            connectionTarget: null,
+            aliases: [],
+            formats: { ...NUMERIC_FORMATS, bookmark_format_kspace: '{alias} {sig} {class}' },
+        });
+
+        expect(name).toBe('ABC HS');
     });
 });
 

--- a/resources/js/lib/bookmark.ts
+++ b/resources/js/lib/bookmark.ts
@@ -1,5 +1,5 @@
 import { isWormholeClass } from '@/const/solarsystemClasses';
-import { aliasTargetKind, guessNextAlias, isIgnoredAlias, TAliasScheme } from '@/lib/alias';
+import { aliasTargetKind, isIgnoredAlias, suggestAlias, TAliasScheme } from '@/lib/alias';
 import { TResolvedSolarsystem } from '@/pages/maps';
 import { TSignature, TStringedSolarsystemClass } from '@/types/models';
 
@@ -185,6 +185,12 @@ function knownTargetClass(targetClass: string | null | undefined): TStringedSola
  * target bookmark — falling back to the guessed alias only when the target
  * itself doesn't carry one yet.
  *
+ * The guess follows the same eligibility rule as the tracking suggestion
+ * (`suggestAlias`): the destination is only aliased when it is a wormhole, or
+ * when the current system is part of the chain (a wormhole or already
+ * aliased). A k-space destination reached from an unaliased k-space system
+ * leaves the alias token blank instead of inventing a top-level alias.
+ *
  * With no connection, the destination is unknown, so only the guessed alias
  * and the signature-level tokens (sig/size/mass/life/wh) are known; the
  * name/region/occupier tokens and an unidentified class stay blank rather than
@@ -206,7 +212,7 @@ export function buildSignatureBookmark(params: {
         wormhole?: { name?: string | null } | null;
         signature_type?: { target_class?: string | null } | null;
     };
-    currentSystem: { alias?: string | null };
+    currentSystem: { alias?: string | null; class?: TStringedSolarsystemClass | null };
     connectionTarget?: BookmarkSystem | null;
     aliases: string[];
     formats: TBookmarkFormats & { bookmark_alias_scheme?: TAliasScheme };
@@ -223,13 +229,18 @@ export function buildSignatureBookmark(params: {
     };
 
     if (connectionTarget) {
+        const targetIsWormhole = isWormholeClass(connectionTarget.solarsystem.class);
         const system: BookmarkSystem = connectionTarget.alias
             ? connectionTarget
             : {
                   ...connectionTarget,
-                  alias: guessNextAlias(currentSystem.alias, aliases, {
+                  alias: suggestAlias({
+                      parentAlias: currentSystem.alias,
+                      targetIsWormhole,
+                      originIsWormhole: isWormholeClass(currentSystem.class),
+                      aliases,
                       scheme: formats.bookmark_alias_scheme,
-                      targetKind: aliasTargetKind(isWormholeClass(connectionTarget.solarsystem.class), connectionTarget.solarsystem.class),
+                      targetKind: aliasTargetKind(targetIsWormhole, connectionTarget.solarsystem.class),
                       ignoredAlias: formats.bookmark_ignored_alias,
                   }),
               };
@@ -241,11 +252,16 @@ export function buildSignatureBookmark(params: {
     const isTargetWormhole = !knownClass || isWormholeClass(knownClass);
 
     const values: Record<TBookmarkToken, string> = {
-        alias: guessNextAlias(currentSystem.alias, aliases, {
-            scheme: formats.bookmark_alias_scheme,
-            targetKind: aliasTargetKind(isTargetWormhole, knownClass),
-            ignoredAlias: formats.bookmark_ignored_alias,
-        }),
+        alias:
+            suggestAlias({
+                parentAlias: currentSystem.alias,
+                targetIsWormhole: isTargetWormhole,
+                originIsWormhole: isWormholeClass(currentSystem.class),
+                aliases,
+                scheme: formats.bookmark_alias_scheme,
+                targetKind: aliasTargetKind(isTargetWormhole, knownClass),
+                ignoredAlias: formats.bookmark_ignored_alias,
+            }) ?? '',
         sig: getSignatureIdShort(context.signatureId),
         class: knownClass ? getBookmarkClassString({ class: knownClass, name: '' }) : '',
         name: '',


### PR DESCRIPTION
Copied bookmarks guessed an alias unconditionally when the target had none, so a k-space system reached from an unaliased k-space system got an invented alias (e.g. jumping through a wandering hole out of Turnur). Route the guess in buildSignatureBookmark through suggestAlias so it follows the same eligibility rule as the tracking prefill.

- Guess an alias only when the target is a wormhole, or the origin is a wormhole or already aliased
- Otherwise the alias token stays blank, as it did before the buildSignatureBookmark switch
- Applies to both the tracked-jump auto-copy and the signature-row copy button