### PR TITLE
fix(killmails): filter J-space by solarsystem type 'wh', not 'wormhole'

### DIFF
--- a/app/Features/MapKillmailsFeature.php
+++ b/app/Features/MapKillmailsFeature.php
@@ -51,7 +51,7 @@ final readonly class MapKillmailsFeature implements ProvidesInertiaProperties
             ])
             ->whereIn('solarsystem_id', $this->map->mapSolarsystems->pluck('solarsystem_id'))
             ->when($this->filter === KillmailFilter::KSpace, fn (Builder $query) => $query->whereRelation('solarsystem', 'type', 'eve'))
-            ->when($this->filter === KillmailFilter::JSpace, fn (Builder $query) => $query->whereRelation('solarsystem', 'type', 'wormhole'))
+            ->when($this->filter === KillmailFilter::JSpace, fn (Builder $query) => $query->whereRelation('solarsystem', 'type', 'wh'))
             ->orderByDesc('id')
             ->limit(50)
             ->get()

--- a/app/Http/Controllers/LandingController.php
+++ b/app/Http/Controllers/LandingController.php
@@ -30,7 +30,7 @@ final class LandingController extends Controller
                 'victimCorporation:id,name,ticker',
                 'victimAlliance:id,name,ticker',
             ])
-            ->whereRelation('solarsystem', 'type', 'wormhole')
+            ->whereRelation('solarsystem', 'type', 'wh')
             ->orderByDesc('id')
             ->limit(12)
             ->get()

--- a/tests/Feature/LandingTest.php
+++ b/tests/Feature/LandingTest.php
@@ -37,7 +37,7 @@ it('renders the landing page for guests', function () {
 });
 
 it('serves the latest wormhole killmails', function () {
-    $wormholeSystem = makeSolarsystem(31000001, -1.0, 'wormhole');
+    $wormholeSystem = makeSolarsystem(31000001, -1.0, 'wh');
     $knownSpaceSystem = makeSolarsystem(30000142, 0.9, 'eve');
 
     $wormholeKillmail = makeLandingKillmail(1001, $wormholeSystem);


### PR DESCRIPTION
Solarsystem.type stores wormhole systems as 'wh' (cf. TSolarsystemType and isWormholeSystem); 'wormhole' is not a valid value and never matches. The map killmail J-space filter and the landing page's wormhole-kills query both compared against 'wormhole', so both returned zero rows. Align both to 'wh'.

The landing test seeded a solarsystem with the same invalid 'wormhole' type, so it passed against the broken query; seed 'wh' so it exercises the real value.