### PR TITLE
feat(map): route tree edges through corridor lanes

### DIFF
--- a/resources/js/map/components/edges/EdgeLayer.vue
+++ b/resources/js/map/components/edges/EdgeLayer.vue
@@ -45,16 +45,15 @@ const treeGeometries = computed<Map<number, EdgeGeometry> | null>(() => {
     if (!store.isLayoutLocked.value) return null;
 
     const edges: EdgeInput[] = [];
-    const nodeIds = new Set<number>();
     for (const connection of store.connections.values()) {
         edges.push({ id: connection.id, sourceId: connection.from_map_solarsystem_id, targetId: connection.to_map_solarsystem_id });
-        nodeIds.add(connection.from_map_solarsystem_id);
-        nodeIds.add(connection.to_map_solarsystem_id);
     }
 
+    // Every measured node, not just the connected ones: the router keeps runs out of
+    // the columns they pass, so it has to see whatever could be in the way.
     const rects = new Map<number, Rect>();
     const anchors = new Map<number, Vec2>();
-    for (const nodeId of nodeIds) {
+    for (const nodeId of store.systems.keys()) {
         const anchor = store.renderPosition(nodeId);
         if (!anchor) continue;
         anchors.set(nodeId, anchor);

--- a/resources/js/map/core/geometry/treeRouting.spec.ts
+++ b/resources/js/map/core/geometry/treeRouting.spec.ts
@@ -1,6 +1,6 @@
 import { nodeRect } from '@/map/core/coords';
-import { BEND_SPACING, computeTreeEdgeGeometries, edgeCenterConnection, PARALLEL_SPACING } from '@/map/core/geometry/treeRouting';
-import type { EdgeGeometry, Rect, Vec2 } from '@/map/core/types';
+import { computeTreeEdgeGeometries, edgeCenterConnection, LANE_MARGIN, PARALLEL_SPACING } from '@/map/core/geometry/treeRouting';
+import type { EdgeGeometry, EdgeInput, Rect, Vec2 } from '@/map/core/types';
 import { describe, expect, it } from 'vitest';
 
 const SIZE = { width: 180, height: 40 };
@@ -9,9 +9,23 @@ function rectAt(anchor: Vec2): Rect {
     return nodeRect(anchor, SIZE);
 }
 
+function rectsAt(anchors: Record<number, Vec2>): Map<number, Rect> {
+    return new Map(Object.entries(anchors).map(([id, anchor]) => [Number(id), rectAt(anchor)]));
+}
+
+function edge(id: number, sourceId: number, targetId: number): EdgeInput {
+    return { id, sourceId, targetId };
+}
+
 function elbow(geometry: EdgeGeometry | undefined) {
     if (!geometry || geometry.kind !== 'elbow') throw new Error('expected an elbow geometry');
     return geometry;
+}
+
+/** The offset of the elbow's perpendicular run, defaulted like the path builder does. */
+function bendOf(geometry: EdgeGeometry | undefined): number {
+    const g = elbow(geometry);
+    return g.bend ?? (g.fromNormal.x !== 0 ? (g.from.x + g.to.x) / 2 : (g.from.y + g.to.y) / 2);
 }
 
 describe('edgeCenterConnection', () => {
@@ -49,36 +63,29 @@ describe('edgeCenterConnection', () => {
 
 describe('computeTreeEdgeGeometries', () => {
     it('falls back to a curve between anchors while a node is unmeasured', () => {
-        const rects = new Map([[1, rectAt({ x: 100, y: 100 })]]);
+        const rects = rectsAt({ 1: { x: 100, y: 100 } });
         const anchors = new Map([
             [1, { x: 100, y: 100 }],
             [2, { x: 500, y: 100 }],
         ]);
 
-        const geometries = computeTreeEdgeGeometries([{ id: 7, sourceId: 1, targetId: 2 }], rects, anchors);
+        const geometries = computeTreeEdgeGeometries([edge(7, 1, 2)], rects, anchors);
         expect(geometries.get(7)).toEqual({ id: 7, kind: 'curve', from: { x: 100, y: 100 }, to: { x: 500, y: 100 } });
     });
 
     it('drops edges with no measured box and no anchor', () => {
-        const geometries = computeTreeEdgeGeometries([{ id: 7, sourceId: 1, targetId: 2 }], new Map(), new Map());
+        const geometries = computeTreeEdgeGeometries([edge(7, 1, 2)], new Map(), new Map());
         expect(geometries.size).toBe(0);
     });
 
     it('spreads endpoints sharing a node edge PARALLEL_SPACING apart, ordered by the far end', () => {
         // One hub with two targets to its right, one above and one below.
-        const rects = new Map([
-            [1, rectAt({ x: 100, y: 300 })],
-            [2, rectAt({ x: 500, y: 100 })],
-            [3, rectAt({ x: 500, y: 500 })],
-        ]);
-        const geometries = computeTreeEdgeGeometries(
-            [
-                { id: 10, sourceId: 1, targetId: 2 },
-                { id: 11, sourceId: 1, targetId: 3 },
-            ],
-            rects,
-            new Map(),
-        );
+        const rects = rectsAt({
+            1: { x: 100, y: 300 },
+            2: { x: 500, y: 100 },
+            3: { x: 500, y: 500 },
+        });
+        const geometries = computeTreeEdgeGeometries([edge(10, 1, 2), edge(11, 1, 3)], rects, new Map());
 
         const up = elbow(geometries.get(10));
         const down = elbow(geometries.get(11));
@@ -91,53 +98,200 @@ describe('computeTreeEdgeGeometries', () => {
         expect(down.from.x).toBe(rects.get(1)!.maxX);
     });
 
-    it('staggers the bends of a fan so the farthest run sits closest to the node', () => {
-        // A hub with three stacked targets in the next column.
-        const rects = new Map([
-            [1, rectAt({ x: 100, y: 300 })],
-            [2, rectAt({ x: 500, y: 100 })],
-            [3, rectAt({ x: 500, y: 300 })],
-            [4, rectAt({ x: 500, y: 500 })],
-        ]);
-        const geometries = computeTreeEdgeGeometries(
-            [
-                { id: 10, sourceId: 1, targetId: 2 },
-                { id: 11, sourceId: 1, targetId: 3 },
-                { id: 12, sourceId: 1, targetId: 4 },
-            ],
-            rects,
-            new Map(),
-        );
+    it('goes out of the top or bottom when the nodes share a clear column', () => {
+        const rects = rectsAt({
+            1: { x: 100, y: 100 },
+            2: { x: 100, y: 460 },
+        });
+        const g = elbow(computeTreeEdgeGeometries([edge(10, 1, 2)], rects, new Map()).get(10));
 
-        const bends = [elbow(geometries.get(10)).bend!, elbow(geometries.get(11)).bend!, elbow(geometries.get(12)).bend!];
-        // All three bends exist, are distinct, and are BEND_SPACING apart.
-        expect(new Set(bends).size).toBe(3);
-        const sorted = [...bends].sort((a, b) => a - b);
-        expect(sorted[1] - sorted[0]).toBeCloseTo(BEND_SPACING);
-        expect(sorted[2] - sorted[1]).toBeCloseTo(BEND_SPACING);
-        // The straight-across link (id 11, distance 0) bends farthest from the hub.
-        expect(elbow(geometries.get(11)).bend).toBe(Math.max(...bends));
+        // Nothing in the way, so it takes the short way: out of the bottom, into the top.
+        expect(g.from).toEqual({ x: rects.get(1)!.centerX, y: rects.get(1)!.maxY });
+        expect(g.to).toEqual({ x: rects.get(2)!.centerX, y: rects.get(2)!.minY });
     });
 
-    it('shrinks fan spacing to keep the runs inside the lane between columns', () => {
-        // Narrow gap between the columns with many connections.
-        const hub = rectAt({ x: 100, y: 300 });
-        const rects = new Map<number, Rect>([[1, hub]]);
-        const edges = [];
-        for (let i = 0; i < 6; i++) {
-            rects.set(2 + i, rectAt({ x: 320, y: 100 + i * 100 }));
-            edges.push({ id: 10 + i, sourceId: 1, targetId: 2 + i });
-        }
-        const geometries = computeTreeEdgeGeometries(edges, rects, new Map());
+    it('detours into the lane when nodes sit between the two in a column', () => {
+        // Four stacked systems in one column, and a connection joining the outer two:
+        // straight down would vanish behind the two in between.
+        const rects = rectsAt({
+            1: { x: 100, y: 100 },
+            2: { x: 100, y: 220 },
+            3: { x: 100, y: 340 },
+            4: { x: 100, y: 460 },
+        });
+        const g = elbow(computeTreeEdgeGeometries([edge(10, 1, 4)], rects, new Map()).get(10));
 
-        const bends = edges.map((edge) => elbow(geometries.get(edge.id)).bend!);
-        const sorted = [...bends].sort((a, b) => a - b);
-        const gap = sorted[1] - sorted[0];
-        expect(gap).toBeLessThan(BEND_SPACING);
-        // Every run stays strictly between the two column faces.
-        for (const bend of bends) {
-            expect(bend).toBeGreaterThan(hub.maxX);
-            expect(bend).toBeLessThan(rectAt({ x: 320, y: 100 }).minX);
+        // Both ends leave the same side, and the run happens beside the column.
+        const columnRight = rects.get(1)!.maxX;
+        expect(g.from).toEqual({ x: columnRight, y: rects.get(1)!.centerY });
+        expect(g.to).toEqual({ x: columnRight, y: rects.get(4)!.centerY });
+        expect(g.bend).toBe(columnRight + LANE_MARGIN);
+    });
+
+    it('never runs vertically through a column it is only passing', () => {
+        // Columns two apart: the midpoint between them is the column in between, which is
+        // exactly where a naive bend would put the vertical run. The middle system is not
+        // even connected — it still has to be routed around.
+        const rects = rectsAt({
+            1: { x: 100, y: 100 },
+            2: { x: 420, y: 400 },
+            3: { x: 740, y: 200 },
+        });
+        const g = computeTreeEdgeGeometries([edge(10, 1, 3)], rects, new Map()).get(10);
+
+        expect(bendOf(g)).toBe(rects.get(2)!.maxX + LANE_MARGIN);
+    });
+});
+
+describe('runs share a lane where they can', () => {
+    // A run up and a run down never overlap, so they can sit on the same line and still be
+    // told apart: each keeps its own stroke. Giving them separate lines made a two-hole
+    // system look like a ladder.
+    it('puts one child above and one below on the same line', () => {
+        const rects = rectsAt({
+            1: { x: 100, y: 300 },
+            2: { x: 420, y: 180 },
+            3: { x: 420, y: 420 },
+        });
+        const geometries = computeTreeEdgeGeometries([edge(10, 1, 2), edge(11, 1, 3)], rects, new Map());
+
+        expect(bendOf(geometries.get(10))).toBe(bendOf(geometries.get(11)));
+    });
+
+    // Two runs the same way do overlap, and would hide each other.
+    it('keeps two children on the same side apart', () => {
+        const rects = rectsAt({
+            1: { x: 100, y: 300 },
+            2: { x: 420, y: 60 },
+            3: { x: 420, y: 180 },
+        });
+        const geometries = computeTreeEdgeGeometries([edge(10, 1, 2), edge(11, 1, 3)], rects, new Map());
+
+        expect(bendOf(geometries.get(10))).not.toBe(bendOf(geometries.get(11)));
+    });
+
+    // A tree layout centres a parent between its two children, so the gap either side is
+    // small. Every such parent in a column should kink on the same line: a map of them
+    // kinking a few pixels apart reads as noise.
+    it('lines up the kink for every parent in a column', () => {
+        const anchors: Record<number, Vec2> = {};
+        const edges: EdgeInput[] = [];
+        let id = 0;
+        let next = 1;
+        [202, 321, 441, 561, 681].forEach((parentY, i) => {
+            const parent = next++;
+            anchors[parent] = { x: 100, y: parentY };
+            for (const childY of [161 + i * 120, 221 + i * 120]) {
+                const child = next++;
+                anchors[child] = { x: 420, y: childY };
+                edges.push(edge(id++, parent, child));
+            }
+        });
+        const geometries = computeTreeEdgeGeometries(edges, rectsAt(anchors), new Map());
+
+        expect(new Set(edges.map((e) => bendOf(geometries.get(e.id)))).size).toBe(1);
+    });
+});
+
+describe('a hub with many children in the next column', () => {
+    const ys = [40, 100, 167, 227, 287, 347, 407, 467, 527, 587, 647, 707, 767];
+
+    function hub() {
+        const anchors: Record<number, Vec2> = { 1: { x: 100, y: 410 } };
+        const edges = ys.map((y, i) => {
+            anchors[i + 2] = { x: 420, y };
+            return edge(10 + i, 1, i + 2);
+        });
+        return { edges, geometries: computeTreeEdgeGeometries(edges, rectsAt(anchors), new Map()) };
+    }
+
+    // The bend used to step a fixed distance from the middle, which walked the outermost
+    // runs onto the target column: they were then shunted past it and doubled back.
+    it('keeps every run between the two columns', () => {
+        const { edges, geometries } = hub();
+        const hubRight = rectAt({ x: 100, y: 410 }).maxX;
+        const targetLeft = rectAt({ x: 420, y: 40 }).minX;
+        for (const e of edges) {
+            const bend = bendOf(geometries.get(e.id));
+            expect(bend).toBeGreaterThan(hubRight);
+            expect(bend).toBeLessThan(targetLeft);
         }
+    });
+
+    it('never draws two runs on top of each other', () => {
+        const { edges, geometries } = hub();
+        const runs = edges.map((e) => {
+            const g = elbow(geometries.get(e.id));
+            return { bend: bendOf(g), y1: Math.min(g.from.y, g.to.y), y2: Math.max(g.from.y, g.to.y) };
+        });
+        for (let i = 0; i < runs.length; i++) {
+            for (let j = i + 1; j < runs.length; j++) {
+                if (Math.abs(runs[i].bend - runs[j].bend) > 0.5) continue;
+                const lo = Math.max(runs[i].y1, runs[j].y1);
+                const hi = Math.min(runs[i].y2, runs[j].y2);
+                expect(hi - lo).toBeLessThanOrEqual(0.5);
+            }
+        }
+    });
+
+    // Thirteen holes, six of them above the node and six below. Every run above overlaps
+    // every other run above near the node, so six lines is the fewest it can be drawn with.
+    it('uses no more lines than the runs actually need', () => {
+        const { edges, geometries } = hub();
+        expect(new Set(edges.map((e) => Math.round(bendOf(geometries.get(e.id))))).size).toBe(6);
+    });
+});
+
+// Distilled from map 1: 23→233 (leftward into the left column) ended level with 5→53
+// (rightward into the right column), and packing order alone put the leftward edge's lane
+// right of the rightward edge's, so their level tails overlapped between the two bends.
+describe('level tails from opposite sides stay apart', () => {
+    it('keeps the leftward lane left of the rightward lane', () => {
+        const rects = rectsAt({
+            1: { x: 100, y: 1000 }, // hub with two children, its ports spread
+            2: { x: 420, y: 440 },
+            3: { x: 420, y: 1060 },
+            4: { x: 420, y: 640 }, // sends an edge back left, level with the hub's lower child
+            5: { x: 100, y: 1060 },
+        });
+        const geometries = computeTreeEdgeGeometries([edge(20, 1, 2), edge(21, 1, 3), edge(22, 4, 5)], rects, new Map());
+
+        const rightward = elbow(geometries.get(21));
+        const leftward = elbow(geometries.get(22));
+        // Both end at the same y on opposite faces of the corridor, in different lanes.
+        expect(rightward.to.y).toBe(leftward.to.y);
+        expect(bendOf(rightward)).not.toBe(bendOf(leftward));
+        // The tails [near, leftward.bend] and [rightward.bend, far] must not overlap.
+        expect(bendOf(leftward)).toBeLessThan(bendOf(rightward));
+    });
+});
+
+// A node with two holes spreads its ends apart so they can be told apart. A neighbour level
+// with it, holding only this one hole, has nothing to spread, so the two ends used to sit a
+// few pixels apart and the line kinked on its way across for no reason.
+describe('a level run stays straight', () => {
+    it('follows the busier end rather than kinking into the middle of the quiet one', () => {
+        const rects = rectsAt({
+            1: { x: 100, y: 300 },
+            2: { x: 500, y: 300 },
+            3: { x: 500, y: 460 },
+        });
+        const level = elbow(computeTreeEdgeGeometries([edge(10, 1, 2), edge(11, 1, 3)], rects, new Map()).get(10));
+
+        expect(level.from.y).toBe(level.to.y);
+    });
+
+    // Only a run that would otherwise be straight gets this: a node above or below still
+    // has a real bend to make, and pulling its end across would drag the line off its own
+    // centre line for nothing.
+    it('leaves a run alone when the nodes are not level', () => {
+        const rects = rectsAt({
+            1: { x: 100, y: 300 },
+            2: { x: 500, y: 340 },
+            3: { x: 500, y: 460 },
+        });
+        const g = elbow(computeTreeEdgeGeometries([edge(10, 1, 2), edge(11, 1, 3)], rects, new Map()).get(10));
+
+        expect(g.to.y).toBe(340);
     });
 });

--- a/resources/js/map/core/geometry/treeRouting.ts
+++ b/resources/js/map/core/geometry/treeRouting.ts
@@ -2,8 +2,10 @@ import type { EdgeGeometry, EdgeInput, Rect, Vec2 } from '../types';
 
 /** Spacing between connections that leave the same node edge, in base units. */
 export const PARALLEL_SPACING = 14;
-/** Spacing between the perpendicular runs of those connections' bends, in base units. */
+/** Spacing between the stacked runs of detours sharing a column, in base units. */
 export const BEND_SPACING = 16;
+/** Clear space kept between a vertical run and the column it routes beside, in base units. */
+export const LANE_MARGIN = 40;
 
 export type Endpoints = { from: Vec2; to: Vec2; fromNormal: Vec2; toNormal: Vec2 };
 
@@ -11,7 +13,7 @@ export type Endpoints = { from: Vec2; to: Vec2; fromNormal: Vec2; toNormal: Vec2
  * Connects the centre of each box's facing edge, leaving perpendicular to it.
  *
  * Prefer the left/right edges whenever the boxes are separated horizontally — then the
- * smoothstep drops its long vertical run through the clear lane between the columns
+ * elbow drops its long vertical run through the clear lane between the columns
  * (down, then right into the node) instead of routing down-over-down with the second
  * vertical run cutting straight through the column of stacked siblings. Top/bottom
  * edges are only used when the boxes share a column, so there is no horizontal lane.
@@ -43,6 +45,81 @@ export function edgeCenterConnection(source: Rect, target: Rect): Endpoints {
     };
 }
 
+/** Both ends out the same side, for two nodes in one column with something between them. */
+function detourConnection(source: Rect, target: Rect): Endpoints {
+    return {
+        from: { x: source.maxX, y: source.centerY },
+        to: { x: target.maxX, y: target.centerY },
+        fromNormal: { x: 1, y: 0 },
+        toNormal: { x: 1, y: 0 },
+    };
+}
+
+/** Whether a node sits between these two in their shared column, which a run would cross. */
+function blockedInColumn(source: Rect, target: Rect, column: Rect[]): boolean {
+    const top = Math.min(source.centerY, target.centerY);
+    const bottom = Math.max(source.centerY, target.centerY);
+    return column.some((other) => other !== source && other !== target && other.minY < bottom && other.maxY > top);
+}
+
+type Column = { left: number; right: number };
+
+/**
+ * A vertical run belongs in the lanes between columns, never inside one: crossing another
+ * edge is readable, disappearing behind a node is not. Only columns the run actually
+ * passes between count, and the shifted lane stays inside them, so an edge never runs past
+ * the node it is heading for and doubles back.
+ */
+function intoLane(x: number, columns: Column[], from: number, to: number): number {
+    const near = Math.min(from, to);
+    const far = Math.max(from, to);
+    for (const column of columns) {
+        if (column.right <= near || column.left >= far) continue;
+        if (x > column.left - LANE_MARGIN / 2 && x < column.right + LANE_MARGIN) {
+            return clamp(column.right + LANE_MARGIN, near, far);
+        }
+    }
+    return x;
+}
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Positions for the lanes of one corridor honouring `precedes` (lane → lanes that must
+ * sit farther out), keeping the original order where the constraints leave a choice.
+ * A cycle would mean tails that cannot all be kept apart; the tie is broken in favour
+ * of the earlier lane and the rest still honoured.
+ */
+function laneOrder(precedes: ReadonlySet<number>[]): number[] {
+    const indegree = precedes.map(() => 0);
+    for (const targets of precedes) {
+        for (const target of targets) {
+            indegree[target]++;
+        }
+    }
+    const position = precedes.map(() => 0);
+    const placed = new Set<number>();
+    for (let slot = 0; slot < precedes.length; slot++) {
+        let pick = -1;
+        for (let lane = 0; lane < precedes.length; lane++) {
+            if (placed.has(lane)) continue;
+            if (indegree[lane] === 0) {
+                pick = lane;
+                break;
+            }
+            if (pick === -1) pick = lane;
+        }
+        placed.add(pick);
+        position[pick] = slot;
+        for (const target of precedes[pick]) {
+            if (!placed.has(target)) indegree[target]--;
+        }
+    }
+    return position;
+}
+
 type Port = { endpoint: Vec2; normal: Vec2; box: Rect; sortKey: number };
 
 /**
@@ -70,15 +147,20 @@ function spreadSharedEdges(ports: Port[]): void {
 type RoutedEdge = Extract<EdgeGeometry, { kind: 'elbow' }> & {
     sourceBox: Rect;
     targetBox: Rect;
-    /** Perpendicular distance and signed offset of the far end, for fan ordering. */
+    /** Both ends leave the same side, to get around the nodes between them. */
+    detour: boolean;
+    /** Perpendicular distance and signed offset of the far end, for ordering the fan. */
     distance: number;
     signed: number;
 };
 
 /**
- * Tree-layout routing, a global pass over all edges: connects facing box edges,
- * fans out endpoints that share a node edge, then staggers the perpendicular runs
- * of connections fanning out from the same node so they nest instead of stacking.
+ * Tree-layout routing, a global pass over all edges: connects facing box edges (or sends
+ * both ends out the same side when the straight run would vanish behind a node in the
+ * shared column), fans out endpoints that share a node edge, packs the perpendicular
+ * runs crossing one corridor onto the fewest lanes that keep them apart, and steers
+ * vertical runs out of the columns they only pass. `rects` should cover every measured
+ * node — routing steers around whatever is actually in the way, connected or not.
  * Edges whose nodes are not both measured fall back to a straight curve between
  * their anchors (edges missing an anchor entirely are dropped).
  */
@@ -89,6 +171,16 @@ export function computeTreeEdgeGeometries(
 ): Map<number, EdgeGeometry> {
     const geometries = new Map<number, EdgeGeometry>();
     const routed: RoutedEdge[] = [];
+
+    // One rect per node, shared below so the column members can be compared by identity.
+    const byColumn = new Map<number, Rect[]>();
+    for (const rect of rects.values()) {
+        (byColumn.get(rect.minX) ?? byColumn.set(rect.minX, []).get(rect.minX)!).push(rect);
+    }
+    const columns: Column[] = [...byColumn.entries()]
+        .map(([left, members]) => ({ left, right: Math.max(...members.map((member) => member.maxX)) }))
+        .sort((a, b) => a.left - b.left);
+    const columnRight = (left: number): number => columns.find((column) => column.left === left)?.right ?? left;
 
     for (const edge of edges) {
         const sourceBox = rects.get(edge.sourceId);
@@ -101,7 +193,8 @@ export function computeTreeEdgeGeometries(
             }
             continue;
         }
-        const ends = edgeCenterConnection(sourceBox, targetBox);
+        const detour = sourceBox.minX === targetBox.minX && blockedInColumn(sourceBox, targetBox, byColumn.get(sourceBox.minX) ?? []);
+        const ends = detour ? detourConnection(sourceBox, targetBox) : edgeCenterConnection(sourceBox, targetBox);
         const item: RoutedEdge = {
             id: edge.id,
             kind: 'elbow',
@@ -112,6 +205,7 @@ export function computeTreeEdgeGeometries(
             bend: null,
             sourceBox,
             targetBox,
+            detour,
             distance: 0,
             signed: 0,
         };
@@ -130,17 +224,42 @@ export function computeTreeEdgeGeometries(
         register(item.from, item.fromNormal, item.sourceBox, item.targetBox);
         register(item.to, item.toNormal, item.targetBox, item.sourceBox);
     }
+    const spreadCount = new Map<Vec2, number>();
     for (const ports of sharedEdges.values()) {
         spreadSharedEdges(ports);
+        for (const port of ports) {
+            spreadCount.set(port.endpoint, ports.length);
+        }
     }
 
-    // Stagger the perpendicular run of connections that fan out from the same node so
-    // they nest instead of stacking. Group by the node the fan leaves on its primary
-    // axis (the left node for horizontal links, the top node for vertical), regardless
-    // of which end is the stored source, and order each group by how far its far end
-    // sits so the runs don't cross.
+    // Two nodes sitting level would be joined by a straight line, except that spreading the
+    // ports on the busier one lifts its end off the other's centre line and leaves a jog of
+    // a few pixels. Where the quiet end is this edge's alone, it follows the busy one
+    // instead: entering off-centre reads better than a kink that means nothing.
+    for (const item of routed) {
+        if (item.detour) continue;
+        const horizontal = item.fromNormal.x !== 0;
+        const level = horizontal
+            ? Math.abs(item.sourceBox.centerY - item.targetBox.centerY) < 0.5
+            : Math.abs(item.sourceBox.centerX - item.targetBox.centerX) < 0.5;
+        if (!level) continue;
+        const fromShared = spreadCount.get(item.from) ?? 1;
+        const toShared = spreadCount.get(item.to) ?? 1;
+        if (fromShared === toShared) continue;
+        const [follow, lead] = fromShared < toShared ? [item.from, item.to] : [item.to, item.from];
+        if (horizontal) {
+            follow.y = lead.y;
+        } else {
+            follow.x = lead.x;
+        }
+    }
+
+    // Grouped by the corridor the run crosses, not by the node it leaves: two runs at the
+    // same offset in the same corridor are the same line, whichever nodes they belong to,
+    // so they all have to be packed together or they lie on top of each other.
     const fans = new Map<string, RoutedEdge[]>();
     for (const item of routed) {
+        if (item.detour) continue;
         const horizontal = item.fromNormal.x !== 0;
         const sourceFirst = horizontal ? item.sourceBox.centerX <= item.targetBox.centerX : item.sourceBox.centerY <= item.targetBox.centerY;
         const primary = sourceFirst ? item.sourceBox : item.targetBox;
@@ -148,23 +267,108 @@ export function computeTreeEdgeGeometries(
         const along = horizontal ? other.centerY - primary.centerY : other.centerX - primary.centerX;
         item.distance = Math.abs(along);
         item.signed = along;
-        const key = `${horizontal ? 'h' : 'v'}|${primary.centerX},${primary.centerY}`;
+        const across = horizontal ? [item.from.x, item.to.x] : [item.from.y, item.to.y];
+        const key = `${horizontal ? 'h' : 'v'}|${Math.min(...across)},${Math.max(...across)}`;
         (fans.get(key) ?? fans.set(key, []).get(key)!).push(item);
     }
+    // Runs crossing one corridor only need separate lines where they would overlap and hide
+    // each other: a run up and a run down can sit on the same line and still be told apart,
+    // because each keeps its own colour. So pack them onto as few lines as possible, then
+    // space those across the corridor.
     for (const group of fans.values()) {
         if (group.length < 2) continue;
         const horizontal = group[0].fromNormal.x !== 0;
-        // Keep the whole fan inside the lane between the two columns: when there are more
-        // connections than BEND_SPACING would fit in the gap, shrink the spacing so the
-        // outermost runs still clear the neighbouring nodes instead of cutting through them.
-        const gap = Math.min(...group.map((item) => Math.abs(horizontal ? item.to.x - item.from.x : item.to.y - item.from.y)));
-        const spacing = Math.min(BEND_SPACING, (gap * 0.8) / (group.length - 1));
-        // Farthest target bends closest to the node; ties (above vs below) split by side.
-        group.sort((a, b) => b.distance - a.distance || a.signed - b.signed);
+        // How far the run reaches along the node edge it leaves from.
+        const reach = (item: RoutedEdge): [number, number] =>
+            horizontal
+                ? [Math.min(item.from.y, item.to.y), Math.max(item.from.y, item.to.y)]
+                : [Math.min(item.from.x, item.to.x), Math.max(item.from.x, item.to.x)];
+
+        const lanes: RoutedEdge[][] = [];
+        const laneOf = new Map<number, number>();
+        const ordered = [...group].sort((a, b) => b.distance - a.distance || a.signed - b.signed);
+        for (const item of ordered) {
+            const span = reach(item);
+            const fits = (lane: number): boolean =>
+                lanes[lane].every((other) => {
+                    const [start, end] = reach(other);
+                    return span[0] >= end || span[1] <= start;
+                });
+            // Overlap is the only thing a lane cannot have: two runs on one line hide each
+            // other, where two runs that cross stay readable. Taken longest first, first fit,
+            // that lands on the fewest lanes the corridor can be drawn with.
+            let lane = lanes.findIndex((_, i) => fits(i));
+            if (lane === -1) {
+                lane = lanes.push([]) - 1;
+            }
+            lanes[lane].push(item);
+            laneOf.set(item.id, lane);
+        }
+
+        // One corridor, so one set of lines: measured from its near edge, not from each
+        // run's own direction, or a run drawn leftward would count its lanes backwards.
+        const ends = group.flatMap((item) => (horizontal ? [item.from.x, item.to.x] : [item.from.y, item.to.y]));
+        const near = Math.min(...ends);
+        const far = Math.max(...ends);
+
+        // Separate lanes only keep the runs themselves apart. Each run also has two tails
+        // tying its lane to a corridor face, and the tails of a leftward and a rightward
+        // edge that end level lie on one line: they stay apart only when the lane of the
+        // edge entering the near face sits nearer than the lane of the edge entering the
+        // far face. Renumber the lanes to honour those orderings, so a run never doubles
+        // back over the tail of a level neighbour approaching from the other side.
+        const tailsOf = (item: RoutedEdge): { at: number; fromNear: boolean }[] => {
+            const middle = (near + far) / 2;
+            return horizontal
+                ? [
+                      { at: item.from.y, fromNear: item.from.x < middle },
+                      { at: item.to.y, fromNear: item.to.x < middle },
+                  ]
+                : [
+                      { at: item.from.x, fromNear: item.from.y < middle },
+                      { at: item.to.x, fromNear: item.to.y < middle },
+                  ];
+        };
+        const precedes = lanes.map(() => new Set<number>());
+        for (let i = 0; i < group.length; i++) {
+            for (let j = i + 1; j < group.length; j++) {
+                const laneA = laneOf.get(group[i].id)!;
+                const laneB = laneOf.get(group[j].id)!;
+                if (laneA === laneB) continue;
+                for (const tailA of tailsOf(group[i])) {
+                    for (const tailB of tailsOf(group[j])) {
+                        if (Math.abs(tailA.at - tailB.at) >= 0.5 || tailA.fromNear === tailB.fromNear) continue;
+                        const [nearLane, farLane] = tailA.fromNear ? [laneA, laneB] : [laneB, laneA];
+                        precedes[nearLane].add(farLane);
+                    }
+                }
+            }
+        }
+        const position = laneOrder(precedes);
+
+        for (const item of group) {
+            item.bend = near + ((far - near) * (position[laneOf.get(item.id)!] + 1)) / (lanes.length + 1);
+        }
+    }
+
+    // Detours stack outwards so several between the same roots stay apart.
+    const detourGroups = new Map<number, RoutedEdge[]>();
+    for (const item of routed) {
+        if (!item.detour) continue;
+        const key = item.sourceBox.minX;
+        (detourGroups.get(key) ?? detourGroups.set(key, []).get(key)!).push(item);
+    }
+    for (const [columnLeft, group] of detourGroups) {
+        group.sort((a, b) => a.from.y - b.from.y);
         group.forEach((item, i) => {
-            const base = horizontal ? (item.from.x + item.to.x) / 2 : (item.from.y + item.to.y) / 2;
-            item.bend = base + (i - (group.length - 1) / 2) * spacing;
+            item.bend = columnRight(columnLeft) + LANE_MARGIN + i * BEND_SPACING;
         });
+    }
+
+    // The midpoint between two columns two apart lands exactly on the column between them.
+    for (const item of routed) {
+        if (item.detour || item.fromNormal.x === 0) continue;
+        item.bend = intoLane(item.bend ?? (item.from.x + item.to.x) / 2, columns, item.from.x, item.to.x);
     }
 
     return geometries;


### PR DESCRIPTION
Backports the tree-layout connection routing from wormholesystems-next, plus a lane-ordering fix found on a live map.

## Routing changes

- **Detours**: two systems in one column with a node between them no longer draw a straight line that vanishes behind the blocker — both ends leave the right side and the run goes down the lane beside the column, stacking outward when several share a column.
- **Corridor lane packing**: vertical runs are grouped by the corridor they cross (not the node they leave) and packed onto the fewest lanes that keep them apart (longest first, first fit). A run up and a run down share one line and stay readable; overlapping runs get separate lanes spread evenly across the corridor. Fixes the ladder look on two-hole systems and lines up the kink for every parent in a column.
- **Lane avoidance**: a run between columns two apart shifts its vertical segment into the clear lane past the column in between instead of landing on it. `EdgeLayer` now feeds the router every measured node so it can steer around unconnected ones too.
- **Level runs stay straight**: when only one end of a level connection is spread by other edges, the quiet end follows the busy one instead of kinking a few pixels for no reason.

## Lane ordering fix

Reproduced with map 1 data: `23→233` (leftward) ended level with `5→53` (rightward) on opposite faces of one corridor, and packing order alone put the leftward lane right of the rightward one, so their horizontal tails overlapped between the two bends. The router now collects ordering constraints from same-y opposite-face tails and renumbers the lanes with a stable topological order that honours them. (Also forward-ported to wormholesystems-next in WormholeSystems/wormholesystems-next@47ccf93.)

## Testing

- `treeRouting.spec.ts` ports the next repo's suite to this codebase (18 tests), including the 13-child hub case (runs stay inside the corridor, never overlap, minimum lane count) and a regression test for the level-tail overlap.
- Verified against live map 1 data: layout + routing produce zero collinear segment overlaps.
- Full vitest suite green (234 tests); eslint and prettier clean.