### PR TITLE
feat(maps): import and export map data

### DIFF
--- a/app/Actions/MapTransfer/ExportMapAction.php
+++ b/app/Actions/MapTransfer/ExportMapAction.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\MapTransfer;
+
+use App\Models\Map;
+use App\Models\MapAccess;
+use App\Models\MapConnection;
+use App\Models\MapRouteSolarsystem;
+use App\Models\MapSolarsystemDetails;
+use App\Models\Signature;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
+
+final readonly class ExportMapAction
+{
+    public const string FORMAT = 'wormholesystems-map-export';
+
+    public const int VERSION = 1;
+
+    /**
+     * Build the export payload for the given sections. Secrets (share token,
+     * webhooks, per-user settings) and the owner access row never leave the map.
+     *
+     * @param  list<string>  $sections
+     * @return array<string, mixed>
+     */
+    public function handle(Map $map, array $sections): array
+    {
+        $payload = [
+            'format' => self::FORMAT,
+            'version' => self::VERSION,
+            'exported_at' => now()->toIso8601String(),
+            'map_name' => $map->name,
+            'sections' => [],
+        ];
+
+        if (in_array('settings', $sections, true)) {
+            $payload['sections']['settings'] = $this->settings($map);
+        }
+
+        if (in_array('access', $sections, true)) {
+            $payload['sections']['access'] = $this->access($map);
+        }
+
+        if (in_array('solarsystems', $sections, true)) {
+            $payload['sections']['solarsystems'] = $this->solarsystems($map);
+        }
+
+        $connection_indexes = [];
+
+        if (in_array('connections', $sections, true)) {
+            [$connections, $connection_indexes] = $this->connections($map);
+            $payload['sections']['connections'] = $connections;
+        }
+
+        if (in_array('signatures', $sections, true)) {
+            $payload['sections']['signatures'] = $this->signatures($map, $connection_indexes);
+        }
+
+        if (in_array('routes', $sections, true)) {
+            $payload['sections']['routes'] = $this->routes($map);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function settings(Map $map): array
+    {
+        return [
+            'name' => $map->name,
+            'layout' => $map->layout->value,
+            'allow_layout_override' => $map->allow_layout_override,
+            'constant_width_enabled' => $map->constant_width_enabled,
+            'bookmark_format_wormhole' => $map->bookmark_format_wormhole,
+            'bookmark_format_kspace' => $map->bookmark_format_kspace,
+            'bookmark_format_return' => $map->bookmark_format_return,
+            'bookmark_alias_scheme' => $map->bookmark_alias_scheme->value,
+            'bookmark_ignored_alias' => $map->bookmark_ignored_alias,
+            'home_solarsystem_id' => $map->home_solarsystem_id,
+            'rally_solarsystem_id' => $map->rally_solarsystem_id,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function access(Map $map): array
+    {
+        return $map->mapAccessors()
+            ->where('is_owner', false)
+            ->with('accessible')
+            ->get()
+            ->map(fn (MapAccess $access): array => [
+                'entity_type' => Str::of(class_basename($access->accessible_type))->lower()->value(),
+                'entity_id' => $access->accessible_id,
+                'entity_name' => $access->accessible->name,
+                'permission' => $access->permission->value,
+                'expires_at' => $access->expires_at?->toIso8601String(),
+            ])
+            ->all();
+    }
+
+    /**
+     * Details are the superset: every placed system has a details row, but intel
+     * can outlive its placement. Details-only rows export with null positions.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function solarsystems(Map $map): array
+    {
+        return $map->mapSolarsystemDetails()
+            ->with('mapSolarsystem')
+            ->get()
+            ->map(fn (MapSolarsystemDetails $details): array => [
+                'solarsystem_id' => $details->solarsystem_id,
+                'alias' => $details->mapSolarsystem?->alias,
+                'position_x' => $details->mapSolarsystem?->position_x,
+                'position_y' => $details->mapSolarsystem?->position_y,
+                'pinned' => $details->mapSolarsystem !== null ? (bool) $details->mapSolarsystem->pinned : null,
+                'status' => $details->status->value,
+                'occupier_alias' => $details->occupier_alias,
+                'notes' => $details->notes,
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array{0: list<array<string, mixed>>, 1: array<int, int>}
+     */
+    private function connections(Map $map): array
+    {
+        $connections = $map->mapConnections()
+            ->with(['fromMapSolarsystem:id,solarsystem_id', 'toMapSolarsystem:id,solarsystem_id', 'wormhole:id,name'])
+            ->get();
+
+        $indexes = $connections->pluck('id')->flip()->all();
+
+        $exported = $connections
+            ->map(fn (MapConnection $connection): array => [
+                'from_solarsystem_id' => $connection->fromMapSolarsystem->solarsystem_id,
+                'to_solarsystem_id' => $connection->toMapSolarsystem->solarsystem_id,
+                'wormhole' => $connection->wormhole?->name,
+                'type' => $connection->type->value,
+                'mass_status' => $connection->mass_status->value,
+                'ship_size' => $connection->ship_size->value,
+                'lifetime' => $connection->lifetime->value,
+                'lifetime_updated_at' => CarbonImmutable::make($connection->lifetime_updated_at)?->toIso8601String(),
+                'connected_at' => CarbonImmutable::make($connection->connected_at)?->toIso8601String(),
+                'preserve_mass' => $connection->preserve_mass,
+            ])
+            ->all();
+
+        return [$exported, $indexes];
+    }
+
+    /**
+     * @param  array<int, int>  $connection_indexes
+     * @return list<array<string, mixed>>
+     */
+    private function signatures(Map $map, array $connection_indexes): array
+    {
+        return Signature::query()
+            ->whereIn('map_solarsystem_id', $map->mapSolarsystems()->select('id'))
+            ->with(['mapSolarsystem:id,solarsystem_id', 'wormhole:id,name', 'signatureType:id,name', 'signatureCategory:id,code'])
+            ->get()
+            ->map(fn (Signature $signature): array => [
+                'solarsystem_id' => $signature->mapSolarsystem->solarsystem_id,
+                'signature_id' => $signature->signature_id,
+                'category' => $signature->signatureCategory?->code?->value,
+                'type_name' => $signature->signatureType?->name,
+                'raw_type_name' => $signature->raw_type_name,
+                'wormhole' => $signature->wormhole?->name,
+                'connection_index' => $signature->map_connection_id !== null
+                    ? ($connection_indexes[$signature->map_connection_id] ?? null)
+                    : null,
+                'mass_status' => $signature->mass_status?->value,
+                'ship_size' => $signature->ship_size?->value,
+                'lifetime' => $signature->lifetime->value,
+                'lifetime_updated_at' => CarbonImmutable::make($signature->lifetime_updated_at)?->toIso8601String(),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<string, list<array<string, mixed>>>
+     */
+    private function routes(Map $map): array
+    {
+        return [
+            'route_solarsystems' => $map->mapRouteSolarsystems()
+                ->get()
+                ->map(fn (MapRouteSolarsystem $route): array => [
+                    'solarsystem_id' => $route->solarsystem_id,
+                    'is_pinned' => (bool) $route->is_pinned,
+                ])
+                ->all(),
+            'ignored_solarsystems' => $map->mapIgnoredSolarsystems()
+                ->get()
+                ->map(fn ($ignored): array => [
+                    'solarsystem_id' => $ignored->solarsystem_id,
+                ])
+                ->all(),
+        ];
+    }
+}

--- a/app/Actions/MapTransfer/ImportMapAction.php
+++ b/app/Actions/MapTransfer/ImportMapAction.php
@@ -1,0 +1,447 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\MapTransfer;
+
+use App\DTO\MapImportSummary;
+use App\Enums\LifetimeStatus;
+use App\Enums\ShipSize;
+use App\Models\Alliance;
+use App\Models\Character;
+use App\Models\Corporation;
+use App\Models\Map;
+use App\Models\MapAccess;
+use App\Models\MapConnection;
+use App\Models\MapIgnoredSolarsystem;
+use App\Models\MapRouteSolarsystem;
+use App\Models\MapSolarsystem;
+use App\Models\MapSolarsystemDetails;
+use App\Models\Signature;
+use App\Models\SignatureCategory;
+use App\Models\SignatureType;
+use App\Models\Solarsystem;
+use App\Models\Wormhole;
+use App\Support\Broadcasting\MapBroadcaster;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Throwable;
+
+final readonly class ImportMapAction
+{
+    public function __construct(private MapBroadcaster $mapBroadcaster) {}
+
+    /**
+     * Merge a parsed export payload into the map. Rows with a natural unique key
+     * are updated in place; connections (which have none) are skipped when an
+     * equivalent edge already exists. The owner access row is never touched.
+     *
+     * @param  array<string, mixed>  $payload
+     *
+     * @throws Throwable
+     */
+    public function handle(Map $map, array $payload): MapImportSummary
+    {
+        $summary = new MapImportSummary;
+
+        DB::transaction(function () use ($map, $payload, $summary): void {
+            $sections = $payload['sections'];
+            $known_solarsystem_ids = $this->knownSolarsystemIds($sections);
+
+            if (isset($sections['settings'])) {
+                $this->importSettings($map, $sections['settings'], $known_solarsystem_ids, $summary);
+            }
+
+            if (isset($sections['access'])) {
+                $this->importAccess($map, $sections['access'], $summary);
+            }
+
+            if (isset($sections['solarsystems'])) {
+                $this->importSolarsystems($map, $sections['solarsystems'], $known_solarsystem_ids, $summary);
+            }
+
+            $connection_ids_by_index = [];
+
+            if (isset($sections['connections'])) {
+                $connection_ids_by_index = $this->importConnections($map, $sections['connections'], $summary);
+            }
+
+            if (isset($sections['signatures'])) {
+                $this->importSignatures($map, $sections['signatures'], $connection_ids_by_index, $summary);
+            }
+
+            if (isset($sections['routes'])) {
+                $this->importRoutes($map, $sections['routes'], $known_solarsystem_ids, $summary);
+            }
+        }, 5);
+
+        $this->mapBroadcaster->resync($map->id);
+
+        return $summary;
+    }
+
+    /**
+     * Every solarsystem id referenced anywhere in the payload that exists in the
+     * local static data, so unknown ids can be skipped instead of hitting FKs.
+     *
+     * @param  array<string, mixed>  $sections
+     * @return array<int, bool>
+     */
+    private function knownSolarsystemIds(array $sections): array
+    {
+        $ids = collect([
+            $sections['settings']['home_solarsystem_id'] ?? null,
+            $sections['settings']['rally_solarsystem_id'] ?? null,
+        ])
+            ->merge(collect($sections['solarsystems'] ?? [])->pluck('solarsystem_id'))
+            ->merge(collect($sections['routes']['route_solarsystems'] ?? [])->pluck('solarsystem_id'))
+            ->merge(collect($sections['routes']['ignored_solarsystems'] ?? [])->pluck('solarsystem_id'))
+            ->filter()
+            ->unique();
+
+        return Solarsystem::query()
+            ->whereIn('id', $ids)
+            ->pluck('id')
+            ->mapWithKeys(fn (int $id): array => [$id => true])
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $settings
+     * @param  array<int, bool>  $known_solarsystem_ids
+     */
+    private function importSettings(Map $map, array $settings, array $known_solarsystem_ids, MapImportSummary $summary): void
+    {
+        $map->update([
+            'name' => $settings['name'],
+            'layout' => $settings['layout'],
+            'allow_layout_override' => $settings['allow_layout_override'],
+            'constant_width_enabled' => $settings['constant_width_enabled'],
+            'bookmark_format_wormhole' => $settings['bookmark_format_wormhole'],
+            'bookmark_format_kspace' => $settings['bookmark_format_kspace'],
+            'bookmark_format_return' => $settings['bookmark_format_return'],
+            'bookmark_alias_scheme' => $settings['bookmark_alias_scheme'],
+            'bookmark_ignored_alias' => $settings['bookmark_ignored_alias'] ?? '',
+            'home_solarsystem_id' => $this->knownOrNull($settings['home_solarsystem_id'], $known_solarsystem_ids),
+            'rally_solarsystem_id' => $this->knownOrNull($settings['rally_solarsystem_id'], $known_solarsystem_ids),
+        ]);
+
+        $summary->updated('settings');
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $entries
+     */
+    private function importAccess(Map $map, array $entries, MapImportSummary $summary): void
+    {
+        $owner = $map->mapOwner;
+
+        foreach ($entries as $entry) {
+            $accessible_type = match ($entry['entity_type']) {
+                'character' => Character::class,
+                'corporation' => Corporation::class,
+                'alliance' => Alliance::class,
+                default => throw new InvalidArgumentException('Unknown access entity type.'),
+            };
+
+            $accessible_type::query()->firstOrCreate(
+                ['id' => $entry['entity_id']],
+                ['name' => $entry['entity_name']],
+            );
+
+            $existing = MapAccess::query()
+                ->where('map_id', $map->id)
+                ->where('accessible_type', $accessible_type)
+                ->where('accessible_id', $entry['entity_id'])
+                ->first();
+
+            $is_owner_entity = $owner instanceof MapAccess
+                && $owner->accessible_type === $accessible_type
+                && $owner->accessible_id === (int) $entry['entity_id'];
+
+            if ($existing?->is_owner || $is_owner_entity) {
+                $summary->skipped('access');
+
+                continue;
+            }
+
+            $attributes = [
+                'permission' => $entry['permission'],
+                'expires_at' => $entry['expires_at'] !== null ? CarbonImmutable::parse($entry['expires_at']) : null,
+                'is_owner' => false,
+            ];
+
+            if ($existing instanceof MapAccess) {
+                $existing->update($attributes);
+                $summary->updated('access');
+            } else {
+                MapAccess::query()->create([
+                    'map_id' => $map->id,
+                    'accessible_type' => $accessible_type,
+                    'accessible_id' => $entry['entity_id'],
+                    ...$attributes,
+                ]);
+                $summary->created('access');
+            }
+        }
+    }
+
+    /**
+     * Details first (they are the superset), then placements for entries that
+     * carry canvas positions. Batched with upserts because alliance-scale
+     * exports carry thousands of systems.
+     *
+     * @param  list<array<string, mixed>>  $entries
+     * @param  array<int, bool>  $known_solarsystem_ids
+     */
+    private function importSolarsystems(Map $map, array $entries, array $known_solarsystem_ids, MapImportSummary $summary): void
+    {
+        $importable = [];
+
+        foreach ($entries as $entry) {
+            if (isset($known_solarsystem_ids[$entry['solarsystem_id']])) {
+                $importable[$entry['solarsystem_id']] = $entry;
+            } else {
+                $summary->skipped('systems');
+            }
+        }
+
+        if ($importable === []) {
+            return;
+        }
+
+        $ids = array_keys($importable);
+        $existing_details = $map->mapSolarsystemDetails()->whereIn('solarsystem_id', $ids)->pluck('solarsystem_id')->flip()->all();
+        $existing_placements = $map->mapSolarsystems()->whereIn('solarsystem_id', $ids)->pluck('solarsystem_id')->flip()->all();
+
+        foreach (array_chunk($importable, 500) as $chunk) {
+            MapSolarsystemDetails::query()->upsert(
+                array_map(fn (array $entry): array => [
+                    'map_id' => $map->id,
+                    'solarsystem_id' => $entry['solarsystem_id'],
+                    'status' => $entry['status'],
+                    'occupier_alias' => $entry['occupier_alias'],
+                    'notes' => $entry['notes'],
+                ], $chunk),
+                ['map_id', 'solarsystem_id'],
+                ['status', 'occupier_alias', 'notes'],
+            );
+        }
+
+        $placed = array_values(array_filter(
+            $importable,
+            fn (array $entry): bool => $entry['position_x'] !== null && $entry['position_y'] !== null,
+        ));
+
+        if ($placed !== []) {
+            $details_ids = $map->mapSolarsystemDetails()
+                ->whereIn('solarsystem_id', array_column($placed, 'solarsystem_id'))
+                ->pluck('id', 'solarsystem_id');
+
+            foreach (array_chunk($placed, 500) as $chunk) {
+                MapSolarsystem::query()->upsert(
+                    array_map(fn (array $entry): array => [
+                        'map_id' => $map->id,
+                        'solarsystem_id' => $entry['solarsystem_id'],
+                        'map_solarsystem_details_id' => $details_ids[$entry['solarsystem_id']],
+                        'alias' => $entry['alias'],
+                        'position_x' => (int) $entry['position_x'],
+                        'position_y' => (int) $entry['position_y'],
+                        'pinned' => (bool) ($entry['pinned'] ?? false),
+                    ], $chunk),
+                    ['map_id', 'solarsystem_id'],
+                    ['map_solarsystem_details_id', 'alias', 'position_x', 'position_y', 'pinned'],
+                );
+            }
+        }
+
+        foreach ($importable as $solarsystem_id => $entry) {
+            $has_position = $entry['position_x'] !== null && $entry['position_y'] !== null;
+            $existed = $has_position ? isset($existing_placements[$solarsystem_id]) : isset($existing_details[$solarsystem_id]);
+            $existed ? $summary->updated('systems') : $summary->created('systems');
+        }
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $entries
+     * @return array<int, int> connection index in the file to local connection id
+     */
+    private function importConnections(Map $map, array $entries, MapImportSummary $summary): array
+    {
+        $placement_ids = $map->mapSolarsystems()->pluck('id', 'solarsystem_id');
+        $existing = $map->mapConnections()->get(['id', 'from_map_solarsystem_id', 'to_map_solarsystem_id']);
+        $connection_ids_by_index = [];
+
+        foreach ($entries as $index => $entry) {
+            $from_id = $placement_ids[$entry['from_solarsystem_id']] ?? null;
+            $to_id = $placement_ids[$entry['to_solarsystem_id']] ?? null;
+
+            if ($from_id === null || $to_id === null) {
+                $summary->skipped('connections');
+
+                continue;
+            }
+
+            $duplicate = $existing->first(
+                fn (MapConnection $connection): bool => ($connection->from_map_solarsystem_id === $from_id && $connection->to_map_solarsystem_id === $to_id)
+                    || ($connection->from_map_solarsystem_id === $to_id && $connection->to_map_solarsystem_id === $from_id)
+            );
+
+            if ($duplicate instanceof MapConnection) {
+                $connection_ids_by_index[$index] = $duplicate->id;
+                $summary->skipped('connections');
+
+                continue;
+            }
+
+            $wormhole = $entry['wormhole'] !== null
+                ? Wormhole::query()->where('name', $entry['wormhole'])->first()
+                : null;
+            $wormhole_ship_size = ShipSize::fromWormhole($wormhole);
+
+            $connection = MapConnection::query()->create([
+                'map_id' => $map->id,
+                'from_map_solarsystem_id' => $from_id,
+                'to_map_solarsystem_id' => $to_id,
+                'wormhole_id' => $wormhole?->id,
+                'type' => $entry['type'],
+                'mass_status' => $entry['mass_status'],
+                'ship_size' => $wormhole_ship_size instanceof ShipSize ? $wormhole_ship_size->value : $entry['ship_size'],
+                'lifetime' => $entry['lifetime'],
+                'lifetime_updated_at' => $entry['lifetime_updated_at'],
+                'connected_at' => $entry['connected_at'] ?? now(),
+                'preserve_mass' => $entry['preserve_mass'],
+            ]);
+
+            $existing->push($connection);
+            $connection_ids_by_index[$index] = $connection->id;
+            $summary->created('connections');
+        }
+
+        return $connection_ids_by_index;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $entries
+     * @param  array<int, int>  $connection_ids_by_index
+     */
+    private function importSignatures(Map $map, array $entries, array $connection_ids_by_index, MapImportSummary $summary): void
+    {
+        $placement_ids = $map->mapSolarsystems()->pluck('id', 'solarsystem_id');
+
+        foreach ($entries as $entry) {
+            $placement_id = $placement_ids[$entry['solarsystem_id']] ?? null;
+
+            if ($placement_id === null) {
+                $summary->skipped('signatures');
+
+                continue;
+            }
+
+            $connection_id = $entry['connection_index'] !== null
+                ? ($connection_ids_by_index[$entry['connection_index']] ?? null)
+                : null;
+
+            $attributes = [
+                'signature_category_id' => $entry['category'] !== null
+                    ? SignatureCategory::query()->where('code', $entry['category'])->first()?->id
+                    : null,
+                'signature_type_id' => $entry['type_name'] !== null
+                    ? SignatureType::query()->where('name', $entry['type_name'])->first()?->id
+                    : null,
+                'wormhole_id' => $entry['wormhole'] !== null
+                    ? Wormhole::query()->where('name', $entry['wormhole'])->first()?->id
+                    : null,
+                'map_connection_id' => $connection_id,
+                'raw_type_name' => $entry['raw_type_name'],
+                'mass_status' => $entry['mass_status'],
+                'ship_size' => $entry['ship_size'],
+                'lifetime' => $entry['lifetime'] ?? LifetimeStatus::Healthy->value,
+                'lifetime_updated_at' => $entry['lifetime_updated_at'],
+            ];
+
+            if ($entry['signature_id'] !== null) {
+                $signature = Signature::query()->updateOrCreate(
+                    ['map_solarsystem_id' => $placement_id, 'signature_id' => $entry['signature_id']],
+                    $attributes,
+                );
+
+                $signature->wasRecentlyCreated ? $summary->created('signatures') : $summary->updated('signatures');
+
+                continue;
+            }
+
+            $existing = Signature::query()
+                ->where('map_solarsystem_id', $placement_id)
+                ->whereNull('signature_id')
+                ->when(
+                    $connection_id !== null,
+                    fn ($query) => $query->where('map_connection_id', $connection_id),
+                    fn ($query) => $query->whereNull('map_connection_id'),
+                )
+                ->first();
+
+            if ($existing instanceof Signature) {
+                $existing->update($attributes);
+                $summary->updated('signatures');
+            } else {
+                Signature::query()->create([
+                    'map_solarsystem_id' => $placement_id,
+                    'signature_id' => null,
+                    ...$attributes,
+                ]);
+                $summary->created('signatures');
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, list<array<string, mixed>>>  $routes
+     * @param  array<int, bool>  $known_solarsystem_ids
+     */
+    private function importRoutes(Map $map, array $routes, array $known_solarsystem_ids, MapImportSummary $summary): void
+    {
+        foreach ($routes['route_solarsystems'] as $entry) {
+            if (! isset($known_solarsystem_ids[$entry['solarsystem_id']])) {
+                $summary->skipped('routes');
+
+                continue;
+            }
+
+            $route = MapRouteSolarsystem::query()->updateOrCreate(
+                ['map_id' => $map->id, 'solarsystem_id' => $entry['solarsystem_id']],
+                ['is_pinned' => $entry['is_pinned']],
+            );
+
+            $route->wasRecentlyCreated ? $summary->created('routes') : $summary->updated('routes');
+        }
+
+        foreach ($routes['ignored_solarsystems'] as $entry) {
+            if (! isset($known_solarsystem_ids[$entry['solarsystem_id']])) {
+                $summary->skipped('routes');
+
+                continue;
+            }
+
+            $ignored = MapIgnoredSolarsystem::query()->firstOrCreate([
+                'map_id' => $map->id,
+                'solarsystem_id' => $entry['solarsystem_id'],
+            ]);
+
+            if ($ignored->wasRecentlyCreated) {
+                $summary->created('routes');
+            }
+        }
+    }
+
+    /**
+     * @param  array<int, bool>  $known_solarsystem_ids
+     */
+    private function knownOrNull(?int $solarsystem_id, array $known_solarsystem_ids): ?int
+    {
+        return $solarsystem_id !== null && isset($known_solarsystem_ids[$solarsystem_id])
+            ? $solarsystem_id
+            : null;
+    }
+}

--- a/app/Actions/MapTransfer/ImportMapAsNewAction.php
+++ b/app/Actions/MapTransfer/ImportMapAsNewAction.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\MapTransfer;
+
+use App\Actions\Map\CreateMapAction;
+use App\Models\Character;
+use App\Models\Map;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+final readonly class ImportMapAsNewAction
+{
+    public function __construct(
+        private CreateMapAction $createMapAction,
+        private ImportMapAction $importMapAction,
+    ) {}
+
+    /**
+     * Create a fresh map owned by the importing character and load the payload
+     * into it. When the file carries a routes section, the seeded trade-hub
+     * defaults make way for the file's list.
+     *
+     * @param  array<string, mixed>  $payload
+     *
+     * @throws Throwable
+     */
+    public function handle(Character $character, array $payload, ?string $name = null): Map
+    {
+        return DB::transaction(function () use ($character, $payload, $name): Map {
+            $map = $this->createMapAction->handle($character, [
+                'name' => $name ?? $payload['map_name'],
+            ]);
+
+            if (isset($payload['sections']['routes'])) {
+                $map->mapRouteSolarsystems()->delete();
+            }
+
+            if (isset($payload['sections']['settings'])) {
+                $payload['sections']['settings']['name'] = $name ?? $payload['sections']['settings']['name'];
+            }
+
+            $this->importMapAction->handle($map, $payload);
+
+            return $map;
+        }, 5);
+    }
+}

--- a/app/Actions/MapTransfer/ParseMapExportFileAction.php
+++ b/app/Actions/MapTransfer/ParseMapExportFileAction.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\MapTransfer;
+
+use App\Enums\AliasScheme;
+use App\Enums\ConnectionType;
+use App\Enums\LifetimeStatus;
+use App\Enums\MapLayout;
+use App\Enums\MapSolarsystemStatus;
+use App\Enums\MassStatus;
+use App\Enums\Permission;
+use App\Enums\ShipSize;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Validation\ValidationException;
+
+final readonly class ParseMapExportFileAction
+{
+    /**
+     * Field specs per section entry. A leading "?" marks the field nullable; the
+     * part after ":" parameterises the base type (max length, enum class, list).
+     * Validated by hand instead of Laravel wildcard rules because exports carry
+     * thousands of entries and rule expansion is quadratic at that size.
+     */
+    private const array SETTINGS_SPEC = [
+        'name' => 'string:255',
+        'layout' => 'enum:'.MapLayout::class,
+        'allow_layout_override' => 'bool',
+        'constant_width_enabled' => 'bool',
+        'bookmark_format_wormhole' => 'string:255',
+        'bookmark_format_kspace' => 'string:255',
+        'bookmark_format_return' => 'string:255',
+        'bookmark_alias_scheme' => 'enum:'.AliasScheme::class,
+        'bookmark_ignored_alias' => '?string:255',
+        'home_solarsystem_id' => '?int',
+        'rally_solarsystem_id' => '?int',
+    ];
+
+    private const array ACCESS_SPEC = [
+        'entity_type' => 'in:character,corporation,alliance',
+        'entity_id' => 'int',
+        'entity_name' => '?string:255',
+        'permission' => 'enum:'.Permission::class,
+        'expires_at' => '?date',
+    ];
+
+    private const array SOLARSYSTEM_SPEC = [
+        'solarsystem_id' => 'int',
+        'alias' => '?string:255',
+        'position_x' => '?number',
+        'position_y' => '?number',
+        'pinned' => '?bool',
+        'status' => 'enum:'.MapSolarsystemStatus::class,
+        'occupier_alias' => '?string:255',
+        'notes' => '?string',
+    ];
+
+    private const array CONNECTION_SPEC = [
+        'from_solarsystem_id' => 'int',
+        'to_solarsystem_id' => 'int',
+        'wormhole' => '?string:255',
+        'type' => 'enum:'.ConnectionType::class,
+        'mass_status' => 'enum:'.MassStatus::class,
+        'ship_size' => 'enum:'.ShipSize::class,
+        'lifetime' => 'enum:'.LifetimeStatus::class,
+        'lifetime_updated_at' => '?date',
+        'connected_at' => '?date',
+        'preserve_mass' => 'bool',
+    ];
+
+    private const array SIGNATURE_SPEC = [
+        'solarsystem_id' => 'int',
+        'signature_id' => '?size:7',
+        'category' => '?string:255',
+        'type_name' => '?string:255',
+        'raw_type_name' => '?string:255',
+        'wormhole' => '?string:255',
+        'connection_index' => '?int',
+        'mass_status' => '?enum:'.MassStatus::class,
+        'ship_size' => '?enum:'.ShipSize::class,
+        'lifetime' => '?enum:'.LifetimeStatus::class,
+        'lifetime_updated_at' => '?date',
+    ];
+
+    private const array ROUTE_SPEC = [
+        'solarsystem_id' => 'int',
+        'is_pinned' => 'bool',
+    ];
+
+    private const array IGNORED_SPEC = [
+        'solarsystem_id' => 'int',
+    ];
+
+    /**
+     * Decode and validate an uploaded export file, returning only the requested
+     * sections. Throws a ValidationException keyed on `file` for anything wrong
+     * with the upload so errors surface in the standard error bag.
+     *
+     * @param  list<string>  $sections
+     * @return array<string, mixed>
+     *
+     * @throws ValidationException
+     */
+    public function handle(UploadedFile $file, array $sections, bool $for_new_map = false): array
+    {
+        $contents = $file->getContent();
+
+        if (! json_validate($contents)) {
+            $this->fail('This file is not valid JSON.');
+        }
+
+        $data = json_decode($contents, true);
+
+        if (! is_array($data) || ($data['format'] ?? null) !== ExportMapAction::FORMAT) {
+            $this->fail('This file is not a wormholesystems map export.');
+        }
+
+        if (($data['version'] ?? null) !== ExportMapAction::VERSION) {
+            $this->fail('This file was exported by an incompatible version of the application.');
+        }
+
+        $available = is_array($data['sections'] ?? null) ? $data['sections'] : [];
+
+        foreach ($sections as $section) {
+            if (! array_key_exists($section, $available)) {
+                $this->fail(sprintf('The file does not contain the "%s" section.', $section));
+            }
+        }
+
+        if ($for_new_map && ! in_array('solarsystems', $sections, true)) {
+            foreach (['connections', 'signatures'] as $dependent) {
+                if (in_array($dependent, $sections, true)) {
+                    $this->fail(sprintf('Importing %s into a new map requires the solar systems section.', $dependent));
+                }
+            }
+        }
+
+        if (! is_string($data['map_name'] ?? null) || $data['map_name'] === '' || mb_strlen($data['map_name']) > 255) {
+            $this->fail('The file does not contain a valid map name.');
+        }
+
+        $data['sections'] = collect($available)
+            ->only($sections)
+            ->all();
+
+        foreach ($data['sections'] as $section => $value) {
+            $this->validateSection((string) $section, $value);
+        }
+
+        return $data;
+    }
+
+    private function validateSection(string $section, mixed $value): void
+    {
+        match ($section) {
+            'settings' => $this->validateEntry('sections.settings', $value, self::SETTINGS_SPEC),
+            'access' => $this->validateList('sections.access', $value, self::ACCESS_SPEC),
+            'solarsystems' => $this->validateList('sections.solarsystems', $value, self::SOLARSYSTEM_SPEC),
+            'connections' => $this->validateList('sections.connections', $value, self::CONNECTION_SPEC),
+            'signatures' => $this->validateList('sections.signatures', $value, self::SIGNATURE_SPEC),
+            'routes' => $this->validateRoutes($value),
+            default => $this->invalid($section),
+        };
+    }
+
+    private function validateRoutes(mixed $value): void
+    {
+        if (! is_array($value)) {
+            $this->invalid('sections.routes');
+        }
+
+        $this->validateList('sections.routes.route_solarsystems', $value['route_solarsystems'] ?? null, self::ROUTE_SPEC);
+        $this->validateList('sections.routes.ignored_solarsystems', $value['ignored_solarsystems'] ?? null, self::IGNORED_SPEC);
+    }
+
+    /**
+     * @param  array<string, string>  $spec
+     */
+    private function validateList(string $path, mixed $entries, array $spec): void
+    {
+        if (! is_array($entries) || ! array_is_list($entries)) {
+            $this->invalid($path);
+        }
+
+        foreach ($entries as $index => $entry) {
+            $this->validateEntry(sprintf('%s.%d', $path, $index), $entry, $spec);
+        }
+    }
+
+    /**
+     * @param  array<string, string>  $spec
+     */
+    private function validateEntry(string $path, mixed $entry, array $spec): void
+    {
+        if (! is_array($entry)) {
+            $this->invalid($path);
+        }
+
+        foreach ($spec as $field => $type) {
+            $nullable = str_starts_with($type, '?');
+            $value = $entry[$field] ?? null;
+
+            if ($value === null) {
+                if (! $nullable) {
+                    $this->invalid(sprintf('%s.%s', $path, $field));
+                }
+
+                continue;
+            }
+
+            if (! $this->matchesType($value, mb_ltrim($type, '?'))) {
+                $this->invalid(sprintf('%s.%s', $path, $field));
+            }
+        }
+    }
+
+    private function matchesType(mixed $value, string $type): bool
+    {
+        [$base, $param] = array_pad(explode(':', $type, 2), 2, null);
+
+        return match ($base) {
+            'int' => is_int($value),
+            'number' => is_int($value) || is_float($value),
+            'bool' => is_bool($value) || $value === 0 || $value === 1,
+            'date' => is_string($value) && strtotime($value) !== false,
+            'string' => is_string($value) && ($param === null || mb_strlen($value) <= (int) $param),
+            'size' => is_string($value) && mb_strlen($value) === (int) $param,
+            'in' => is_string($value) && in_array($value, explode(',', (string) $param), true),
+            'enum' => is_string($value) && $param::tryFrom($value) !== null,
+            default => false,
+        };
+    }
+
+    private function invalid(string $path): never
+    {
+        $this->fail(sprintf('The file contains invalid data at %s.', $path));
+    }
+
+    private function fail(string $message): never
+    {
+        throw ValidationException::withMessages(['file' => $message]);
+    }
+}

--- a/app/DTO/MapImportSummary.php
+++ b/app/DTO/MapImportSummary.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+final class MapImportSummary
+{
+    /** @var array<string, array{created: int, updated: int, skipped: int}> */
+    private array $sections = [];
+
+    public function created(string $section, int $count = 1): void
+    {
+        $this->increment($section, 'created', $count);
+    }
+
+    public function updated(string $section, int $count = 1): void
+    {
+        $this->increment($section, 'updated', $count);
+    }
+
+    public function skipped(string $section, int $count = 1): void
+    {
+        $this->increment($section, 'skipped', $count);
+    }
+
+    public function describe(): string
+    {
+        if ($this->sections === []) {
+            return 'Nothing to import.';
+        }
+
+        $parts = [];
+
+        foreach ($this->sections as $section => $counts) {
+            $detail = collect($counts)
+                ->filter(fn (int $count): bool => $count > 0)
+                ->map(fn (int $count, string $kind): string => sprintf('%d %s', $count, $kind))
+                ->implode(', ');
+
+            if ($detail !== '') {
+                $parts[] = sprintf('%s: %s', str_replace('_', ' ', $section), $detail);
+            }
+        }
+
+        return $parts === [] ? 'Nothing to import.' : implode('. ', $parts).'.';
+    }
+
+    private function increment(string $section, string $kind, int $count): void
+    {
+        $this->sections[$section] ??= ['created' => 0, 'updated' => 0, 'skipped' => 0];
+        $this->sections[$section][$kind] += $count;
+    }
+}

--- a/app/Http/Controllers/MapImportController.php
+++ b/app/Http/Controllers/MapImportController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Actions\MapTransfer\ImportMapAsNewAction;
+use App\Actions\MapTransfer\ParseMapExportFileAction;
+use App\Http\Requests\ImportNewMapRequest;
+use App\Models\User;
+use Illuminate\Container\Attributes\CurrentUser;
+use Illuminate\Http\RedirectResponse;
+use Throwable;
+
+final class MapImportController extends Controller
+{
+    public function __construct(#[CurrentUser] private readonly User $user) {}
+
+    /**
+     * @throws Throwable
+     */
+    public function store(
+        ImportNewMapRequest $request,
+        ParseMapExportFileAction $parseAction,
+        ImportMapAsNewAction $importAction,
+    ): RedirectResponse {
+        $payload = $parseAction->handle($request->file('file'), $request->validated('sections'), for_new_map: true);
+
+        $map = $importAction->handle(
+            $this->user->active_character,
+            $payload,
+            $request->validated('name'),
+        );
+
+        return to_route('maps.settings.general.show', $map)
+            ->notify('Map imported.', sprintf('The map "%s" has been created from the import file.', $map->name));
+    }
+}

--- a/app/Http/Controllers/MapTransferController.php
+++ b/app/Http/Controllers/MapTransferController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Actions\MapTransfer\ExportMapAction;
+use App\Actions\MapTransfer\ImportMapAction;
+use App\Actions\MapTransfer\ParseMapExportFileAction;
+use App\Http\Requests\ExportMapRequest;
+use App\Http\Requests\ImportMapRequest;
+use App\Http\Resources\MapInfoResource;
+use App\Models\Map;
+use App\Models\Signature;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Throwable;
+
+final class MapTransferController extends Controller
+{
+    public function show(Map $map): Response
+    {
+        Gate::authorize('manageAccess', $map);
+
+        return Inertia::render('maps/settings/ShowTransfer', [
+            'map' => $map->toResource(MapInfoResource::class),
+            'permission' => $map->getUserPermission(auth()->user())?->value,
+            'counts' => [
+                'access' => $map->mapAccessors()->where('is_owner', false)->count(),
+                'solarsystems' => $map->mapSolarsystemDetails()->count(),
+                'connections' => $map->mapConnections()->count(),
+                'signatures' => Signature::query()->whereIn('map_solarsystem_id', $map->mapSolarsystems()->select('id'))->count(),
+                'routes' => $map->mapRouteSolarsystems()->count() + $map->mapIgnoredSolarsystems()->count(),
+            ],
+        ]);
+    }
+
+    public function export(ExportMapRequest $request, Map $map, ExportMapAction $action): StreamedResponse
+    {
+        $payload = $action->handle($map, $request->validated('sections'));
+
+        return response()->streamDownload(
+            fn () => print json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            sprintf('%s-export-%s.json', $map->slug, now()->format('Y-m-d')),
+            ['Content-Type' => 'application/json'],
+        );
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function import(
+        ImportMapRequest $request,
+        Map $map,
+        ParseMapExportFileAction $parseAction,
+        ImportMapAction $importAction,
+    ): RedirectResponse {
+        $payload = $parseAction->handle($request->file('file'), $request->validated('sections'));
+
+        $summary = $importAction->handle($map, $payload);
+
+        return back()->notify('Import complete.', $summary->describe());
+    }
+}

--- a/app/Http/Requests/ExportMapRequest.php
+++ b/app/Http/Requests/ExportMapRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Models\Map;
+use Illuminate\Container\Attributes\RouteParameter;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class ExportMapRequest extends FormRequest
+{
+    public function __construct(#[RouteParameter('map')] public Map $map)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Exports carry notes and the full access roster, so only managers may pull them.
+     */
+    public function authorize(): bool
+    {
+        return (bool) $this->user()?->can('manageAccess', $this->map);
+    }
+
+    /**
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'sections' => ['required', 'array', 'min:1'],
+            'sections.*' => ['string', Rule::in(['settings', 'access', 'solarsystems', 'connections', 'signatures', 'routes'])],
+        ];
+    }
+}

--- a/app/Http/Requests/ImportMapRequest.php
+++ b/app/Http/Requests/ImportMapRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Models\Map;
+use Illuminate\Container\Attributes\RouteParameter;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class ImportMapRequest extends FormRequest
+{
+    public function __construct(#[RouteParameter('map')] public Map $map)
+    {
+        parent::__construct();
+    }
+
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if (! $user?->can('updateSettings', $this->map)) {
+            return false;
+        }
+
+        if (in_array('access', (array) $this->input('sections', []), true)) {
+            return (bool) $user->can('manageAccess', $this->map);
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'file' => ['required', 'file', 'max:5120', 'mimetypes:application/json,text/plain'],
+            'sections' => ['required', 'array', 'min:1'],
+            'sections.*' => ['string', Rule::in(['settings', 'access', 'solarsystems', 'connections', 'signatures', 'routes'])],
+        ];
+    }
+}

--- a/app/Http/Requests/ImportNewMapRequest.php
+++ b/app/Http/Requests/ImportNewMapRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Models\Map;
+use App\Models\User;
+use Illuminate\Container\Attributes\CurrentUser;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class ImportNewMapRequest extends FormRequest
+{
+    public function authorize(#[CurrentUser] User $user): bool
+    {
+        return $user->can('create', Map::class) && $user->active_character !== null;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'file' => ['required', 'file', 'max:5120', 'mimetypes:application/json,text/plain'],
+            'sections' => ['required', 'array', 'min:1'],
+            'sections.*' => ['string', Rule::in(['settings', 'access', 'solarsystems', 'connections', 'signatures', 'routes'])],
+            'name' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Models/Map.php
+++ b/app/Models/Map.php
@@ -25,6 +25,8 @@ use function sprintf;
  * @property int $id
  * @property string $name
  * @property bool $is_public
+ * @property MapLayout $layout
+ * @property bool $allow_layout_override
  * @property bool $constant_width_enabled
  * @property string|null $share_token
  * @property int|null $home_solarsystem_id
@@ -46,7 +48,7 @@ use function sprintf;
  * @property-read Collection<int,MapWebhookRole> $mapWebhookRoles
  * @property-read Collection<int,MapAlert> $mapAlerts
  * @property-read null|MapUserSetting $mapUserSetting
- * @property-read MapAccess $mapOwner
+ * @property-read MapAccess|null $mapOwner
  */
 final class Map extends Model
 {

--- a/app/Models/MapConnection.php
+++ b/app/Models/MapConnection.php
@@ -34,7 +34,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string|ShipSize $ship_size
  * @property LifetimeStatus $lifetime
  * @property DateTimeImmutable|string|null $lifetime_updated_at
- * @property CarbonImmutable $connected_at
+ * @property CarbonImmutable|null $connected_at
  * @property-read string|CarbonImmutable $created_at
  * @property-read string|CarbonImmutable $updated_at
  * @property-read MapSolarsystem $fromMapSolarsystem
@@ -106,6 +106,8 @@ final class MapConnection extends Model
 
     /**
      * The wormhole associated with this connection.
+     *
+     * @return BelongsTo<Wormhole, $this>
      */
     public function wormhole(): BelongsTo
     {

--- a/app/Models/Signature.php
+++ b/app/Models/Signature.php
@@ -8,7 +8,10 @@ use App\Enums\LifetimeStatus;
 use App\Enums\MassStatus;
 use App\Enums\ShipSize;
 use Carbon\CarbonImmutable;
+use Database\Factories\SignatureFactory;
 use DateTimeImmutable;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -16,7 +19,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * Signature model representing a signature in the game.
  *
  * @property int $id
- * @property string $signature_id
+ * @property string|null $signature_id
  * @property int $map_solarsystem_id
  * @property int|null $map_connection_id
  * @property int|null $wormhole_id
@@ -35,8 +38,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property-read SignatureType|null $signatureType
  * @property-read SignatureCategory|null $signatureCategory
  */
+#[UseFactory(SignatureFactory::class)]
 final class Signature extends Model
 {
+    /** @use HasFactory<SignatureFactory> */
+    use HasFactory;
+
     protected $casts = [
         'created_at' => 'immutable_datetime',
         'updated_at' => 'immutable_datetime',

--- a/database/factories/SignatureFactory.php
+++ b/database/factories/SignatureFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\LifetimeStatus;
+use App\Models\MapSolarsystem;
+use App\Models\Signature;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Signature>
+ */
+final class SignatureFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'map_solarsystem_id' => MapSolarsystem::factory(),
+            'signature_id' => sprintf('%s-%03d', mb_strtoupper($this->faker->lexify('???')), $this->faker->numberBetween(0, 999)),
+            'lifetime' => LifetimeStatus::Healthy,
+        ];
+    }
+}

--- a/resources/js/layouts/SettingsLayout.vue
+++ b/resources/js/layouts/SettingsLayout.vue
@@ -5,6 +5,7 @@ import MapIgnoredSolarsystemController from '@/actions/App/Http/Controllers/MapI
 import MapPreferencesController from '@/actions/App/Http/Controllers/MapPreferencesController';
 import MapRoutingSettingsController from '@/actions/App/Http/Controllers/MapRoutingSettingsController';
 import MapSettingsController from '@/actions/App/Http/Controllers/MapSettingsController';
+import MapTransferController from '@/actions/App/Http/Controllers/MapTransferController';
 import DiscordIcon from '@/components/icons/DiscordIcon.vue';
 import { Button } from '@/components/ui/button';
 import usePermission from '@/composables/usePermission';
@@ -12,7 +13,7 @@ import AppLayout from '@/layouts/AppLayout.vue';
 import SeoHead from '@/layouts/SeoHead.vue';
 import { TMapSummary } from '@/pages/maps';
 import { Link, usePage } from '@inertiajs/vue3';
-import { ArrowLeft, Crosshair, Route, Settings, User, Users } from 'lucide-vue-next';
+import { ArrowLeft, ArrowLeftRight, Crosshair, Route, Settings, User, Users } from 'lucide-vue-next';
 import { computed } from 'vue';
 
 interface Props {
@@ -80,6 +81,16 @@ const navigationItems = computed(() => {
             href: MapDiscordController.show(props.map.slug),
             icon: DiscordIcon,
             description: 'Alerts, delivery, and oversight',
+        });
+    }
+
+    // Transfer - Manager+ only
+    if (canManageAccess.value) {
+        items.push({
+            name: 'Import / Export',
+            href: MapTransferController.show(props.map.slug),
+            icon: ArrowLeftRight,
+            description: 'Move map data in and out',
         });
     }
 

--- a/resources/js/pages/maps/settings/ShowTransfer.vue
+++ b/resources/js/pages/maps/settings/ShowTransfer.vue
@@ -1,0 +1,450 @@
+<script setup lang="ts">
+import MapImportController from '@/actions/App/Http/Controllers/MapImportController';
+import MapTransferController from '@/actions/App/Http/Controllers/MapTransferController';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import SettingsLayout from '@/layouts/SettingsLayout.vue';
+import { TMapSummary } from '@/pages/maps';
+import { router } from '@inertiajs/vue3';
+import {
+    Check,
+    Download,
+    FileJson,
+    FilePlus2,
+    Loader2,
+    Orbit,
+    Radar,
+    Route,
+    SlidersHorizontal,
+    Upload,
+    Users,
+    Waypoints,
+    type LucideIcon,
+} from 'lucide-vue-next';
+import { computed, ref, useTemplateRef } from 'vue';
+
+const { map, counts } = defineProps<{
+    map: TMapSummary;
+    counts: Record<string, number>;
+}>();
+
+type TSectionKey = 'settings' | 'access' | 'solarsystems' | 'connections' | 'signatures' | 'routes';
+
+const sections: { key: TSectionKey; label: string; description: string; icon: LucideIcon }[] = [
+    { key: 'settings', label: 'Map settings', description: 'Name, layout, bookmark formats', icon: SlidersHorizontal },
+    { key: 'access', label: 'Access', description: 'Characters, corporations, alliances', icon: Users },
+    { key: 'solarsystems', label: 'Solar systems', description: 'Positions, notes, statuses', icon: Orbit },
+    { key: 'connections', label: 'Connections', description: 'Wormholes between systems', icon: Waypoints },
+    { key: 'signatures', label: 'Signatures', description: 'Scan results per system', icon: Radar },
+    { key: 'routes', label: 'Routes', description: 'Route and ignored systems', icon: Route },
+];
+
+function toggleSection(selection: TSectionKey[], key: TSectionKey) {
+    const index = selection.indexOf(key);
+    if (index === -1) {
+        selection.push(key);
+    } else {
+        selection.splice(index, 1);
+    }
+}
+
+/* Export */
+
+const export_sections = ref<TSectionKey[]>(sections.map((section) => section.key));
+
+function downloadExport() {
+    const params = new URLSearchParams();
+    export_sections.value.forEach((section) => params.append('sections[]', section));
+    window.location.href = `${MapTransferController.export(map.slug).url}?${params.toString()}`;
+}
+
+/* Import */
+
+type TFilePreview = {
+    map_name: string;
+    exported_at: string | null;
+    sections: Partial<Record<TSectionKey, number | null>>;
+};
+
+const steps = [
+    { number: 1, label: 'File' },
+    { number: 2, label: 'Destination' },
+    { number: 3, label: 'Review' },
+];
+
+const step = ref(1);
+const file_input = useTemplateRef<HTMLInputElement>('file-input');
+const selected_file = ref<File | null>(null);
+const preview = ref<TFilePreview | null>(null);
+const parse_error = ref<string | null>(null);
+const is_dragging = ref(false);
+const destination = ref<'merge' | 'new'>('merge');
+const new_map_name = ref('');
+const import_sections = ref<TSectionKey[]>([]);
+const server_error = ref<string | null>(null);
+const is_importing = ref(false);
+
+const available_sections = computed(() => sections.filter((section) => preview.value && section.key in preview.value.sections));
+
+const exported_date = computed(() => {
+    if (!preview.value?.exported_at) return null;
+    const date = new Date(preview.value.exported_at);
+    return Number.isNaN(date.getTime()) ? null : date.toLocaleDateString();
+});
+
+function onFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = '';
+    if (file) readFile(file);
+}
+
+function onFileDropped(event: DragEvent) {
+    is_dragging.value = false;
+    const file = event.dataTransfer?.files?.[0];
+    if (file) readFile(file);
+}
+
+async function readFile(file: File) {
+    parse_error.value = null;
+    server_error.value = null;
+
+    let data: unknown;
+    try {
+        data = JSON.parse(await file.text());
+    } catch {
+        parse_error.value = 'This file is not valid JSON.';
+        return;
+    }
+
+    const payload = data as { format?: string; version?: number; map_name?: string; exported_at?: string; sections?: Record<string, unknown> };
+
+    if (payload?.format !== 'wormholesystems-map-export') {
+        parse_error.value = 'This file is not a wormholesystems map export.';
+        return;
+    }
+
+    if (payload.version !== 1) {
+        parse_error.value = 'This file was exported by an incompatible version of the application.';
+        return;
+    }
+
+    const file_sections: TFilePreview['sections'] = {};
+    for (const section of sections) {
+        const value = payload.sections?.[section.key];
+        if (value === undefined) continue;
+        if (section.key === 'routes') {
+            const routes = value as { route_solarsystems?: unknown[]; ignored_solarsystems?: unknown[] };
+            file_sections.routes = (routes?.route_solarsystems?.length ?? 0) + (routes?.ignored_solarsystems?.length ?? 0);
+        } else if (Array.isArray(value)) {
+            file_sections[section.key] = value.length;
+        } else {
+            file_sections[section.key] = null;
+        }
+    }
+
+    if (Object.keys(file_sections).length === 0) {
+        parse_error.value = 'This file does not contain any importable sections.';
+        return;
+    }
+
+    selected_file.value = file;
+    preview.value = {
+        map_name: payload.map_name ?? 'Unnamed map',
+        exported_at: payload.exported_at ?? null,
+        sections: file_sections,
+    };
+    import_sections.value = Object.keys(file_sections) as TSectionKey[];
+    step.value = 2;
+}
+
+function resetImport() {
+    step.value = 1;
+    selected_file.value = null;
+    preview.value = null;
+    parse_error.value = null;
+    server_error.value = null;
+    destination.value = 'merge';
+    new_map_name.value = '';
+    import_sections.value = [];
+}
+
+function submitImport() {
+    if (!selected_file.value || import_sections.value.length === 0) return;
+
+    is_importing.value = true;
+    server_error.value = null;
+
+    const shared = {
+        forceFormData: true,
+        preserveScroll: true,
+        onError: (errors: Record<string, string>) => {
+            server_error.value = errors.file ?? errors.name ?? Object.values(errors)[0] ?? null;
+        },
+        onSuccess: () => resetImport(),
+        onFinish: () => {
+            is_importing.value = false;
+        },
+    };
+
+    if (destination.value === 'merge') {
+        router.post(MapTransferController.import(map.slug).url, { file: selected_file.value, sections: import_sections.value }, shared);
+    } else {
+        router.post(
+            MapImportController.store().url,
+            { file: selected_file.value, sections: import_sections.value, name: new_map_name.value || null },
+            shared,
+        );
+    }
+}
+</script>
+
+<template>
+    <SettingsLayout :map="map" title="Import / Export" description="Move map data between maps and installations">
+        <Card>
+            <CardContent class="pt-6">
+                <Tabs default-value="export">
+                    <TabsList class="grid w-full max-w-xs grid-cols-2">
+                        <TabsTrigger value="export">
+                            <Download class="mr-2 size-4" />
+                            Export
+                        </TabsTrigger>
+                        <TabsTrigger value="import">
+                            <Upload class="mr-2 size-4" />
+                            Import
+                        </TabsTrigger>
+                    </TabsList>
+
+                    <!-- Export -->
+                    <TabsContent value="export" class="mt-6">
+                        <div class="space-y-6">
+                            <div>
+                                <h3 class="text-sm font-medium">Choose what travels</h3>
+                                <p class="mt-1 text-xs text-muted-foreground">
+                                    Share links, webhook URLs, and personal preferences are never included.
+                                </p>
+                            </div>
+
+                            <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                                <button
+                                    v-for="section in sections"
+                                    :key="`export-${section.key}`"
+                                    type="button"
+                                    class="group relative flex items-start gap-3 rounded-lg border p-3 text-left transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                                    :class="
+                                        export_sections.includes(section.key)
+                                            ? 'border-primary/50 bg-primary/5'
+                                            : 'border-border/60 hover:bg-muted/40'
+                                    "
+                                    @click="toggleSection(export_sections, section.key)"
+                                >
+                                    <component
+                                        :is="section.icon"
+                                        class="mt-0.5 size-4 shrink-0"
+                                        :class="export_sections.includes(section.key) ? 'text-primary' : 'text-muted-foreground'"
+                                    />
+                                    <span class="min-w-0">
+                                        <span class="block text-sm font-medium">{{ section.label }}</span>
+                                        <span class="block truncate text-xs text-muted-foreground">{{ section.description }}</span>
+                                    </span>
+                                    <span v-if="counts[section.key] !== undefined" class="ml-auto text-xs text-muted-foreground tabular-nums">
+                                        {{ counts[section.key] }}
+                                    </span>
+                                    <span
+                                        class="absolute -top-1.5 -right-1.5 flex size-4 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity"
+                                        :class="export_sections.includes(section.key) ? 'opacity-100' : 'opacity-0'"
+                                    >
+                                        <Check class="size-3" />
+                                    </span>
+                                </button>
+                            </div>
+
+                            <div class="flex items-center justify-between border-t border-border/50 pt-4">
+                                <p class="text-xs text-muted-foreground">{{ export_sections.length }} of {{ sections.length }} sections selected</p>
+                                <Button :disabled="export_sections.length === 0" @click="downloadExport">
+                                    <Download class="mr-2 size-4" />
+                                    Download export
+                                </Button>
+                            </div>
+                        </div>
+                    </TabsContent>
+
+                    <!-- Import -->
+                    <TabsContent value="import" class="mt-6">
+                        <div class="space-y-6">
+                            <!-- Step rail -->
+                            <ol class="flex items-center gap-2">
+                                <template v-for="(item, index) in steps" :key="item.number">
+                                    <li class="flex items-center gap-2">
+                                        <span
+                                            class="flex size-6 items-center justify-center rounded-full text-xs font-medium transition-colors"
+                                            :class="{
+                                                'bg-primary text-primary-foreground': step === item.number,
+                                                'bg-primary/15 text-primary': step > item.number,
+                                                'bg-muted text-muted-foreground': step < item.number,
+                                            }"
+                                        >
+                                            <Check v-if="step > item.number" class="size-3.5" />
+                                            <template v-else>{{ item.number }}</template>
+                                        </span>
+                                        <span class="text-sm" :class="step === item.number ? 'font-medium' : 'text-muted-foreground'">
+                                            {{ item.label }}
+                                        </span>
+                                    </li>
+                                    <li v-if="index < steps.length - 1" class="h-px flex-1 bg-border" aria-hidden="true" />
+                                </template>
+                            </ol>
+
+                            <!-- Step 1: File -->
+                            <div v-if="step === 1" class="space-y-3">
+                                <input ref="file-input" type="file" accept="application/json,.json" class="hidden" @change="onFileSelected" />
+                                <button
+                                    type="button"
+                                    class="flex w-full flex-col items-center justify-center gap-3 rounded-lg border border-dashed px-6 py-12 transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                                    :class="is_dragging ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted/30'"
+                                    @click="file_input?.click()"
+                                    @dragover.prevent="is_dragging = true"
+                                    @dragleave="is_dragging = false"
+                                    @drop.prevent="onFileDropped"
+                                >
+                                    <FileJson class="size-8 text-muted-foreground" />
+                                    <span class="text-sm font-medium">Drop an export file here, or click to browse</span>
+                                    <span class="text-xs text-muted-foreground">JSON exports from any wormholesystems map, up to 5 MB</span>
+                                </button>
+                                <p v-if="parse_error" class="text-sm text-red-500">{{ parse_error }}</p>
+                            </div>
+
+                            <!-- Step 2: Destination -->
+                            <div v-else-if="step === 2 && preview" class="space-y-4">
+                                <div class="flex items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3">
+                                    <FileJson class="size-5 shrink-0 text-muted-foreground" />
+                                    <div class="min-w-0">
+                                        <p class="truncate text-sm font-medium">{{ preview.map_name }}</p>
+                                        <p class="text-xs text-muted-foreground">
+                                            {{ selected_file?.name }}<template v-if="exported_date"> · exported {{ exported_date }}</template>
+                                        </p>
+                                    </div>
+                                </div>
+
+                                <div class="grid gap-2 sm:grid-cols-2">
+                                    <button
+                                        type="button"
+                                        class="flex items-start gap-3 rounded-lg border p-4 text-left transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                                        :class="destination === 'merge' ? 'border-primary/50 bg-primary/5' : 'border-border/60 hover:bg-muted/40'"
+                                        @click="destination = 'merge'"
+                                    >
+                                        <Upload
+                                            class="mt-0.5 size-5 shrink-0"
+                                            :class="destination === 'merge' ? 'text-primary' : 'text-muted-foreground'"
+                                        />
+                                        <span>
+                                            <span class="block text-sm font-medium">Merge into "{{ map.name }}"</span>
+                                            <span class="block text-xs text-muted-foreground">
+                                                Matching systems, signatures, and settings are overwritten
+                                            </span>
+                                        </span>
+                                    </button>
+                                    <button
+                                        type="button"
+                                        class="flex items-start gap-3 rounded-lg border p-4 text-left transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                                        :class="destination === 'new' ? 'border-primary/50 bg-primary/5' : 'border-border/60 hover:bg-muted/40'"
+                                        @click="destination = 'new'"
+                                    >
+                                        <FilePlus2
+                                            class="mt-0.5 size-5 shrink-0"
+                                            :class="destination === 'new' ? 'text-primary' : 'text-muted-foreground'"
+                                        />
+                                        <span>
+                                            <span class="block text-sm font-medium">Create a new map</span>
+                                            <span class="block text-xs text-muted-foreground">A fresh map owned by you, nothing here is touched</span>
+                                        </span>
+                                    </button>
+                                </div>
+
+                                <div v-if="destination === 'new'">
+                                    <Label for="new-map-name" class="text-sm font-medium">Map name</Label>
+                                    <Input id="new-map-name" v-model="new_map_name" :placeholder="preview.map_name" class="mt-2 max-w-sm" />
+                                    <p class="mt-1 text-xs text-muted-foreground">Leave empty to keep the name from the file</p>
+                                </div>
+
+                                <div class="flex items-center justify-between border-t border-border/50 pt-4">
+                                    <Button variant="ghost" @click="resetImport">Back</Button>
+                                    <Button @click="step = 3">Continue</Button>
+                                </div>
+                            </div>
+
+                            <!-- Step 3: Review -->
+                            <div v-else-if="step === 3 && preview" class="space-y-4">
+                                <div>
+                                    <h3 class="text-sm font-medium">Choose what to import</h3>
+                                    <p class="mt-1 text-xs text-muted-foreground">Only sections present in the file are shown</p>
+                                </div>
+
+                                <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                                    <button
+                                        v-for="section in available_sections"
+                                        :key="`import-${section.key}`"
+                                        type="button"
+                                        class="group relative flex items-start gap-3 rounded-lg border p-3 text-left transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                                        :class="
+                                            import_sections.includes(section.key)
+                                                ? 'border-primary/50 bg-primary/5'
+                                                : 'border-border/60 hover:bg-muted/40'
+                                        "
+                                        @click="toggleSection(import_sections, section.key)"
+                                    >
+                                        <component
+                                            :is="section.icon"
+                                            class="mt-0.5 size-4 shrink-0"
+                                            :class="import_sections.includes(section.key) ? 'text-primary' : 'text-muted-foreground'"
+                                        />
+                                        <span class="min-w-0">
+                                            <span class="block text-sm font-medium">{{ section.label }}</span>
+                                            <span class="block truncate text-xs text-muted-foreground">{{ section.description }}</span>
+                                        </span>
+                                        <span
+                                            v-if="preview.sections[section.key] !== null"
+                                            class="ml-auto text-xs text-muted-foreground tabular-nums"
+                                        >
+                                            {{ preview.sections[section.key] }}
+                                        </span>
+                                        <span
+                                            class="absolute -top-1.5 -right-1.5 flex size-4 items-center justify-center rounded-full bg-primary text-primary-foreground transition-opacity"
+                                            :class="import_sections.includes(section.key) ? 'opacity-100' : 'opacity-0'"
+                                        >
+                                            <Check class="size-3" />
+                                        </span>
+                                    </button>
+                                </div>
+
+                                <p v-if="destination === 'merge'" class="text-xs text-muted-foreground">
+                                    Matching entries on "{{ map.name }}" will be overwritten. Existing connections are kept.
+                                </p>
+                                <p v-else class="text-xs text-muted-foreground">
+                                    A new map named "{{ new_map_name || preview.map_name }}" will be created, owned by you.
+                                </p>
+
+                                <p v-if="server_error" class="text-sm text-red-500">{{ server_error }}</p>
+
+                                <div class="flex items-center justify-between border-t border-border/50 pt-4">
+                                    <Button variant="ghost" :disabled="is_importing" @click="step = 2">Back</Button>
+                                    <Button
+                                        :variant="destination === 'merge' ? 'destructive' : 'default'"
+                                        :disabled="import_sections.length === 0 || is_importing"
+                                        @click="submitImport"
+                                    >
+                                        <Loader2 v-if="is_importing" class="mr-2 size-4 animate-spin" />
+                                        {{ destination === 'merge' ? `Import into "${map.name}"` : 'Create map' }}
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
+                    </TabsContent>
+                </Tabs>
+            </CardContent>
+        </Card>
+    </SettingsLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\MapConnectionJumpController;
 use App\Http\Controllers\MapController;
 use App\Http\Controllers\MapDiscordController;
 use App\Http\Controllers\MapIgnoredSolarsystemController;
+use App\Http\Controllers\MapImportController;
 use App\Http\Controllers\MapLayoutController;
 use App\Http\Controllers\MapPreferencesController;
 use App\Http\Controllers\MapRouteSolarsystemController;
@@ -34,6 +35,7 @@ use App\Http\Controllers\MapSearchController;
 use App\Http\Controllers\MapSelectionController;
 use App\Http\Controllers\MapSettingsController;
 use App\Http\Controllers\MapSolarsystemController;
+use App\Http\Controllers\MapTransferController;
 use App\Http\Controllers\MapUserSettingController;
 use App\Http\Controllers\MapWebhookController;
 use App\Http\Controllers\MapWebhookRoleController;
@@ -94,7 +96,13 @@ Route::middleware('auth')->group(function () {
         Route::get('mapping', [MapIgnoredSolarsystemController::class, 'show'])->name('mapping.show');
 
         Route::get('discord', [MapDiscordController::class, 'show'])->name('discord.show');
+
+        Route::get('transfer', [MapTransferController::class, 'show'])->name('transfer.show');
+        Route::get('transfer/export', [MapTransferController::class, 'export'])->name('transfer.export');
+        Route::post('transfer/import', [MapTransferController::class, 'import'])->name('transfer.import');
     });
+
+    Route::post('maps/import', [MapImportController::class, 'store'])->name('maps.import.store');
 
     Route::delete('logout', [AuthController::class, 'destroy'])->name('logout');
 

--- a/tests/Feature/MapTransfer/MapExportTest.php
+++ b/tests/Feature/MapTransfer/MapExportTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Permission;
+use App\Models\Character;
+use App\Models\Corporation;
+use App\Models\Map;
+use App\Models\MapAccess;
+use App\Models\MapConnection;
+use App\Models\MapIgnoredSolarsystem;
+use App\Models\MapRouteSolarsystem;
+use App\Models\MapSolarsystemDetails;
+use App\Models\Signature;
+use App\Models\SignatureCategory;
+use App\Models\SignatureType;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+function transferExportUser(Map $map, Permission $permission): User
+{
+    $user = User::factory()
+        ->has(Character::factory()->has(MapAccess::factory(['permission' => $permission])->for($map)))
+        ->create();
+
+    $user->forceFill(['preferred_character_id' => $user->characters()->value('id')])->save();
+
+    return $user->refresh();
+}
+
+function transferExportPayload(Map $map, array $sections): array
+{
+    $response = actingAs(transferExportUser($map, Permission::Manager))
+        ->get(route('maps.settings.transfer.export', ['map' => $map, 'sections' => $sections]))
+        ->assertSuccessful();
+
+    return json_decode($response->streamedContent(), true);
+}
+
+it('shows the transfer page with section counts for managers', function () {
+    $map = Map::factory()->create();
+    MapAccess::factory()->for($map)->create([
+        'accessible_type' => Character::class,
+        'accessible_id' => Character::factory()->create()->id,
+        'permission' => Permission::Manager,
+        'is_owner' => true,
+    ]);
+    $from = placeMapSolarsystem($map, 31000406);
+    $to = placeMapSolarsystem($map, 31000407);
+    MapConnection::factory()->create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $from->id,
+        'to_map_solarsystem_id' => $to->id,
+    ]);
+    Signature::factory()->create(['map_solarsystem_id' => $from->id]);
+
+    actingAs(transferExportUser($map, Permission::Manager))
+        ->get(route('maps.settings.transfer.show', $map))
+        ->assertSuccessful()
+        ->assertInertia(
+            fn ($page) => $page
+                ->component('maps/settings/ShowTransfer')
+                ->where('counts.solarsystems', 2)
+                ->where('counts.connections', 1)
+                ->where('counts.signatures', 1)
+                ->where('counts.access', 1)
+                ->where('counts.routes', 0),
+        );
+});
+
+it('lets a manager download a versioned export', function () {
+    $map = Map::factory()->create(['share_token' => 'secret-token']);
+    placeMapSolarsystem($map, 31000401);
+
+    $response = actingAs(transferExportUser($map, Permission::Manager))
+        ->get(route('maps.settings.transfer.export', ['map' => $map, 'sections' => ['settings', 'solarsystems']]))
+        ->assertSuccessful()
+        ->assertDownload();
+
+    $payload = json_decode($response->streamedContent(), true);
+
+    expect($payload['format'])->toBe('wormholesystems-map-export')
+        ->and($payload['version'])->toBe(1)
+        ->and($payload['exported_at'])->not->toBeNull()
+        ->and($payload['map_name'])->toBe($map->name)
+        ->and(json_encode($payload))->not->toContain('secret-token');
+});
+
+it('denies members and guests', function () {
+    $map = Map::factory()->create();
+
+    $this->get(route('maps.settings.transfer.export', ['map' => $map, 'sections' => ['settings']]))
+        ->assertRedirect();
+
+    actingAs(transferExportUser($map, Permission::Member))
+        ->get(route('maps.settings.transfer.export', ['map' => $map, 'sections' => ['settings']]))
+        ->assertForbidden();
+});
+
+it('includes only the selected sections', function () {
+    $map = Map::factory()->create();
+    placeMapSolarsystem($map, 31000402);
+
+    $payload = transferExportPayload($map, ['solarsystems']);
+
+    expect($payload['sections'])->toHaveKey('solarsystems')
+        ->and($payload['sections'])->not->toHaveKeys(['settings', 'access', 'connections', 'signatures', 'routes']);
+});
+
+it('exports access entries without the owner row', function () {
+    $map = Map::factory()->create();
+    $corporation = Corporation::factory()->create(['name' => 'Krab Horizon']);
+    MapAccess::factory()->for($map)->create([
+        'accessible_type' => Corporation::class,
+        'accessible_id' => $corporation->id,
+        'permission' => Permission::Member,
+        'is_owner' => false,
+    ]);
+    $owner_character = Character::factory()->create();
+    MapAccess::factory()->for($map)->create([
+        'accessible_type' => Character::class,
+        'accessible_id' => $owner_character->id,
+        'permission' => Permission::Manager,
+        'is_owner' => true,
+    ]);
+
+    $payload = transferExportPayload($map, ['access']);
+
+    expect($payload['sections']['access'])->toHaveCount(2)
+        ->and(collect($payload['sections']['access'])->pluck('entity_id'))->not->toContain($owner_character->id)
+        ->and(collect($payload['sections']['access'])->firstWhere('entity_type', 'corporation'))
+        ->toMatchArray(['entity_id' => $corporation->id, 'entity_name' => 'Krab Horizon', 'permission' => 'member']);
+});
+
+it('exports connections by wormhole name and signatures by connection index', function () {
+    $map = Map::factory()->create();
+    $from = placeMapSolarsystem($map, 31000403);
+    $to = placeMapSolarsystem($map, 31000404);
+    $wormhole = makeWormhole('H296');
+    $connection = MapConnection::factory()->create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $from->id,
+        'to_map_solarsystem_id' => $to->id,
+        'wormhole_id' => $wormhole->id,
+    ]);
+    $category = SignatureCategory::query()->where('code', 'wormhole')->firstOrFail();
+    $type = SignatureType::query()->firstOrCreate(['name' => 'H296 - C5', 'signature_category_id' => $category->id]);
+    Signature::factory()->create([
+        'map_solarsystem_id' => $from->id,
+        'signature_id' => 'ABC-123',
+        'map_connection_id' => $connection->id,
+        'wormhole_id' => $wormhole->id,
+        'signature_category_id' => $category->id,
+        'signature_type_id' => $type->id,
+    ]);
+
+    $payload = transferExportPayload($map, ['connections', 'signatures']);
+
+    expect($payload['sections']['connections'])->toHaveCount(1)
+        ->and($payload['sections']['connections'][0])->toMatchArray([
+            'from_solarsystem_id' => 31000403,
+            'to_solarsystem_id' => 31000404,
+            'wormhole' => 'H296',
+        ])
+        ->and($payload['sections']['signatures'][0])->toMatchArray([
+            'solarsystem_id' => 31000403,
+            'signature_id' => 'ABC-123',
+            'category' => 'wormhole',
+            'type_name' => 'H296 - C5',
+            'wormhole' => 'H296',
+            'connection_index' => 0,
+        ]);
+});
+
+it('exports details-only systems with null positions', function () {
+    $map = Map::factory()->create();
+    makeSolarsystem(31000405);
+    MapSolarsystemDetails::factory()->create([
+        'map_id' => $map->id,
+        'solarsystem_id' => 31000405,
+        'notes' => 'Old staging intel.',
+    ]);
+
+    $payload = transferExportPayload($map, ['solarsystems']);
+
+    expect($payload['sections']['solarsystems'])->toHaveCount(1)
+        ->and($payload['sections']['solarsystems'][0])->toMatchArray([
+            'solarsystem_id' => 31000405,
+            'position_x' => null,
+            'position_y' => null,
+            'notes' => 'Old staging intel.',
+        ]);
+});
+
+it('exports routes and ignored systems', function () {
+    $map = Map::factory()->create();
+    makeSolarsystem(30000142);
+    makeSolarsystem(30002187);
+    MapRouteSolarsystem::factory()->create(['map_id' => $map->id, 'solarsystem_id' => 30000142, 'is_pinned' => true]);
+    MapIgnoredSolarsystem::factory()->create(['map_id' => $map->id, 'solarsystem_id' => 30002187]);
+
+    $payload = transferExportPayload($map, ['routes']);
+
+    expect($payload['sections']['routes']['route_solarsystems'])->toBe([['solarsystem_id' => 30000142, 'is_pinned' => true]])
+        ->and($payload['sections']['routes']['ignored_solarsystems'])->toBe([['solarsystem_id' => 30002187]]);
+});

--- a/tests/Feature/MapTransfer/MapImportMergeTest.php
+++ b/tests/Feature/MapTransfer/MapImportMergeTest.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MapSolarsystemStatus;
+use App\Enums\Permission;
+use App\Events\Maps\MapResyncEvent;
+use App\Models\Character;
+use App\Models\Corporation;
+use App\Models\Map;
+use App\Models\MapAccess;
+use App\Models\MapConnection;
+use App\Models\MapSolarsystem;
+use App\Models\MapSolarsystemDetails;
+use App\Models\Signature;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
+
+use function Pest\Laravel\actingAs;
+
+function transferMergeUser(Map $map, Permission $permission): User
+{
+    $user = User::factory()
+        ->has(Character::factory()->has(MapAccess::factory(['permission' => $permission])->for($map)))
+        ->create();
+
+    $user->forceFill(['preferred_character_id' => $user->characters()->value('id')])->save();
+
+    return $user->refresh();
+}
+
+function transferFile(array $sections, array $overrides = []): UploadedFile
+{
+    $payload = array_merge([
+        'format' => 'wormholesystems-map-export',
+        'version' => 1,
+        'exported_at' => now()->toIso8601String(),
+        'map_name' => 'Imported Map',
+        'sections' => $sections,
+    ], $overrides);
+
+    return UploadedFile::fake()->createWithContent('export.json', json_encode($payload));
+}
+
+function transferSystemEntry(int $solarsystem_id, array $overrides = []): array
+{
+    return array_merge([
+        'solarsystem_id' => $solarsystem_id,
+        'alias' => null,
+        'position_x' => 100,
+        'position_y' => 100,
+        'pinned' => false,
+        'status' => MapSolarsystemStatus::Unknown->value,
+        'occupier_alias' => null,
+        'notes' => null,
+    ], $overrides);
+}
+
+function transferConnectionEntry(int $from, int $to, array $overrides = []): array
+{
+    return array_merge([
+        'from_solarsystem_id' => $from,
+        'to_solarsystem_id' => $to,
+        'wormhole' => null,
+        'type' => 'wormhole',
+        'mass_status' => 'fresh',
+        'ship_size' => 'large',
+        'lifetime' => 'healthy',
+        'lifetime_updated_at' => null,
+        'connected_at' => now()->toIso8601String(),
+        'preserve_mass' => false,
+    ], $overrides);
+}
+
+function transferSignatureEntry(int $solarsystem_id, ?string $signature_id, array $overrides = []): array
+{
+    return array_merge([
+        'solarsystem_id' => $solarsystem_id,
+        'signature_id' => $signature_id,
+        'category' => null,
+        'type_name' => null,
+        'raw_type_name' => null,
+        'wormhole' => null,
+        'connection_index' => null,
+        'mass_status' => null,
+        'ship_size' => null,
+        'lifetime' => 'healthy',
+        'lifetime_updated_at' => null,
+    ], $overrides);
+}
+
+it('merges systems, connections, signatures, routes, and access into the map', function () {
+    Event::fake([MapResyncEvent::class]);
+
+    $map = Map::factory()->create();
+    makeSolarsystem(31000501);
+    makeSolarsystem(31000502);
+    makeSolarsystem(30000142);
+    makeWormhole('H296');
+
+    $file = transferFile([
+        'solarsystems' => [
+            transferSystemEntry(31000501, ['alias' => 'Home', 'notes' => 'Staging.', 'status' => 'friendly']),
+            transferSystemEntry(31000502, ['position_x' => 300, 'position_y' => 200]),
+        ],
+        'connections' => [
+            transferConnectionEntry(31000501, 31000502, ['wormhole' => 'H296']),
+        ],
+        'signatures' => [
+            transferSignatureEntry(31000501, 'ABC-123', ['wormhole' => 'H296', 'connection_index' => 0]),
+        ],
+        'routes' => [
+            'route_solarsystems' => [['solarsystem_id' => 30000142, 'is_pinned' => true]],
+            'ignored_solarsystems' => [['solarsystem_id' => 31000502]],
+        ],
+        'access' => [
+            ['entity_type' => 'corporation', 'entity_id' => 98000001, 'entity_name' => 'Krab Horizon', 'permission' => 'member', 'expires_at' => null],
+        ],
+    ]);
+
+    actingAs(transferMergeUser($map, Permission::Manager))
+        ->post(route('maps.settings.transfer.import', $map), [
+            'file' => $file,
+            'sections' => ['solarsystems', 'connections', 'signatures', 'routes', 'access'],
+        ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $from = $map->mapSolarsystems()->where('solarsystem_id', 31000501)->first();
+    $to = $map->mapSolarsystems()->where('solarsystem_id', 31000502)->first();
+    $connection = $map->mapConnections()->first();
+    $signature = Signature::query()->where('map_solarsystem_id', $from->id)->first();
+
+    expect($from->alias)->toBe('Home')
+        ->and($from->details->notes)->toBe('Staging.')
+        ->and($from->details->status)->toBe(MapSolarsystemStatus::Friendly)
+        ->and($connection->from_map_solarsystem_id)->toBe($from->id)
+        ->and($connection->to_map_solarsystem_id)->toBe($to->id)
+        ->and($connection->wormhole->name)->toBe('H296')
+        ->and($signature->signature_id)->toBe('ABC-123')
+        ->and($signature->map_connection_id)->toBe($connection->id)
+        ->and($map->mapRouteSolarsystems()->pluck('solarsystem_id')->all())->toBe([30000142])
+        ->and($map->mapIgnoredSolarsystems()->pluck('solarsystem_id')->all())->toBe([31000502])
+        ->and(Corporation::query()->find(98000001)->name)->toBe('Krab Horizon')
+        ->and(MapAccess::query()->where('map_id', $map->id)->where('accessible_id', 98000001)->first()->permission)->toBe(Permission::Member);
+
+    Event::assertDispatched(MapResyncEvent::class);
+});
+
+it('denies members', function () {
+    $map = Map::factory()->create();
+
+    actingAs(transferMergeUser($map, Permission::Member))
+        ->post(route('maps.settings.transfer.import', $map), [
+            'file' => transferFile(['solarsystems' => []]),
+            'sections' => ['solarsystems'],
+        ])
+        ->assertForbidden();
+});
+
+it('updates existing systems and signatures in place', function () {
+    $map = Map::factory()->create();
+    $placement = placeMapSolarsystem($map, 31000503);
+    $placement->details->update(['notes' => 'Stale intel.', 'status' => MapSolarsystemStatus::Hostile]);
+    Signature::factory()->create([
+        'map_solarsystem_id' => $placement->id,
+        'signature_id' => 'DEF-456',
+        'raw_type_name' => 'Old Site',
+    ]);
+
+    $file = transferFile([
+        'solarsystems' => [
+            transferSystemEntry(31000503, ['position_x' => 500, 'position_y' => 600, 'notes' => 'Fresh intel.', 'status' => 'friendly']),
+        ],
+        'signatures' => [
+            transferSignatureEntry(31000503, 'DEF-456', ['raw_type_name' => 'New Site']),
+        ],
+    ]);
+
+    actingAs(transferMergeUser($map, Permission::Manager))
+        ->post(route('maps.settings.transfer.import', $map), [
+            'file' => $file,
+            'sections' => ['solarsystems', 'signatures'],
+        ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $placement->refresh();
+
+    expect($placement->position_x)->toBe(500)
+        ->and($placement->position_y)->toBe(600)
+        ->and($placement->details->notes)->toBe('Fresh intel.')
+        ->and($placement->details->status)->toBe(MapSolarsystemStatus::Friendly)
+        ->and($placement->signatures()->count())->toBe(1)
+        ->and($placement->signatures()->first()->raw_type_name)->toBe('New Site');
+});
+
+it('skips a duplicate connection but links signatures to the existing edge', function () {
+    $map = Map::factory()->create();
+    $from = placeMapSolarsystem($map, 31000504);
+    $to = placeMapSolarsystem($map, 31000505);
+    $existing = MapConnection::factory()->create([
+        'map_id' => $map->id,
+        'from_map_solarsystem_id' => $to->id,
+        'to_map_solarsystem_id' => $from->id,
+    ]);
+
+    $file = transferFile([
+        'solarsystems' => [
+            transferSystemEntry(31000504),
+            transferSystemEntry(31000505),
+        ],
+        'connections' => [
+            transferConnectionEntry(31000504, 31000505),
+        ],
+        'signatures' => [
+            transferSignatureEntry(31000504, 'GHI-789', ['connection_index' => 0]),
+        ],
+    ]);
+
+    actingAs(transferMergeUser($map, Permission::Manager))
+        ->post(route('maps.settings.transfer.import', $map), [
+            'file' => $file,
+            'sections' => ['solarsystems', 'connections', 'signatures'],
+        ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    expect($map->mapConnections()->count())->toBe(1)
+        ->and(Signature::query()->where('signature_id', 'GHI-789')->first()->map_connection_id)->toBe($existing->id);
+});
+
+it('never touches the owner access row', function () {
+    $map = Map::factory()->create();
+    $owner_character = Character::factory()->create();
+    MapAccess::factory()->for($map)->create([
+        'accessible_type' => Character::class,
+        'accessible_id' => $owner_character->id,
+        'permission' => Permission::Manager,
+        'is_owner' => true,
+    ]);
+
+    $file = transferFile([
+        'access' => [
+            ['entity_type' => 'character', 'entity_id' => $owner_character->id, 'entity_name' => $owner_character->name, 'permission' => 'viewer', 'expires_at' => null],
+        ],
+    ]);
+
+    actingAs(transferMergeUser($map, Permission::Manager))
+        ->post(route('maps.settings.transfer.import', $map), [
+            'file' => $file,
+            'sections' => ['access'],
+        ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $owner_access = MapAccess::query()
+        ->where('map_id', $map->id)
+        ->where('accessible_id', $owner_character->id)
+        ->first();
+
+    expect($owner_access->is_owner)->toBeTruthy()
+        ->and($owner_access->permission)->toBe(Permission::Manager);
+});
+
+it('nulls unknown wormhole and signature type names but keeps the rows', function () {
+    $map = Map::factory()->create();
+    placeMapSolarsystem($map, 31000506);
+    makeSolarsystem(31000507);
+
+    $file = transferFile([
+        'solarsystems' => [transferSystemEntry(31000507)],
+        'connections' => [
+            transferConnectionEntry(31000506, 31000507, ['wormhole' => 'Z999']),
+        ],
+        'signatures' => [
+            transferSignatureEntry(31000506, 'JKL-012', ['type_name' => 'Unknown Site', 'raw_type_name' => 'Unknown Site']),
+        ],
+    ]);
+
+    actingAs(transferMergeUser($map, Permission::Manager))
+        ->post(route('maps.settings.transfer.import', $map), [
+            'file' => $file,
+            'sections' => ['solarsystems', 'connections', 'signatures'],
+        ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $connection = $map->mapConnections()->first();
+    $signature = Signature::query()->where('signature_id', 'JKL-012')->first();
+
+    expect($connection->wormhole_id)->toBeNull()
+        ->and($signature->signature_type_id)->toBeNull()
+        ->and($signature->raw_type_name)->toBe('Unknown Site');
+});
+
+it('skips connections whose endpoints are missing', function () {
+    $map = Map::factory()->create();
+    placeMapSolarsystem($map, 31000508);
+
+    $file = transferFile([
+        'connections' => [
+            transferConnectionEntry(31000508, 31000999),
+        ],
+    ]);
+
+    actingAs(transferMergeUser($map, Permission::Manager))
+        ->post(route('maps.settings.transfer.import', $map), [
+            'file' => $file,
+            'sections' => ['connections'],
+        ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    expect($map->mapConnections()->count())->toBe(0);
+});
+
+it('imports signatures without a scanned id and does not duplicate them on re-import', function () {
+    $map = Map::factory()->create();
+    placeMapSolarsystem($map, 31000509);
+    makeSolarsystem(31000510);
+
+    $file_sections = [
+        'solarsystems' => [transferSystemEntry(31000510)],
+        'connections' => [transferConnectionEntry(31000509, 31000510)],
+        'signatures' => [
+            transferSignatureEntry(31000509, null, ['connection_index' => 0]),
+        ],
+    ];
+
+    $user = transferMergeUser($map, Permission::Manager);
+
+    foreach (range(1, 2) as $attempt) {
+        actingAs($user)
+            ->post(route('maps.settings.transfer.import', $map), [
+                'file' => transferFile($file_sections),
+                'sections' => ['solarsystems', 'connections', 'signatures'],
+            ])
+            ->assertRedirect()
+            ->assertSessionDoesntHaveErrors();
+    }
+
+    $signatures = Signature::query()->whereNull('signature_id')->get();
+
+    expect($signatures)->toHaveCount(1)
+        ->and($signatures->first()->map_connection_id)->toBe($map->mapConnections()->value('id'));
+});
+
+it('rejects files that are not valid exports', function (UploadedFile $file) {
+    $map = Map::factory()->create();
+
+    actingAs(transferMergeUser($map, Permission::Manager))
+        ->from(route('maps.settings.transfer.show', $map))
+        ->post(route('maps.settings.transfer.import', $map), [
+            'file' => $file,
+            'sections' => ['solarsystems'],
+        ])
+        ->assertRedirect(route('maps.settings.transfer.show', $map))
+        ->assertSessionHasErrors('file');
+
+    expect(MapSolarsystem::query()->count())->toBe(0)
+        ->and(MapSolarsystemDetails::query()->count())->toBe(0);
+})->with([
+    'not JSON' => fn () => UploadedFile::fake()->createWithContent('export.json', 'not json at all'),
+    'wrong format' => fn () => UploadedFile::fake()->createWithContent('export.json', json_encode(['format' => 'other-tool', 'version' => 1, 'sections' => []])),
+    'newer version' => fn () => UploadedFile::fake()->createWithContent('export.json', json_encode(['format' => 'wormholesystems-map-export', 'version' => 2, 'map_name' => 'X', 'sections' => ['solarsystems' => []]])),
+    'missing section' => fn () => transferFile(['settings' => []]),
+    'invalid structure' => fn () => transferFile(['solarsystems' => [['solarsystem_id' => 'not-a-number']]]),
+]);

--- a/tests/Feature/MapTransfer/MapImportNewMapTest.php
+++ b/tests/Feature/MapTransfer/MapImportNewMapTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\MapTransfer\ExportMapAction;
+use App\Enums\MapSolarsystemStatus;
+use App\Enums\Permission;
+use App\Models\Character;
+use App\Models\Corporation;
+use App\Models\Map;
+use App\Models\MapAccess;
+use App\Models\MapConnection;
+use App\Models\Signature;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+
+use function Pest\Laravel\actingAs;
+
+function transferImporter(): User
+{
+    $user = User::factory()->has(Character::factory())->create();
+
+    $user->forceFill(['preferred_character_id' => $user->characters()->value('id')])->save();
+
+    return $user->refresh();
+}
+
+function transferNewMapFile(array $sections, string $map_name = 'Imported Map'): UploadedFile
+{
+    return UploadedFile::fake()->createWithContent('export.json', json_encode([
+        'format' => 'wormholesystems-map-export',
+        'version' => 1,
+        'exported_at' => now()->toIso8601String(),
+        'map_name' => $map_name,
+        'sections' => $sections,
+    ]));
+}
+
+it('creates a new map owned by the importer', function () {
+    makeSolarsystem(31000601);
+    $user = transferImporter();
+
+    $file = transferNewMapFile([
+        'settings' => [
+            'name' => 'Imported Chain',
+            'layout' => 'manual',
+            'allow_layout_override' => true,
+            'constant_width_enabled' => false,
+            'bookmark_format_wormhole' => '{alias}',
+            'bookmark_format_kspace' => '{name}',
+            'bookmark_format_return' => 'return',
+            'bookmark_alias_scheme' => 'numeric',
+            'bookmark_ignored_alias' => null,
+            'home_solarsystem_id' => 31000601,
+            'rally_solarsystem_id' => null,
+        ],
+        'solarsystems' => [
+            [
+                'solarsystem_id' => 31000601,
+                'alias' => 'Home',
+                'position_x' => 120,
+                'position_y' => 340,
+                'pinned' => true,
+                'status' => MapSolarsystemStatus::Friendly->value,
+                'occupier_alias' => 'KRAB',
+                'notes' => 'Imported staging notes.',
+            ],
+        ],
+        'routes' => [
+            'route_solarsystems' => [['solarsystem_id' => 31000601, 'is_pinned' => false]],
+            'ignored_solarsystems' => [],
+        ],
+    ]);
+
+    actingAs($user)
+        ->post(route('maps.import.store'), [
+            'file' => $file,
+            'sections' => ['settings', 'solarsystems', 'routes'],
+        ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $map = Map::query()->where('name', 'Imported Chain')->firstOrFail();
+    $owner = $map->mapOwner;
+
+    expect($owner->accessible_id)->toBe($user->active_character->id)
+        ->and($owner->accessible_type)->toBe(Character::class)
+        ->and($map->share_token)->toBeNull()
+        ->and($map->is_public)->toBeFalse()
+        ->and($map->home_solarsystem_id)->toBe(31000601)
+        ->and($map->mapSolarsystems()->count())->toBe(1)
+        ->and($map->mapSolarsystems()->first()->details->notes)->toBe('Imported staging notes.')
+        ->and($map->mapRouteSolarsystems()->pluck('solarsystem_id')->all())->toBe([31000601]);
+});
+
+it('respects the name override', function () {
+    $user = transferImporter();
+
+    actingAs($user)
+        ->post(route('maps.import.store'), [
+            'file' => transferNewMapFile(['solarsystems' => []]),
+            'sections' => ['solarsystems'],
+            'name' => 'My Copy',
+        ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    expect(Map::query()->where('name', 'My Copy')->exists())->toBeTrue();
+});
+
+it('rejects connections without the solar systems section for a new map', function () {
+    $user = transferImporter();
+
+    actingAs($user)
+        ->post(route('maps.import.store'), [
+            'file' => transferNewMapFile([
+                'connections' => [],
+            ]),
+            'sections' => ['connections'],
+        ])
+        ->assertRedirect()
+        ->assertSessionHasErrors('file');
+
+    expect(Map::query()->count())->toBe(0);
+});
+
+it('round-trips a full export into an equivalent new map', function () {
+    $source = Map::factory()->create();
+    $from = placeMapSolarsystem($source, 31000602);
+    $to = placeMapSolarsystem($source, 31000603);
+    $from->update(['alias' => 'Home']);
+    $from->details->update(['notes' => 'Round trip notes.', 'status' => MapSolarsystemStatus::Friendly]);
+    $wormhole = makeWormhole('H296');
+    $connection = MapConnection::factory()->create([
+        'map_id' => $source->id,
+        'from_map_solarsystem_id' => $from->id,
+        'to_map_solarsystem_id' => $to->id,
+        'wormhole_id' => $wormhole->id,
+    ]);
+    Signature::factory()->create([
+        'map_solarsystem_id' => $from->id,
+        'signature_id' => 'RTA-001',
+        'map_connection_id' => $connection->id,
+        'wormhole_id' => $wormhole->id,
+    ]);
+    $corporation = Corporation::factory()->create(['name' => 'Krab Horizon']);
+    MapAccess::factory()->for($source)->create([
+        'accessible_type' => Corporation::class,
+        'accessible_id' => $corporation->id,
+        'permission' => Permission::Member,
+        'is_owner' => false,
+    ]);
+
+    $sections = ['settings', 'access', 'solarsystems', 'connections', 'signatures', 'routes'];
+    $payload = app(ExportMapAction::class)->handle($source->refresh(), $sections);
+    $file = UploadedFile::fake()->createWithContent('export.json', json_encode($payload));
+
+    $user = transferImporter();
+
+    actingAs($user)
+        ->post(route('maps.import.store'), [
+            'file' => $file,
+            'sections' => $sections,
+            'name' => 'Round Trip Copy',
+        ])
+        ->assertRedirect()
+        ->assertSessionDoesntHaveErrors();
+
+    $copy = Map::query()->where('name', 'Round Trip Copy')->firstOrFail();
+    $copied_from = $copy->mapSolarsystems()->where('solarsystem_id', 31000602)->first();
+    $copied_signature = Signature::query()->where('map_solarsystem_id', $copied_from->id)->first();
+
+    expect($copy->mapSolarsystems()->count())->toBe(2)
+        ->and($copy->mapConnections()->count())->toBe(1)
+        ->and($copied_from->alias)->toBe('Home')
+        ->and($copied_from->details->notes)->toBe('Round trip notes.')
+        ->and($copied_signature->signature_id)->toBe('RTA-001')
+        ->and($copied_signature->map_connection_id)->toBe($copy->mapConnections()->value('id'))
+        ->and($copy->mapAccessors()->where('is_owner', false)->count())->toBe(1)
+        ->and($copy->mapAccessors()->where('is_owner', false)->first()->accessible_id)->toBe((int) $corporation->id)
+        ->and($copy->mapOwner->accessible_id)->toBe($user->active_character->id)
+        ->and($copy->share_token)->toBeNull();
+});


### PR DESCRIPTION
Adds a manager-only Import / Export page to map settings.

- Versioned JSON export with selectable sections: settings, access, solar systems, connections, signatures, routes
- Import merges into an existing map or creates a new one owned by the importer
- Share tokens, webhook URLs, per-user settings, and the owner access row never travel
- Client-side file preview with a stepped import flow (file, destination, review)
- Batched validation and upserts so alliance-scale exports import in under a second