### PR TITLE
feat(tracking): follow the pilot into the jumped-into system (opt-in)

### DIFF
--- a/app/Features/MapSettingsFeature.php
+++ b/app/Features/MapSettingsFeature.php
@@ -27,6 +27,7 @@ final readonly class MapSettingsFeature implements ProvidesInertiaProperties
         'preselect_signature_enabled' => false,
         'suggest_alias_enabled' => false,
         'copy_bookmark_enabled' => false,
+        'follow_character_enabled' => false,
         'layout_breakpoints' => null,
         'hidden_cards' => null,
         'show_threat_level' => true,

--- a/app/Http/Requests/UpdateMapUserSettingRequest.php
+++ b/app/Http/Requests/UpdateMapUserSettingRequest.php
@@ -55,6 +55,7 @@ final class UpdateMapUserSettingRequest extends FormRequest
             'preselect_signature_enabled' => ['boolean'],
             'suggest_alias_enabled' => ['boolean'],
             'copy_bookmark_enabled' => ['boolean'],
+            'follow_character_enabled' => ['boolean'],
             'layout_breakpoints' => ['nullable', 'array'],
             'hidden_cards' => ['nullable', 'array'],
             'hidden_cards.*' => ['string', Rule::enum(RemovableCard::class)],

--- a/app/Http/Resources/MapUserSettingResource.php
+++ b/app/Http/Resources/MapUserSettingResource.php
@@ -39,6 +39,7 @@ final class MapUserSettingResource extends JsonResource
             'preselect_signature_enabled' => $this->preselect_signature_enabled ?? false,
             'suggest_alias_enabled' => $this->suggest_alias_enabled,
             'copy_bookmark_enabled' => $this->copy_bookmark_enabled,
+            'follow_character_enabled' => $this->follow_character_enabled,
             'layout_breakpoints' => $this->layout_breakpoints,
             'hidden_cards' => $this->hidden_cards ?? [],
             'show_threat_level' => $this->show_threat_level,

--- a/app/Models/MapUserSetting.php
+++ b/app/Models/MapUserSetting.php
@@ -33,6 +33,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property bool $preselect_signature_enabled
  * @property bool $suggest_alias_enabled
  * @property bool $copy_bookmark_enabled
+ * @property bool $follow_character_enabled
  * @property array|null $layout_breakpoints
  * @property array|null $hidden_cards
  * @property bool $show_threat_level
@@ -85,6 +86,7 @@ final class MapUserSetting extends Model
             'preselect_signature_enabled' => 'boolean',
             'suggest_alias_enabled' => 'boolean',
             'copy_bookmark_enabled' => 'boolean',
+            'follow_character_enabled' => 'boolean',
             'layout_breakpoints' => 'array',
             'hidden_cards' => 'array',
             'show_threat_level' => 'boolean',

--- a/database/migrations/2026_08_20_180109_add_follow_character_enabled_to_map_user_settings_table.php
+++ b/database/migrations/2026_08_20_180109_add_follow_character_enabled_to_map_user_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('map_user_settings', function (Blueprint $table): void {
+            $table->boolean('follow_character_enabled')->default(false)->after('copy_bookmark_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('map_user_settings', function (Blueprint $table): void {
+            $table->dropColumn('follow_character_enabled');
+        });
+    }
+};

--- a/resources/js/components/map/MapStatusBar.vue
+++ b/resources/js/components/map/MapStatusBar.vue
@@ -20,7 +20,7 @@ import type { TMapUserSetting } from '@/types/models';
 import { Link } from '@inertiajs/vue3';
 import { useConnectionStatus } from '@laravel/echo-vue';
 import { ConnectionStatus } from 'laravel-echo';
-import { AlertTriangle, Eye, EyeOff, LayoutGrid, Map as MapIcon, Settings, ShieldAlert, Wifi, WifiOff } from 'lucide-vue-next';
+import { AlertTriangle, Eye, EyeOff, LayoutGrid, LocateFixed, Map as MapIcon, Settings, ShieldAlert, Wifi, WifiOff } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
 import CommandPaletteButton from './CommandPaletteButton.vue';
 import TrackingSignatureDialog from './TrackingSignatureDialog.vue';
@@ -46,6 +46,8 @@ const currentSolarsystem = useStaticSolarsystem(() => character.value?.status?.s
 // Tracking
 const {
     toggle: toggleTracking,
+    toggle_follow: toggleFollow,
+    follow_enabled,
     is_tracking,
     is_tracking_allowed,
     can_track,
@@ -260,6 +262,26 @@ const settingsUrl = computed(() => {
                     <p class="text-xs font-medium">Auto-Tracking</p>
                     <p class="text-xs text-muted-foreground">{{ is_tracking ? 'Enabled' : 'Disabled' }} - Track system changes</p>
                 </template>
+            </TooltipContent>
+        </Tooltip>
+
+        <!-- Follow Toggle -->
+        <Tooltip v-if="canEdit">
+            <TooltipTrigger as-child>
+                <button
+                    @click="toggleFollow"
+                    class="flex items-center gap-1.5 rounded px-1.5 py-1 text-xs transition-colors sm:px-2"
+                    :class="follow_enabled ? 'bg-sky-500/20 text-sky-400 hover:bg-sky-500/30' : 'bg-muted text-muted-foreground hover:bg-muted/80'"
+                >
+                    <LocateFixed class="size-3.5" />
+                    <span class="hidden md:inline">Follow</span>
+                </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+                <p class="text-xs font-medium">Follow Pilot</p>
+                <p class="text-xs text-muted-foreground">
+                    {{ follow_enabled ? 'Enabled' : 'Disabled' }} - Select the system your character jumps into
+                </p>
             </TooltipContent>
         </Tooltip>
 

--- a/resources/js/composables/signatures/useTracking.ts
+++ b/resources/js/composables/signatures/useTracking.ts
@@ -9,7 +9,9 @@ import { buildSignatureBookmark } from '@/lib/bookmark';
 import { groupSignatureOptions } from '@/lib/signatureCompatibility';
 import { isWormholeSystem } from '@/lib/solarsystem';
 import { createTracking, updateMapUserSettings, useMapSolarsystems } from '@/map/api';
+import { show } from '@/routes/maps';
 import { TLifetimeStatus, TMassStatus, TShipSize, TSignature } from '@/types/models';
+import { router } from '@inertiajs/vue3';
 import { computed, ref, watch } from 'vue';
 import { toast } from 'vue-sonner';
 
@@ -87,6 +89,25 @@ export function useTracking() {
         },
     );
 
+    // Follow the pilot: select the system the character jumped into, so the
+    // signature panel and details follow it.
+    //
+    // Always called once the system is known to be on the map — either it
+    // already was, or the tracking request that added it has come back. That
+    // ordering matters: the requests a jump fires off (the tracking lookup, the
+    // tracking POST) carry the pre-jump URL, and whichever lands last decides
+    // what the page URL is. Selecting after them, rather than racing them, is
+    // what keeps the selection from being reverted.
+    function followInto(solarsystem_id: number) {
+        if (!map_user_settings.value.follow_character_enabled) return;
+
+        router.visit(show(page.props.map.slug, { mergeQuery: { solarsystem_id } }).url, {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['map', 'selected_map_solarsystem', 'map_navigation', 'map_characters', 'eve_scout_connections', 'threat_analysis'],
+        });
+    }
+
     function handleSolarsystemJump(old_solarsystem_id: number | null, new_solarsystem_id: number) {
         if (isIgnored(new_solarsystem_id)) return;
         const old_map_solarsystem = map_solarsystems.value.find((s) => s.solarsystem_id === old_solarsystem_id);
@@ -106,12 +127,22 @@ export function useTracking() {
     }
 
     function performJump() {
-        if (existing_connection.value?.map_connection_id) return;
-        const gate_connected = isGateConnected(origin_map_solarsystem.value?.solarsystem_id, target_solarsystem.value?.id);
-        if (gate_connected || !possible_signatures.value.length || !map_user_settings.value.prompt_for_signature_enabled) {
-            return createTracking(origin_map_solarsystem.value!.id, target_solarsystem.value!.id);
+        const target_solarsystem_id = target_solarsystem.value!.id;
+
+        // Already connected: the system is on the map, nothing to wait for.
+        if (existing_connection.value?.map_connection_id) {
+            followInto(target_solarsystem_id);
+
+            return;
         }
 
+        const gate_connected = isGateConnected(origin_map_solarsystem.value?.solarsystem_id, target_solarsystem.value?.id);
+        if (gate_connected || !possible_signatures.value.length || !map_user_settings.value.prompt_for_signature_enabled) {
+            return createTracking(origin_map_solarsystem.value!.id, target_solarsystem_id, {}, () => followInto(target_solarsystem_id));
+        }
+
+        // The dialog defers the tracking request until the scout picks a
+        // signature, so following waits for that path instead.
         show_signature_modal.value = true;
     }
 
@@ -120,6 +151,14 @@ export function useTracking() {
 
         updateMapUserSettings(page.props.map.slug, {
             is_tracking: !map_user_settings.value.is_tracking,
+        });
+    }
+
+    const follow_enabled = computed(() => map_user_settings.value.follow_character_enabled);
+
+    function handleToggleFollow() {
+        updateMapUserSettings(page.props.map.slug, {
+            follow_character_enabled: !map_user_settings.value.follow_character_enabled,
         });
     }
 
@@ -132,14 +171,22 @@ export function useTracking() {
     }) {
         show_signature_modal.value = false;
         if (!origin_map_solarsystem.value || !target_solarsystem.value) return;
+
+        const target_solarsystem_id = target_solarsystem.value.id;
+
         copyConnectionBookmark(selection.signatureId, selection.alias);
-        createTracking(origin_map_solarsystem.value.id, target_solarsystem.value.id, {
-            signature_id: selection.signatureId,
-            alias: selection.alias,
-            lifetime: selection.lifetime,
-            mass_status: selection.massStatus,
-            ship_size: selection.shipSize,
-        });
+        createTracking(
+            origin_map_solarsystem.value.id,
+            target_solarsystem_id,
+            {
+                signature_id: selection.signatureId,
+                alias: selection.alias,
+                lifetime: selection.lifetime,
+                mass_status: selection.massStatus,
+                ship_size: selection.shipSize,
+            },
+            () => followInto(target_solarsystem_id),
+        );
     }
 
     // Copy the connection bookmark for the system we just jumped into, using the
@@ -176,6 +223,8 @@ export function useTracking() {
 
     return {
         toggle: handleToggle,
+        toggle_follow: handleToggleFollow,
+        follow_enabled,
         is_tracking,
         is_tracking_allowed,
         can_track,

--- a/resources/js/map/actions/createTracking.ts
+++ b/resources/js/map/actions/createTracking.ts
@@ -10,7 +10,13 @@ type TrackingOptions = {
     ship_size?: TShipSize | null;
 };
 
-export function createTracking(from_map_solarsystem_id: number, to_solarsystem_id: number, options: TrackingOptions = {}): void {
+export function createTracking(
+    from_map_solarsystem_id: number,
+    to_solarsystem_id: number,
+    options: TrackingOptions = {},
+    /** Runs once the jumped-into system is on the map, for callers that need to act on it. */
+    onSuccess?: () => void,
+): void {
     return router.post(
         Tracking.store().url,
         {
@@ -22,6 +28,7 @@ export function createTracking(from_map_solarsystem_id: number, to_solarsystem_i
             preserveScroll: true,
             preserveState: true,
             only: ['map', 'map_navigation', 'selected_map_solarsystem'],
+            onSuccess: () => onSuccess?.(),
             onError: () => router.reload({ only: ['map'] }),
         },
     );

--- a/resources/js/map/sync/reloadCoalescer.ts
+++ b/resources/js/map/sync/reloadCoalescer.ts
@@ -18,7 +18,10 @@ type CoalescerOptions = {
  */
 export function createReloadCoalescer(options: CoalescerOptions = {}): ReloadCoalescer {
     const delayMs = options.delayMs ?? 150;
-    const reload = options.reload ?? ((props: string[]) => router.reload({ only: props }));
+    // preserveUrl: these are prop-only refreshes triggered by broadcasts; they must
+    // never touch the URL. Without it a reload captured with a stale URL can land
+    // after a navigation and revert it (e.g. reverting the follow selection).
+    const reload = options.reload ?? ((props: string[]) => router.reload({ only: props, preserveUrl: true }));
 
     const pending = new Set<string>();
     let timer: ReturnType<typeof setTimeout> | null = null;

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -289,6 +289,7 @@ export type TMapUserSetting = {
     preselect_signature_enabled: boolean;
     suggest_alias_enabled: boolean;
     copy_bookmark_enabled: boolean;
+    follow_character_enabled: boolean;
     layout_breakpoints?: Record<string, any> | null;
     hidden_cards: string[] | null;
     show_threat_level: boolean;

--- a/tests/Feature/MapUserSettingTest.php
+++ b/tests/Feature/MapUserSettingTest.php
@@ -258,3 +258,20 @@ it('persists the compact signature list setting', function () {
         ->value('compact_signature_list')
     )->toBeTruthy();
 });
+
+it('persists the follow character setting', function () {
+    $map = Map::factory()->create();
+    $user = User::factory()->ownsMap($map)->create();
+
+    actingAs($user);
+
+    $this->put(route('maps.user-settings.update', $map), [
+        'follow_character_enabled' => true,
+    ])->assertRedirect();
+
+    expect(MapUserSetting::query()
+        ->where('user_id', $user->id)
+        ->where('map_id', $map->id)
+        ->value('follow_character_enabled')
+    )->toBeTruthy();
+});


### PR DESCRIPTION
Implements #52. When the active character jumps, the system it arrives in becomes the selected one, so the signature panel and details follow the pilot instead of being re-clicked after every jump.

Opt-in per user via a new `follow_character_enabled` map-user setting (default off), toggled from the map status bar next to Tracking, so each member of a map decides for themselves.

Selection lives in the URL as `?solarsystem_id=`, and a jump fires several requests that each carry the pre-jump URL: the tracking origin/target reload, the tracking POST (which redirects back to the Referer it captured) and the broadcast-driven prop reloads. `router.reload` is `async: true` in @inertiajs/core 3.6.1, so they neither cancel nor order against each other, and whichever lands last decides the page URL.

So the selection is sequenced rather than raced: it happens once the system is known to be on the map, either because it already was, or in the tracking request's onSuccess. Nothing to retry, and no timers.

Broadcast reloads still need `preserveUrl` — they can land at any moment, including after the selection. That part is a defect in its own right and is also submitted separately.