### PR TITLE
feat(access): let an instance restrict who may create maps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ DISCORD_INVITE=
 # and/or alliance), comma separated. Leave empty to allow anyone to log in.
 ALLOWED_AFFILIATION_IDS=
 
+# Restrict who may create new maps, same format. Independent of the login
+# whitelist: leave empty to let everyone who can log in create maps.
+MAP_CREATOR_AFFILIATION_IDS=
+
 # Reverb connection for the server, usually internal Docker network, only change if you know what you're doing
 REVERB_HOST=reverb
 REVERB_PORT=8080

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -123,6 +123,10 @@ final class MapController extends Controller
                 ->get()
                 ->toResourceCollection(MapCardResource::class),
             'search' => $search->toString(),
+            // Drives the "Create New Map" button: the instance can restrict
+            // creation to named affiliations, and a button that only produces a
+            // 403 is worse than no button.
+            'can_create_map' => Gate::allows('create', Map::class),
         ]);
     }
 

--- a/app/Policies/MapPolicy.php
+++ b/app/Policies/MapPolicy.php
@@ -7,9 +7,19 @@ namespace App\Policies;
 use App\Enums\Permission;
 use App\Models\Map;
 use App\Models\User;
+use App\Services\AffiliationWhitelist;
+use Illuminate\Container\Attributes\Config;
 
 final class MapPolicy
 {
+    /**
+     * @param  list<int>  $mapCreatorAffiliationIds
+     */
+    public function __construct(
+        #[Config('access.map_creator_affiliation_ids')]
+        private array $mapCreatorAffiliationIds = [],
+    ) {}
+
     public function viewAny(): bool
     {
         return true;
@@ -48,9 +58,38 @@ final class MapPolicy
         return $permission instanceof Permission && $permission->isAtLeast(Permission::Member);
     }
 
-    public function create(): bool
+    /**
+     * Creating a map is open to every authenticated user unless the instance
+     * names the affiliations allowed to do so. Same shape as the login
+     * whitelist, and independent of it: an instance can be open to an alliance
+     * while only its leadership creates maps.
+     *
+     * The check is against the *active* character rather than every character
+     * on the account: an account holding a director and an alt in an NPC
+     * corporation should not let the alt create maps, and the active character
+     * is the one the map is created as.
+     */
+    public function create(?User $user): bool
     {
-        return true;
+        if (! $user instanceof User) {
+            return false;
+        }
+
+        $whitelist = new AffiliationWhitelist($this->mapCreatorAffiliationIds);
+
+        // Nothing configured means nothing changes: return before resolving the
+        // active character, which is work an unconfigured instance should not do.
+        if (! $whitelist->isEnforced()) {
+            return true;
+        }
+
+        $character = $user->active_character;
+
+        return $whitelist->allows([
+            $character?->id,
+            $character?->corporation_id,
+            $character?->alliance_id,
+        ]);
     }
 
     public function update(?User $user, Map $map): bool

--- a/config/access.php
+++ b/config/access.php
@@ -20,4 +20,24 @@ return [
         static fn (string $id): int => (int) mb_trim($id),
         explode(',', (string) env('ALLOWED_AFFILIATION_IDS', '')),
     ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Map Creation Whitelist
+    |--------------------------------------------------------------------------
+    |
+    | A whitelist of EVE affiliation IDs (character, corporation, or alliance)
+    | whose members may create new maps. A user may create a map when any of
+    | their characters' affiliations is present in this list.
+    |
+    | Leave empty to let every authenticated user create maps (the default).
+    | This is independent of the login whitelist above: an instance can be open
+    | to a whole alliance while only its leadership creates maps.
+    |
+    */
+
+    'map_creator_affiliation_ids' => array_values(array_filter(array_map(
+        static fn (string $id): int => (int) mb_trim($id),
+        explode(',', (string) env('MAP_CREATOR_AFFILIATION_IDS', '')),
+    ))),
 ];

--- a/resources/js/pages/maps/ShowAllMaps.vue
+++ b/resources/js/pages/maps/ShowAllMaps.vue
@@ -12,8 +12,9 @@ import { TMapSummary } from '@/pages/maps/index';
 import { Archive, ChevronDown, SearchIcon } from 'lucide-vue-next';
 import { computed, ref } from 'vue';
 
-const { maps } = defineProps<{
+const { maps, can_create_map } = defineProps<{
     maps: TMapSummary[];
+    can_create_map: boolean;
 }>();
 
 const search = useSearch('search', ['maps']);
@@ -49,7 +50,7 @@ const stats = computed(() => [
                     <h1 class="font-display text-3xl font-bold tracking-tight text-foreground">Maps</h1>
                     <p class="mt-2 text-muted-foreground">Manage and explore your wormhole mapping networks</p>
                 </div>
-                <CreateMapDialog>
+                <CreateMapDialog v-if="can_create_map">
                     <Button class="flex items-center gap-2">
                         <PlusIcon class="h-4 w-4" />
                         Create New Map
@@ -126,7 +127,7 @@ const stats = computed(() => [
                 </p>
                 <div class="flex gap-2">
                     <Button v-if="search" variant="outline" @click="search = ''">Clear Search</Button>
-                    <CreateMapDialog>
+                    <CreateMapDialog v-if="can_create_map">
                         <Button class="flex items-center gap-2">
                             <PlusIcon class="h-4 w-4" />
                             {{ search ? 'Create New Map' : 'Create Your First Map' }}

--- a/tests/Feature/MapCreationWhitelistTest.php
+++ b/tests/Feature/MapCreationWhitelistTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Alliance;
+use App\Models\Character;
+use App\Models\Corporation;
+use App\Models\Map;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+it('lets any authenticated user create a map when no whitelist is configured', function () {
+    config()->set('access.map_creator_affiliation_ids', []);
+
+    $user = User::factory()->has(Character::factory())->create();
+
+    $user->update(['preferred_character_id' => $user->characters->first()->id]);
+
+    actingAs($user)
+        ->post(route('maps.store'), ['name' => 'Home chain'])
+        ->assertRedirect();
+
+    expect(Map::query()->where('name', 'Home chain')->exists())->toBeTrue();
+});
+
+it('lets a whitelisted character create a map', function () {
+    $user = User::factory()->has(Character::factory())->create();
+    $character = $user->characters->first();
+
+    config()->set('access.map_creator_affiliation_ids', [$character->id]);
+
+    $user->update(['preferred_character_id' => $user->characters->first()->id]);
+
+    actingAs($user)
+        ->post(route('maps.store'), ['name' => 'Home chain'])
+        ->assertRedirect();
+
+    expect(Map::query()->where('name', 'Home chain')->exists())->toBeTrue();
+});
+
+it('lets a member of a whitelisted corporation create a map', function () {
+    $corporation = Corporation::factory()->create();
+    $user = User::factory()->has(Character::factory()->for($corporation))->create();
+
+    config()->set('access.map_creator_affiliation_ids', [$corporation->id]);
+
+    $user->update(['preferred_character_id' => $user->characters->first()->id]);
+
+    actingAs($user)
+        ->post(route('maps.store'), ['name' => 'Home chain'])
+        ->assertRedirect();
+
+    expect(Map::query()->where('name', 'Home chain')->exists())->toBeTrue();
+});
+
+it('lets a member of a whitelisted alliance create a map', function () {
+    $alliance = Alliance::factory()->create();
+    $corporation = Corporation::factory()->for($alliance)->create();
+    $user = User::factory()->has(Character::factory()->for($corporation)->for($alliance))->create();
+
+    config()->set('access.map_creator_affiliation_ids', [$alliance->id]);
+
+    $user->update(['preferred_character_id' => $user->characters->first()->id]);
+
+    actingAs($user)
+        ->post(route('maps.store'), ['name' => 'Home chain'])
+        ->assertRedirect();
+
+    expect(Map::query()->where('name', 'Home chain')->exists())->toBeTrue();
+});
+
+it('stops a user outside the whitelist from creating a map', function () {
+    $user = User::factory()->has(Character::factory())->create();
+
+    // An affiliation the user has nothing to do with.
+    config()->set('access.map_creator_affiliation_ids', [99_999_999]);
+
+    actingAs($user->fresh())
+        ->post(route('maps.store'), ['name' => 'Home chain'])
+        ->assertForbidden();
+
+    expect(Map::query()->where('name', 'Home chain')->exists())->toBeFalse();
+});
+
+it('does not affect who may view or edit an existing map', function () {
+    // The whitelist governs creation only: a user who cannot create a map can
+    // still work on one they have been given access to.
+    config()->set('access.map_creator_affiliation_ids', [99_999_999]);
+
+    $map = Map::factory()->create();
+    $user = User::factory()->ownsMap($map)->create();
+    $user->update(['preferred_character_id' => $user->characters->first()->id]);
+
+    actingAs($user)
+        ->get(route('maps.show', $map))
+        ->assertSuccessful();
+});
+
+it('checks the active character, not every character on the account', function () {
+    // An account can hold a director and an alt in an NPC corporation. Playing
+    // the alt should not inherit the director's right to create maps.
+    $allowed = Corporation::factory()->create();
+    $user = User::factory()->has(Character::factory()->for($allowed))->create();
+    $director = $user->characters->first();
+    $alt = Character::factory()->for(Corporation::factory()->create())->create(['user_id' => $user->id]);
+
+    config()->set('access.map_creator_affiliation_ids', [$allowed->id]);
+
+    $user->update(['preferred_character_id' => $alt->id]);
+    actingAs($user->fresh())
+        ->post(route('maps.store'), ['name' => 'From the alt'])
+        ->assertForbidden();
+
+    $user->update(['preferred_character_id' => $director->id]);
+    actingAs($user->fresh())
+        ->post(route('maps.store'), ['name' => 'From the director'])
+        ->assertRedirect();
+
+    expect(Map::query()->where('name', 'From the alt')->exists())->toBeFalse()
+        ->and(Map::query()->where('name', 'From the director')->exists())->toBeTrue();
+});
+
+it('tells the maps page whether the user may create one', function () {
+    $user = User::factory()->has(Character::factory())->create();
+    $user->update(['preferred_character_id' => $user->characters->first()->id]);
+
+    config()->set('access.map_creator_affiliation_ids', []);
+
+    actingAs($user)
+        ->get(route('home'))
+        ->assertInertia(fn ($page) => $page->where('can_create_map', true)->etc());
+
+    config()->set('access.map_creator_affiliation_ids', [99_999_999]);
+
+    actingAs($user)
+        ->get(route('home'))
+        ->assertInertia(fn ($page) => $page->where('can_create_map', false)->etc());
+});


### PR DESCRIPTION
Creating a map was open to every authenticated user, so an instance that is open to a whole alliance had no way to keep map creation with the people who should be doing it.

Add MAP_CREATOR_AFFILIATION_IDS, the same shape and semantics as the login whitelist: a comma-separated list of EVE character, corporation or alliance ids, empty meaning everyone, so nothing changes for existing installs. The check reuses AffiliationWhitelist rather than restating "empty means everyone" in a second place, and it is independent of the login whitelist: an instance can admit an alliance while only its leadership creates maps.

It matches the active character, not every character on the account. An account holding a director and an alt in an NPC corporation should not let the alt create maps, and the active character is the one the map is created as. When nothing is configured the policy returns before resolving the active character, so an unconfigured instance behaves exactly as before.

The maps page is told whether the current user may create one, so the button is absent rather than producing a 403.