### PR TITLE
fix(esi): accept NPC corporations, which have no founding date

### DIFF
--- a/app/Actions/EnsureOrganisationExistsAction.php
+++ b/app/Actions/EnsureOrganisationExistsAction.php
@@ -82,7 +82,10 @@ final readonly class EnsureOrganisationExistsAction
                     'member_count' => $corp_data->member_count,
                     'shares' => $corp_data->shares,
                     'tax_rate' => $corp_data->tax_rate,
-                    'date_founded' => $corp_data->date_founded,
+                    // ESI reports NPC corporations with an empty founding
+                    // date rather than omitting it, and an empty string is
+                    // not a datetime MySQL will accept in strict mode.
+                    'date_founded' => $corp_data->date_founded ?: null,
                     'creator_id' => $corp_data->creator_id,
                     'last_updated' => now(),
                     'unresolvable_at' => null,
@@ -156,7 +159,7 @@ final readonly class EnsureOrganisationExistsAction
                     'faction_id' => $alliance_data->faction_id,
                     'creator_id' => $alliance_data->creator_id,
                     'creator_corporation_id' => $alliance_data->creator_corporation_id,
-                    'date_founded' => $alliance_data->date_founded,
+                    'date_founded' => $alliance_data->date_founded ?: null,
                     'last_updated' => now(),
                     'unresolvable_at' => null,
                 ]

--- a/app/Jobs/UpdateAffiliations.php
+++ b/app/Jobs/UpdateAffiliations.php
@@ -93,7 +93,9 @@ final class UpdateAffiliations implements ShouldQueue
                 'shares' => $corp_data->shares,
                 'tax_rate' => $corp_data->tax_rate,
                 'home_station_id' => $corp_data->home_station_id,
-                'date_founded' => $corp_data->date_founded,
+                // See EnsureOrganisationExistsAction: NPC corporations come
+                // back with an empty founding date, not a null one.
+                'date_founded' => $corp_data->date_founded ?: null,
                 'creator_id' => $corp_data->creator_id,
                 'last_updated' => now(),
             ]
@@ -144,7 +146,7 @@ final class UpdateAffiliations implements ShouldQueue
                 'ticker' => $alliance_data->ticker,
                 'faction_id' => $alliance_data->faction_id,
                 'creator_id' => $alliance_data->creator_id,
-                'date_founded' => $alliance_data->date_founded,
+                'date_founded' => $alliance_data->date_founded ?: null,
                 'last_updated' => now(),
             ]
         );

--- a/tests/Feature/Actions/NpcCorporationDateFoundedTest.php
+++ b/tests/Feature/Actions/NpcCorporationDateFoundedTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\EnsureOrganisationExistsAction;
+use App\Models\Corporation;
+use NicolasKion\Esi\DTO\EsiResult;
+use NicolasKion\Esi\Esi;
+
+function makeEsiCorporationFoundedOn(?string $dateFounded): NicolasKion\Esi\DTO\Corporation
+{
+    return new NicolasKion\Esi\DTO\Corporation(
+        alliance_id: null,
+        ceo_id: 3004421,
+        creator_id: 1,
+        date_founded: $dateFounded,
+        description: 'An NPC corporation',
+        faction_id: null,
+        home_station_id: 60004588,
+        member_count: 109383,
+        name: 'Brutor Tribe',
+        shares: 100000000,
+        tax_rate: 0.11,
+        ticker: 'B',
+        url: '',
+        war_eligible: false,
+    );
+}
+
+it('stores an NPC corporation whose founding date is empty', function () {
+    // ESI reports NPC corporations with an empty founding date rather than
+    // omitting it, and MySQL in strict mode rejects '' for a datetime column.
+    // Adding a character in a starter corporation used to fail on this.
+    $esi = $this->mock(Esi::class);
+    $esi->shouldReceive('getCorporation')
+        ->with(1000049)
+        ->once()
+        ->andReturn(new EsiResult(data: makeEsiCorporationFoundedOn('')));
+
+    app(EnsureOrganisationExistsAction::class)->ensureCorporationExists(1000049);
+
+    $corporation = Corporation::query()->find(1000049);
+
+    expect($corporation)->not->toBeNull()
+        ->and($corporation->name)->toBe('Brutor Tribe')
+        ->and($corporation->date_founded)->toBeNull();
+});
+
+it('keeps a real founding date', function () {
+    $esi = $this->mock(Esi::class);
+    $esi->shouldReceive('getCorporation')
+        ->with(98000202)
+        ->once()
+        ->andReturn(new EsiResult(data: makeEsiCorporationFoundedOn('2003-01-01T00:00:00Z')));
+
+    app(EnsureOrganisationExistsAction::class)->ensureCorporationExists(98000202);
+
+    expect(Corporation::query()->find(98000202)->date_founded->toDateString())->toBe('2003-01-01');
+});


### PR DESCRIPTION
ESI reports NPC corporations with date_founded as an empty string rather than omitting it, and MySQL in strict mode rejects '' for a datetime column. Adding a character who sits in a starter corporation therefore failed outright:

  SQLSTATE[22007]: Invalid datetime format: 1292 Incorrect datetime value:
  '' for column 'date_founded'

Coerce the empty value to null at the four places an organisation is written: corporation and alliance, in both EnsureOrganisationExistsAction and the UpdateAffiliations job. The column is already nullable.